### PR TITLE
Depend on latest kafo and curl

### DIFF
--- a/foreman-installer.spec
+++ b/foreman-installer.spec
@@ -30,8 +30,9 @@ BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildArch:  noarch
 
+Requires:   curl
 Requires:   %{?scl_prefix}puppet >= 2.7.0
-Requires:   %{?scl_prefix}rubygem-kafo >= 0.4.0
+Requires:   %{?scl_prefix}rubygem-kafo >= 0.5.3
 Requires:   %{?scl_prefix}rubygem-foreman_api >= 0.1.4
 
 %if %{?skip_generator:0}%{!?skip_generator:1}


### PR DESCRIPTION
We need it because of foreman_discovery plugin installation

Merge this before or at the same time as https://github.com/theforeman/puppet-foreman/pull/174
