### PR TITLE
adding spec and temp release script

### DIFF
--- a/foreman-installer.spec
+++ b/foreman-installer.spec
@@ -1,0 +1,77 @@
+
+# uncomment to disable foreman-generate-answers script (and dependencies)
+#global skip_generator 1
+
+%if "%{?scl}" == "ruby193"
+    %global scl_prefix %{scl}-
+    %global scl_ruby /usr/bin/ruby193-ruby
+%else
+    %global scl_ruby /usr/bin/ruby
+%endif
+
+# set and uncomment all three to set alpha tag
+#global alphatag RC1
+#global dotalphatag .%{alphatag}
+#global dashalphatag -%{alphatag}
+
+Name:       foreman-installer
+Epoch:      1
+Version:    1.2.9999
+Release:    1%{?dotalphatag}%{?dist}
+Summary:    Puppet-based installer for The Foreman
+Group:      Applications/System
+License:    GPLv3+ and ASL 2.0
+URL:        http://theforeman.org
+Source0:    %{name}-%{version}%{?dashalphatag}.tar.gz
+
+%if 0%{?rhel} && 0%{?rhel} == 5
+BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+%endif
+
+BuildArch:  noarch
+
+Requires:   %{?scl_prefix}puppet >= 0.24.4
+
+%if %{?skip_generator:0}%{!?skip_generator:1}
+Requires:   %{?scl_prefix}ruby(abi)
+Requires:   %{?scl_prefix}rubygem-highline
+%endif
+
+%description
+Complete installer for The Foreman life-cycle management system based on puppet and
+script to generate answers for puppet manifests.
+
+%prep
+%setup -q -n %{name}-%{version}%{?dashalphatag}
+
+%build
+echo "%{version}" > VERSION
+#replace shebangs for SCL
+%if %{?scl:1}%{!?scl:0}
+  sed -ri '1sX(/usr/bin/ruby|/usr/bin/env ruby)X%{scl_ruby}X' generate_answers.rb
+%endif
+
+%install
+mkdir -p %{buildroot}/%{_datadir}/%{name}
+cp -dpR * %{buildroot}/%{_datadir}/%{name}
+%if %{?skip_generator:0}%{!?skip_generator:1}
+  mkdir -p %{buildroot}/%{_sbindir}
+  ln -sf %{_datadir}/%{name}/generate_answers.rb %{buildroot}/%{_sbindir}/foreman-generate-answers
+%endif
+
+%if 0%{?rhel} && 0%{?rhel} == 5
+%clean
+%{__rm} -rf $RPM_BUILD_ROOT
+%endif
+
+%files
+%defattr(-,root,root,-)
+%doc README.*
+%{_datadir}/%{name}
+%if %{?skip_generator:0}%{!?skip_generator:1}
+  %{_sbindir}/foreman-generate-answers
+%endif
+
+%changelog
+* Wed May 23 2013 Lukas Zapletal <lzap+rpm[@]redhat.com> - 1.2.9999-1
+- initial version

--- a/generate_answers.rb
+++ b/generate_answers.rb
@@ -4,6 +4,7 @@ require 'rubygems'
 require 'yaml'
 require 'highline/import'
 
+$workdir = File.dirname( File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__ )
 $terminal = $terminal || Highline.new
 
 # Bonus, per-module, questions defined up top where they're easy to find :)
@@ -72,7 +73,7 @@ $terminal.page_at = data.last
 
 # default output
 
-$outfile = "#{File.dirname(__FILE__)}/foreman_installer/answers.yaml"
+$outfile = "#{$workdir}/foreman_installer/answers.yaml"
 $output = {
   "foreman" => true,
   "foreman_proxy" => true,
@@ -85,7 +86,7 @@ $output = {
 def save_or_run_and_exit
   File.open($outfile, 'w') {|f| f.write(YAML.dump($output)) }
   # If the foreman_installer module exists then just use it. Otherwise, ask.
-  $modulepath = File.exists?("#{File.dirname(__FILE__)}/foreman_installer") ? File.dirname(__FILE__) : ask("<%= color('Where are the installer Puppet modules?', :question) %>")
+  $modulepath = File.exists?("#{$workdir}/foreman_installer") ? $workdir : ask("<%= color('Where are the installer Puppet modules?', :question) %>")
   if Process::UID.eid == 0 && agree("\n<%= color('Do you want to run Puppet now with these settings?', :question) %> (y/n)", false)
     system("echo include foreman_installer | puppet apply --modulepath #{$modulepath} -v")
     parting_message

--- a/release
+++ b/release
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# simple script to create a release without tito
+# it works in-place, so take care!
+#
+# Usage: release 1.2 el6
+#
+
+[ -z "$1" -o -z "$2" ] && echo "Usage: release version_tag dist" && exit 42
+
+PROJECT=foreman-installer
+VERSION=$1
+DIST=$2
+
+git describe $VERSION >/dev/null || echo "WARNING! There is no such tag: $VERSION!"
+
+TEMPDIR=$(mktemp -d)
+trap "rm -rf $TEMPDIR" EXIT
+mkdir $TEMPDIR/$PROJECT-$VERSION
+cp -Rad . $TEMPDIR/$PROJECT-$VERSION
+pushd $TEMPDIR
+rm -rf `find -name ".git*"`
+tar c $PROJECT-$VERSION | gzip -9 > ~/rpmbuild/SOURCES/$PROJECT-$VERSION.tar.gz
+cd $PROJECT-$VERSION
+rpmbuild -bs $PROJECT.spec --define "dist $DIST"
+popd


### PR DESCRIPTION
This is SCL enabled RHEL SPEC file and a temporary release script until we
sort out how to use tito with repositories with git submodules.

Here is a build: http://koji.katello.org/koji/taskinfo?taskID=36605

Replaces: https://github.com/theforeman/foreman-installer/pull/49
