### PR TITLE
Pin puppetlabs/postgresql to avoid MODULES-2185

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,6 +2,7 @@ forge 'https://forgeapi.puppetlabs.com'
 
 # Dependencies
 mod 'puppetlabs/mysql'
+mod 'puppetlabs/postgresql',    '< 4.4.0'
 mod 'puppetlabs/puppetdb'
 mod 'theforeman/dhcp',          :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',           :git => 'https://github.com/theforeman/puppet-dns'


### PR DESCRIPTION
Affects config of PostgreSQL on Puppet 2.7.

---

My PR's been merged into master, but it's unlikely to result in another 4.4.x release to fix the regression.  Since 4.5.0's not likely to be for a month or two, pin temporarily?
