### PR TITLE
puppetlabs-puppetdb 5.x is incompatible

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,7 +3,7 @@ forge 'https://forgeapi.puppetlabs.com'
 # Dependencies
 mod 'puppetlabs/mysql'
 mod 'puppetlabs/postgresql',    '< 4.4.0'
-mod 'puppetlabs/puppetdb'
+mod 'puppetlabs/puppetdb',      '< 5.0.0'
 mod 'theforeman/dhcp',          :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',           :git => 'https://github.com/theforeman/puppet-dns'
 mod 'theforeman/git',           :git => 'https://github.com/theforeman/puppet-git'


### PR DESCRIPTION
with theforeman-puppet

this should also go into 1.8 and 1.9
