### PR TITLE
fixes #14475 - add and install config file migrations

### DIFF
--- a/config/foreman.migrations/20160405121109_foreman_ansible.rb
+++ b/config/foreman.migrations/20160405121109_foreman_ansible.rb
@@ -1,0 +1,2 @@
+answers['foreman::plugin::ansible'] ||= false
+scenario[:mapping]['foreman::plugin::ansible'] ||= {:dir_name => 'foreman', :manifest_name => 'plugin/ansible'}

--- a/config/foreman.migrations/20160405121739_foreman_memcache.rb
+++ b/config/foreman.migrations/20160405121739_foreman_memcache.rb
@@ -1,0 +1,2 @@
+answers['foreman::plugin::memcache'] ||= false
+scenario[:mapping]['foreman::plugin::memcache'] ||= {:dir_name => 'foreman', :manifest_name => 'plugin/memcache', :params_name => 'plugin/memcache/params'}

--- a/config/foreman.migrations/20160405121855_foreman_cockpit.rb
+++ b/config/foreman.migrations/20160405121855_foreman_cockpit.rb
@@ -1,0 +1,2 @@
+answers['foreman::plugin::cockpit'] ||= false
+scenario[:mapping]['foreman::plugin::cockpit'] ||= {:dir_name => 'foreman', :manifest_name => 'plugin/cockpit'}

--- a/config/foreman.migrations/20160405122117_passenger_ruby.rb
+++ b/config/foreman.migrations/20160405122117_passenger_ruby.rb
@@ -1,0 +1,2 @@
+# Redetermine the value of passenger_ruby, as it changed on Debian in puppet-foreman f9329b6
+answers['foreman'].delete('passenger_ruby')

--- a/config/foreman.migrations/20160405135043_foreman_proxy_discovery.rb
+++ b/config/foreman.migrations/20160405135043_foreman_proxy_discovery.rb
@@ -1,0 +1,2 @@
+answers['foreman_proxy::plugin::discovery'] ||= false
+scenario[:mapping]['foreman_proxy::plugin::discovery'] ||= {:dir_name => 'foreman_proxy', :manifest_name => 'plugin/discovery', :params_name => 'plugin/discovery/params'}


### PR DESCRIPTION
To keep the migration files and applied file meeting packaging standards
they're symlinked into place, using this layout:

```
/etc/foreman-installer/scenarios.d/foreman.migrations ->
  /usr/share/foreman-installer/config/foreman.migrations
/etc/foreman-installer/scenarios.d/foreman.migrations/.applied ->
  /etc/foreman-installer/scenarios.d/foreman-migrations-applied
```

Includes migrations for current 1.10-stable to develop changes.
