### PR TITLE
Remove pl-apache git reference, now 1.0.0 is out

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,8 +1,5 @@
 forge 'http://forge.puppetlabs.com'
 
-# Temporary for Apache 2.4 support (post-0.11.0)
-mod 'puppetlabs/apache',        :git => 'https://github.com/puppetlabs/puppetlabs-apache'
-
 # Temporary for Amazon Linux support (https://github.com/puppetlabs/puppetlabs-xinetd/issues/32)
 mod 'puppetlabs/xinetd',        :git => 'https://github.com/puppetlabs/puppetlabs-xinetd'
 


### PR DESCRIPTION
Please merge as soon as https://github.com/theforeman/puppet-foreman/pull/162 and https://github.com/theforeman/puppet-puppet/pull/140 are in.
