### PR TITLE
adding ovirt_provision plugin to installer options

### DIFF
--- a/config/foreman-installer.yaml
+++ b/config/foreman-installer.yaml
@@ -52,6 +52,9 @@
     :dir_name: foreman
     :manifest_name: plugin/discovery
     :params_name: plugin/discovery/params
+  :foreman::plugin::ovirt_provision:
+    :dir_name: foreman
+    :manifest_name: plugin/ovirt_provision
   :foreman::plugin::chef:
     :dir_name: foreman
     :manifest_name: plugin/chef


### PR DESCRIPTION
Adding an option to install ovirt_provision plugin with foreman-installer 

Signed-off-by: Yaniv Bronhaim ybronhei@redhat.com
