### PR TITLE
fixes #4454 - switch PostgreSQL module to latest for EL7 support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,6 +4,9 @@ forge 'http://forge.puppetlabs.com'
 mod 'puppetlabs/apache',        :git => 'https://github.com/puppetlabs/puppetlabs-apache',
                                 :ref => 'c8bd21a0bfc837bb651ccd3ee4228d9aed168ec1'
 
+# Temporary fix for EL7 support
+mod 'puppetlabs/postgresql',    :git => 'https://github.com/puppetlabs/puppetlabs-postgresql',
+                                :ref => '72c357a32a807bfecfa8fe21550931480cd94bfc'
 # Dependencies
 mod 'puppetlabs/mysql'
 mod 'theforeman/concat_native', :git => 'https://github.com/theforeman/puppet-concat'


### PR DESCRIPTION
I was going to hold off on this as I was expecting a release a few weeks ago, but it doesn't seem forthcoming.  I guess we can expect releases for both Apache and PostgreSQL soon, then we can remove them.
