### PR TITLE
Use fork of puppetlabs-apache for Fedora 19 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/theforeman/puppet-tftp.git
 [submodule "apache"]
 	path = modules/apache
-	url = https://github.com/theforeman/puppet-apache.git
+	url = https://github.com/stbenjam/puppetlabs-apache.git
 [submodule "foreman"]
 	path = modules/foreman
 	url = https://github.com/theforeman/puppet-foreman.git


### PR DESCRIPTION
Use my fork of puppetlabs-apache until they support Apache 2.4 and Fedora.  These are the minimum changes for foreman-installer to function correctly on F19:
- Use " Mutex sysvsem " instead of SSLMutex
  -  Issue: puppetlabs/puppetlabs-apache#564
- Don't enable authn_alias, authn_default, authz_default
  - Issue: puppetlabs/puppetlabs-apache#423
- Include Fedora's Include conf.modules.d/*.conf for proper MPM setup
  - Issue: puppetlabs/puppetlabs-apache#467
