### PR TITLE
Rename loadyaml to loadanyyaml to prevent stdlib conflict

### DIFF
--- a/foreman_installer/lib/puppet/parser/functions/loadanyyaml.rb
+++ b/foreman_installer/lib/puppet/parser/functions/loadanyyaml.rb
@@ -1,18 +1,18 @@
 module Puppet::Parser::Functions
 
-  newfunction(:loadyaml, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+  newfunction(:loadanyyaml, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
     Load a YAML file containing an array, string, or hash, and return the data
     in the corresponding native data type.
 
     For example:
 
-        $myhash = loadyaml('/etc/puppet/data/myhash.yaml')
+        $myhash = loadanyyaml('/etc/puppet/data/myhash.yaml')
     ENDHEREDOC
 
     args.delete_if { |filename| not File.exist? filename }
 
     if args.length == 0
-      raise Puppet::ParseError, ("loadyaml(): No files to load")
+      raise Puppet::ParseError, ("loadanyyaml(): No files to load")
     end
 
     YAML.load_file(args[0])

--- a/foreman_installer/manifests/init.pp
+++ b/foreman_installer/manifests/init.pp
@@ -8,9 +8,9 @@ class foreman_installer(
   $answers = undef
 ) {
 
-  $params=loadyaml($answers,
-                   "/etc/foreman-installer/answers.yaml",
-                   "${settings::modulepath}/${module_name}/answers.yaml")
+  $params=loadanyyaml($answers,
+                      "/etc/foreman-installer/answers.yaml",
+                      "${settings::modulepath}/${module_name}/answers.yaml")
 
   foreman_installer::yaml_to_class { ['foreman', 'foreman_proxy', 'puppet']: }
 


### PR DESCRIPTION
loadyaml currently conflicts with puppetlabs-stdlib since they're different.

err: Could not retrieve catalog from remote server: Error 400 on SERVER: loadyaml(): wrong number of arguments (3; must be 1) at /etc/puppet/modules/production/foreman_installer/manifests/init.pp:11 on node foreman.fm.example.net
