### PR TITLE
base the answer file location on the basename of the script 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ end
 
 file "#{BUILDDIR}/foreman-installer" => 'bin/foreman-installer' do |t|
   cp t.prerequisites[0], t.name
-  sh 'sed -i "s#\(.*CONFIG_FILE\).*#\1 = \"%s\"#" %s' % ["#{SYSCONFDIR}/foreman/foreman-installer.yaml", t.name]
+  sh 'sed -i "s#\(^.*CONFIG_FILE = \'/etc/foreman\'*.\).*#  CONFIG_FILE = %s#" %s' % ["'#{SYSCONFDIR}/foreman/' + config_filename", t.name]
 end
 
 file "#{BUILDDIR}/options.asciidoc" do |t|

--- a/bin/foreman-installer
+++ b/bin/foreman-installer
@@ -4,8 +4,17 @@ require 'highline/import'
 require 'yaml'
 require 'kafo'
 
+# base the answer file name on the file calling the
+# script.  This allows other programs to use their own
+# files if named based on their executable
+config_filename = File.basename($0) + ".yaml"
+
 # where to find answer file
-CONFIG_FILE = "config/foreman-installer.yaml"
+if File.exist?('config/' + config_filename)
+  CONFIG_FILE = 'config/' + config_filename   
+else
+  CONFIG_FILE = '/etc/foreman/' + config_filename
+end
 
 # helpers
 def module_enabled?(name)


### PR DESCRIPTION
This change allows katello-installer and others to use its own configuration file
but re-use the logic contained within foreman-installer.

Originally proposed this here:

https://github.com/theforeman/foreman-installer/pull/100

but re-did this change here with an entirely different approach.  We also no longer need the sed script to munge the location during the build which becomes hard to maintain when the CONFIG_FILE variable is now based on some logic
