### PR TITLE
Change digest type to MD5 to stop unpack errors

### DIFF
--- a/release
+++ b/release
@@ -22,5 +22,5 @@ pushd $TEMPDIR
 rm -rf `find -name ".git*"`
 tar c $PROJECT-$VERSION | gzip -9 > ~/rpmbuild/SOURCES/$PROJECT-$VERSION.tar.gz
 cd $PROJECT-$VERSION
-rpmbuild -bs $PROJECT.spec --define "dist $DIST"
+rpmbuild -bs $PROJECT.spec --define "dist $DIST" --define "_source_filedigest_algorithm md5" --define "_binary_filedigest_algorithm md5"
 popd


### PR DESCRIPTION
I don't know if this solves it, but I have it on @lzap's authority that this is what tito does :)
