### PR TITLE
Fix concurrent execution of the release script during Jenkins builds

### DIFF
--- a/release
+++ b/release
@@ -14,13 +14,15 @@ DIST=$2
 
 git describe $VERSION >/dev/null || echo "WARNING! There is no such tag: $VERSION!"
 
+RPMBUILD=$(pwd)/pkg/rpmbuild
 TEMPDIR=$(mktemp -d)
 trap "rm -rf $TEMPDIR" EXIT
-mkdir $TEMPDIR/$PROJECT-$VERSION
+mkdir -p $TEMPDIR/$PROJECT-$VERSION $RPMBUILD/SOURCES
 cp -Rad . $TEMPDIR/$PROJECT-$VERSION
+
 pushd $TEMPDIR
 rm -rf `find -name ".git*"`
-tar c $PROJECT-$VERSION | gzip -9 > ~/rpmbuild/SOURCES/$PROJECT-$VERSION.tar.gz
+tar c $PROJECT-$VERSION | gzip -9 > $RPMBUILD/SOURCES/$PROJECT-$VERSION.tar.gz
 cd $PROJECT-$VERSION
-rpmbuild -bs $PROJECT.spec --define "dist $DIST"
+rpmbuild -bs $PROJECT.spec --define "dist $DIST" --define "_topdir $RPMBUILD"
 popd


### PR DESCRIPTION
Should fix the invalid SRPMS and tarballs being uploaded to koji, which were
failing with CRC errors as Jenkins runs 2/3 of these in parallel for
different dists.

e.g. http://koji.katello.org/koji/getfile?taskID=65594&name=build.log
