### PR TITLE
refs #14475 - change module mapping keys to symbols

### DIFF
--- a/config/foreman.migrations/20160407114850_remove_string_mappings.rb
+++ b/config/foreman.migrations/20160407114850_remove_string_mappings.rb
@@ -1,0 +1,4 @@
+['foreman::plugin::ansible', 'foreman::plugin::cockpit', 'foreman::plugin::memcache', 'foreman_proxy::plugin::discovery'].each do |mod|
+  mapping = scenario[:mapping].delete(mod)
+  scenario[:mapping][mod.to_sym] ||= mapping if mapping
+end


### PR DESCRIPTION
Module names in the config mapping section should be symbols, so the
new migrations caused extra sections to be added. Recombine them in
another migration.
