### PR TITLE
Revert "Pin puppetlabs/postgresql to avoid MODULES-2185"

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,7 +2,7 @@ forge 'https://forgeapi.puppetlabs.com'
 
 # Dependencies
 mod 'puppetlabs/mysql'
-mod 'puppetlabs/postgresql',    '< 4.4.0'
+mod 'puppetlabs/postgresql'
 mod 'puppetlabs/puppetdb',      '< 5.0.0'
 mod 'theforeman/dhcp',          :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',           :git => 'https://github.com/theforeman/puppet-dns'


### PR DESCRIPTION
This reverts commit 2878f315a4478b53da9358d221032d8305e1c1be.

pl-postgresql 4.4.2 resolves the issue.
