### PR TITLE
Disable foreman_bootdisk by default

### DIFF
--- a/config/answers.yaml
+++ b/config/answers.yaml
@@ -16,7 +16,7 @@ foreman_proxy:
 puppet:
   server: true
 foreman::cli: true
-foreman::plugin::bootdisk: true
+foreman::plugin::bootdisk: false
 foreman::plugin::chef: false
 foreman::plugin::default_hostgroup: false
 foreman::plugin::discovery: false


### PR DESCRIPTION
I don't think this was a good idea, so would like to remove it again from the default install so it's in the same boat as other plugins.
