### PR TITLE
Revert "refs #7970 - include fixed alternatives module for Ubuntu 12.04"

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,9 +1,5 @@
 forge 'http://forge.puppetlabs.com'
 
-# Temporary fix for Ubuntu 12.04 setting alternative to manual mode
-mod 'adrien/alternatives',      :git => 'https://github.com/domcleal/puppet-alternatives',
-                                :ref => 'mode'
-
 # Dependencies
 mod 'puppetlabs/mysql'
 mod 'theforeman/concat_native', :git => 'https://github.com/theforeman/puppet-concat'


### PR DESCRIPTION
This reverts commit 9c63273104787db0eba0a1c5f7cadc2e87322e6f.

Use version 0.3.0 or later from Puppet Forge instead.

Depends on https://github.com/theforeman/puppet-foreman/pull/266
