### PR TITLE
Switch back to official pl-apache release & pl-postgresql upstream git

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,12 +1,9 @@
 forge 'http://forge.puppetlabs.com'
 
-# Temporary fix for Ubuntu 14.04
-mod 'puppetlabs/apache',        :git => 'https://github.com/puppetlabs/puppetlabs-apache',
-                                :ref => 'c8bd21a0bfc837bb651ccd3ee4228d9aed168ec1'
+# Temporary fix for F19 support
+mod 'puppetlabs/postgresql',    :git => 'https://github.com/puppetlabs/puppetlabs-postgresql',
+                                :ref => '4345749a71b734c12a746c5cf9e358797ddb0a1a'
 
-# Temporary fix for EL7 and F19 support
-mod 'puppetlabs/postgresql',    :git => 'https://github.com/theforeman/puppetlabs-postgresql',
-                                :ref => 'fedora-sysconfig'
 # Dependencies
 mod 'puppetlabs/mysql'
 mod 'theforeman/concat_native', :git => 'https://github.com/theforeman/puppet-concat'


### PR DESCRIPTION
pl-apache was released the other day, and pl-postgresql was released (for EL7), but remained broken for F19.
