### PR TITLE
Allow to skip man page generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,11 @@ file "#{BUILDDIR}/foreman-installer.8.asciidoc" =>
 end
 
 file "#{BUILDDIR}/foreman-installer.8" => "#{BUILDDIR}/foreman-installer.8.asciidoc" do |t|
-  sh "a2x -d manpage -f manpage #{BUILDDIR}/foreman-installer.8.asciidoc -L"
+  if ENV['NO_MAN_PAGE']
+    touch "#{BUILDDIR}/foreman-installer.8"
+  else
+    sh "a2x -d manpage -f manpage #{BUILDDIR}/foreman-installer.8.asciidoc -L"
+  end
 end
 
 task :build => [


### PR DESCRIPTION
With `rake NO_MAN_PAGE=1` command it will be possible to build also on squeeze
where asciidoc is somehow screwed.
