### PR TITLE
Revert to released postgresql module for Fedora fix

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,9 +1,5 @@
 forge 'http://forge.puppetlabs.com'
 
-# Temporary fix for F19 support
-mod 'puppetlabs/postgresql',    :git => 'https://github.com/puppetlabs/puppetlabs-postgresql',
-                                :ref => '4345749a71b734c12a746c5cf9e358797ddb0a1a'
-
 # Dependencies
 mod 'puppetlabs/mysql'
 mod 'theforeman/concat_native', :git => 'https://github.com/theforeman/puppet-concat'


### PR DESCRIPTION
We can now rely on https://github.com/puppetlabs/puppetlabs-postgresql/blob/3.4.x/CHANGELOG.md#2014-07-31---supported-release-342.
