### PR TITLE
Reuse color support from Kafo

### DIFF
--- a/bin/foreman-installer
+++ b/bin/foreman-installer
@@ -54,23 +54,6 @@ end
 @result = Kafo::KafoConfigure.run
 exit 0 if @result.nil? # --help invocation
 
-# Setup colors
-color_hash = {
-  :info => [:bold, :cyan, :on_black],
-  :bad  => [:bold, :red, :on_black],
-  :good => [:bold, :green, :on_black]
-}
-
-colors = HighLine::ColorScheme.new do |cs|
-  color_hash.each { |c,arr| cs[c] = arr }
-end
-
-nocolors = HighLine::ColorScheme.new do |cs|
-  color_hash.each { |c,arr| cs[c] = [] }
-end
-
-HighLine.color_scheme = Kafo::KafoConfigure.config.app[:colors] ? colors : nocolors
-
 # Puppet status codes say 0 for unchanged, 2 for changed succesfully
 if [0,2].include? @result.exit_code
   say "  <%= color('Success!', :good) %>"

--- a/foreman-installer.spec
+++ b/foreman-installer.spec
@@ -31,7 +31,7 @@ BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:  noarch
 
 Requires:   %{?scl_prefix}puppet >= 2.7.0
-Requires:   %{?scl_prefix}rubygem-kafo >= 0.3.0
+Requires:   %{?scl_prefix}rubygem-kafo >= 0.4.0
 Requires:   %{?scl_prefix}rubygem-foreman_api >= 0.1.4
 
 %if %{?skip_generator:0}%{!?skip_generator:1}


### PR DESCRIPTION
Installer output now uses color scheme selected by user. Also we don't
have to check color configuration manually. HighLine is already set by
Kafo.
