### PR TITLE
fixing man page generation on Debian

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,7 @@ file "#{BUILDDIR}/foreman-installer.8.asciidoc" =>
 end
 
 file "#{BUILDDIR}/foreman-installer.8" => "#{BUILDDIR}/foreman-installer.8.asciidoc" do |t|
-  sh "a2x -d manpage -f manpage #{BUILDDIR}/foreman-installer.8.asciidoc"
+  sh "a2x -d manpage -f manpage #{BUILDDIR}/foreman-installer.8.asciidoc -L"
 end
 
 task :build => [


### PR DESCRIPTION
For some reason, Debian xmllint is failing to validate our man page. It works
in Fedoras and Red Hats, therefore I am disabling xmllint for man page 
generation.

@ewoud is this it? Thanks
