### PR TITLE
refs #4030 - use latest dependency modules from git

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,11 +1,20 @@
 forge 'http://forge.puppetlabs.com'
 
 # Temporary for Apache 2.4 support (post-0.11.0)
-mod 'apache', :git => 'https://github.com/puppetlabs/puppetlabs-apache'
+mod 'puppetlabs/apache', :git => 'https://github.com/puppetlabs/puppetlabs-apache'
 
 # Temporary for Amazon Linux support (https://github.com/puppetlabs/puppetlabs-xinetd/issues/32)
-mod 'xinetd', :git => 'https://github.com/puppetlabs/puppetlabs-xinetd'
+mod 'puppetlabs/xinetd', :git => 'https://github.com/puppetlabs/puppetlabs-xinetd'
 
-mod 'foreman', :git => 'https://github.com/theforeman/puppet-foreman'
-mod 'foreman_proxy', :git => 'https://github.com/theforeman/puppet-foreman_proxy'
-mod 'puppet', :git => 'https://github.com/theforeman/puppet-puppet'
+# Dependencies
+mod 'puppetlabs/mysql'
+mod 'theforeman/concat_native', :git => 'https://github.com/theforeman/puppet-concat'
+mod 'theforeman/dhcp', :git => 'https://github.com/theforeman/puppet-dhcp'
+mod 'theforeman/dns', :git => 'https://github.com/theforeman/puppet-dns'
+mod 'theforeman/git', :git => 'https://github.com/theforeman/puppet-git'
+mod 'theforeman/tftp', :git => 'https://github.com/theforeman/puppet-tftp'
+
+# Top-level modules
+mod 'theforeman/foreman', :git => 'https://github.com/theforeman/puppet-foreman'
+mod 'theforeman/foreman_proxy', :git => 'https://github.com/theforeman/puppet-foreman_proxy'
+mod 'theforeman/puppet', :git => 'https://github.com/theforeman/puppet-puppet'


### PR DESCRIPTION
It just occurred to me that we're not pulling the latest dependency modules from git, just from the Forge.
