### PR TITLE
[do not merge] Validate modules/classes against supported OSes

### DIFF
--- a/hooks/boot/12-ignore_os_support.rb
+++ b/hooks/boot/12-ignore_os_support.rb
@@ -1,0 +1,5 @@
+app_option(
+  '--ignore-os-support', :flag,
+  "Ignore checks for supported operating systems and attempt to install anyway"
+  :default => false
+)

--- a/hooks/pre_commit/10-apply_os_support.rb
+++ b/hooks/pre_commit/10-apply_os_support.rb
@@ -1,0 +1,46 @@
+require 'facter'
+require 'json'
+
+# Check OS support for top-level modules and disable those that aren't known
+# to work on the current OS.
+def apply_os_support
+  kafo.config.modules.each do |mod|
+    metajson = File.join(KafoConfigure.modules_dir, mod.dir_name, 'foreman-installer.json')
+    next unless File.exist?(metajson)
+
+    meta = JSON.load(File.read(metajson))
+    if meta[mod.identifier] && meta[mod.identifier]['operatingsystem_support']
+      supported = meta[mod.identifier]['operatingsystem_support'].any? do |os|
+        os.all? { |fname,fvalue| os_fact_matches?(fname, fvalue) }
+      end
+
+      unless supported
+        logger.warn("Skipping module #{mod.name} as it isn't supported on this operating system. Please check the plugin documentation for its supported OSes, or use --ignore-os-support to attempt to run this module.")
+        mod.disable
+      end
+    end
+  end
+end
+
+def os_fact_matches?(name, value)
+  os_value = [os_fact(name)].flatten.map(&:to_s)
+  [value].flatten.any? do |value|
+    os_value.include? value.to_s
+  end
+end
+
+def os_fact(name)
+  # metadata style uses osrelease when it really means the major release
+  if name == 'operatingsystemrelease'
+    maj = Facter.value(:operatingsystemmajrelease)
+    return maj if maj
+
+    # Facter 1.6 compatibility, no osmajrelease
+    release = Facter.value(:operatingsystemrelease)
+    [release, release.gsub(/\.[^\.]+\z/, '')]
+  else
+    Facter.value(name.to_sym)
+  end
+end
+
+apply_os_support unless app_value(:ignore_os_support)


### PR DESCRIPTION
Allow each module to ship a foreman-installer.json file containing:

```
{"example::class":{"operatingsystem_support":{ .. }}
```

and validate each kafo module (class) against the OS list.  If it isn't
listed then disable the module before execution and log a warning.

The operatingsystem_support hash matches Puppet's metadata.json format,
with a hash of facts to supported values.

---

Marked as DNM as this requires [a newer kafo](https://github.com/theforeman/kafo/pull/115), some metadata in our modules and probably some discussion.

It attempts to fix the problem described here: https://github.com/theforeman/foreman-bats/pull/72#issuecomment-110033421

Using the installer to install all of our plugins doesn't always work as some aren't shipped on certain OSes, either because they're unsupported or it hasn't been done yet.  I think this means we ought to put the support matrix into a data file somewhere, either in foreman-installer or the modules themselves, which lets us either disable the options or advise the user somehow.  (In this PR, I only advise the user if they enable/select it, and ignore their choice.)

We could put the data in foreman-installer, which might be easier to handle with branching and releasing, or by putting it in the modules, we can change it at the same time as we make any changes to the plugin::\* classes.

Either way, there's always a risk that the data file will be out of date compared to the contents of our repo.  To get around this, I added the --ignore-os-support switch in case a user knows better.
