### PR TITLE
fixes #14453 - build and install Kafo parser cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'kafo', '>= 0.7.1'
+gem 'kafo', '>= 0.8.0'
 gem 'librarian-puppet'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 3.0'
 gem 'rake'

--- a/config/foreman.migrations/20160405115512_parser_cache.rb
+++ b/config/foreman.migrations/20160405115512_parser_cache.rb
@@ -1,0 +1,1 @@
+scenario[:parser_cache_path] ||= File.join(scenario[:installer_dir], 'parser_cache', 'foreman.yaml')

--- a/config/foreman.yaml
+++ b/config/foreman.yaml
@@ -7,6 +7,8 @@
 :installer_dir: .
 # Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default
 :module_dirs: ./_build/modules
+# Location of an optional cache of parsed module data, generate with kafo-export-params -f parsercache
+:parser_cache_path: ./_build/parser_cache/foreman.yaml
 
 ## Useful for development, e.g. when you want to move log files to local directory
 :log_dir: './_build/'


### PR DESCRIPTION
The parser cache will provide support for Puppet in AIO in the near
future with Kafo by not loading Puppet or puppet-strings, and provides
a performance boost to the installer startup. Requires Kafo 0.7.3.

Be careful to preserve mtimes of manifest files to ensure the cache
validity. Extra kafo-export-params search dirs were removed as all
current packages install correctly into /usr/bin or PATH, and it is
now required to build.
