### PR TITLE
[Review only] Refs #3308 - Auto-create mappings hash from detected plugin classes

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,20 +1,20 @@
 forge 'http://forge.puppetlabs.com'
 
 # Temporary for Apache 2.4 support (post-0.11.0)
-mod 'puppetlabs/apache', :git => 'https://github.com/puppetlabs/puppetlabs-apache'
+mod 'puppetlabs/apache',        :git => 'https://github.com/puppetlabs/puppetlabs-apache'
 
 # Temporary for Amazon Linux support (https://github.com/puppetlabs/puppetlabs-xinetd/issues/32)
-mod 'puppetlabs/xinetd', :git => 'https://github.com/puppetlabs/puppetlabs-xinetd'
+mod 'puppetlabs/xinetd',        :git => 'https://github.com/puppetlabs/puppetlabs-xinetd'
 
 # Dependencies
 mod 'puppetlabs/mysql'
 mod 'theforeman/concat_native', :git => 'https://github.com/theforeman/puppet-concat'
-mod 'theforeman/dhcp', :git => 'https://github.com/theforeman/puppet-dhcp'
-mod 'theforeman/dns', :git => 'https://github.com/theforeman/puppet-dns'
-mod 'theforeman/git', :git => 'https://github.com/theforeman/puppet-git'
-mod 'theforeman/tftp', :git => 'https://github.com/theforeman/puppet-tftp'
+mod 'theforeman/dhcp',          :git => 'https://github.com/theforeman/puppet-dhcp'
+mod 'theforeman/dns',           :git => 'https://github.com/theforeman/puppet-dns'
+mod 'theforeman/git',           :git => 'https://github.com/theforeman/puppet-git'
+mod 'theforeman/tftp',          :git => 'https://github.com/theforeman/puppet-tftp'
 
 # Top-level modules
-mod 'theforeman/foreman', :git => 'https://github.com/theforeman/puppet-foreman'
+mod 'theforeman/foreman',       :git => 'https://github.com/theforeman/puppet-foreman'
 mod 'theforeman/foreman_proxy', :git => 'https://github.com/theforeman/puppet-foreman_proxy'
-mod 'theforeman/puppet', :git => 'https://github.com/theforeman/puppet-puppet'
+mod 'theforeman/puppet',        :git => 'https://github.com/theforeman/puppet-puppet'

--- a/config/answers.yaml
+++ b/config/answers.yaml
@@ -4,6 +4,9 @@
 # <classname>:
 #   <param>: <value> - include and override the default(s)
 #
+# Every support plugin/compute class is listed, so that it
+# shows up in the interactive menu
+#
 # See params.pp in each class for what options are available
 ---
 foreman:
@@ -12,3 +15,18 @@ foreman_proxy:
   custom_repo: true
 puppet:
   server: true
+foreman::plugin::bootdisk: true
+foreman::plugin::chef: false
+foreman::plugin::default_hostgroup: false
+foreman::plugin::discovery: false
+foreman::plugin::hooks: false
+foreman::plugin::puppetdb: false
+foreman::plugin::setup: true
+foreman::plugin::templates: false
+foreman::compute::ec2: false
+foreman::compute::gce: false
+foreman::compute::libvirt: false
+foreman::compute::openstack: false
+foreman::compute::ovirt: false
+foreman::compute::rackspace: false
+foreman::compute::vmware: false

--- a/config/foreman-installer.yaml
+++ b/config/foreman-installer.yaml
@@ -8,15 +8,6 @@
 # Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default
 :modules_dir: ./_build/modules
 
-## Kafo tuning, customization of core functionality
-:name: Foreman
-# :no_prefix: false
-# :mapping:
-:order:
-  - foreman
-  - foreman_proxy
-  - puppet
-
 ## Useful for development, e.g. when you want to move log files to local directory
 :log_dir: '/var/log/foreman-installer'
 :log_name: 'foreman-installer.log'
@@ -33,3 +24,59 @@
 
 # If using the Debian ruby-kafo package, uncomment this
 # :kafo_modules_dir: /usr/lib/ruby/vendor_ruby/kafo/modules
+
+## Kafo tuning, customization of core functionality
+:name: Foreman
+# :no_prefix: false
+:order:
+  - foreman
+  - foreman_proxy
+  - puppet
+
+# The mapping hash provides Kafo with the information to find plugin classes
+:mapping:
+  :foreman::plugin::bootdisk:
+    :dir_name: foreman
+    :manifest_name: plugin/bootdisk
+  :foreman::plugin::puppetdb:
+    :dir_name: foreman
+    :manifest_name: plugin/puppetdb
+  :foreman::plugin::hooks:
+    :dir_name: foreman
+    :manifest_name: plugin/hooks
+  :foreman::plugin::discovery:
+    :dir_name: foreman
+    :manifest_name: plugin/discovery
+  :foreman::plugin::chef:
+    :dir_name: foreman
+    :manifest_name: plugin/chef
+  :foreman::plugin::templates:
+    :dir_name: foreman
+    :manifest_name: plugin/templates
+  :foreman::plugin::setup:
+    :dir_name: foreman
+    :manifest_name: plugin/setup
+  :foreman::plugin::default_hostgroup:
+    :dir_name: foreman
+    :manifest_name: plugin/default_hostgroup
+  :foreman::compute::rackspace:
+    :dir_name: foreman
+    :manifest_name: compute/rackspace
+  :foreman::compute::openstack:
+    :dir_name: foreman
+    :manifest_name: compute/openstack
+  :foreman::compute::vmware:
+    :dir_name: foreman
+    :manifest_name: compute/vmware
+  :foreman::compute::libvirt:
+    :dir_name: foreman
+    :manifest_name: compute/libvirt
+  :foreman::compute::ec2:
+    :dir_name: foreman
+    :manifest_name: compute/ec2
+  :foreman::compute::gce:
+    :dir_name: foreman
+    :manifest_name: compute/gce
+  :foreman::compute::ovirt:
+    :dir_name: foreman
+    :manifest_name: compute/ovirt


### PR DESCRIPTION
Not to be merged until after [puppet-foreman/156](https://github.com/theforeman/puppet-foreman/pull/156) as it contains entries in the answers.yaml for classes which don't exist yet :)

The sed hackery in the Rakefile is annoying though - I might rewrite it to do it properly in Ruby....
