### PR TITLE
setting minimal version of foreman_api to 0.1.4

### DIFF
--- a/foreman-installer.spec
+++ b/foreman-installer.spec
@@ -31,7 +31,7 @@ BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:  noarch
 
 Requires:   %{?scl_prefix}puppet >= 0.24.4
-Requires:   %{?scl_prefix}rubygem-foreman_api
+Requires:   %{?scl_prefix}rubygem-foreman_api >= 0.1.4
 
 %if %{?skip_generator:0}%{!?skip_generator:1}
 %if 0%{?fedora} > 18


### PR DESCRIPTION
We need this patch

https://github.com/mbacovsky/foreman_api/commit/434e90f7f7a962cca8a284a196fa1e03b8d03d34

otherwise some requests (POST) will fail during oauth.
