### PR TITLE
Add Travis CI test to build/install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _build
 Puppetfile.lock
 modules/*
 .ruby-*
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: ruby
+addons:
+  apt:
+    packages:
+    - asciidoc
+    - libxml2-utils
+    - xsltproc
+    - docbook-xsl
+    - ca-certificates
+rvm: 2.1.0
+env:
+  - PUPPET_VERSION=3.5
+script:
+  - INSTDIR=$(mktemp -d)
+  - bundle exec rake build install PREFIX=$INSTDIR
+  - bundle exec $INSTDIR/sbin/foreman-installer --help

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'kafo', '>= 0.7.1'
+gem 'librarian-puppet'
+gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 3.0'
+gem 'rake'

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ INCLUDEDIR = ENV['INCLUDEDIR'] || "#{PREFIX}/include"
 SYSCONFDIR = ENV['SYSCONFDIR'] || "#{PREFIX}/etc"
 LOCALSTATEDIR = ENV['LOCALSTATEDIR'] || "#{PREFIX}/var"
 SHAREDSTAREDIR = ENV['SHAREDSTAREDIR'] || "#{LOCALSTATEDIR}/lib"
+LOGDIR = ENV['LOGDIR'] || "#{LOCALSTATEDIR}/log"
 DATAROOTDIR = DATADIR = ENV['DATAROOTDIR'] || "#{PREFIX}/share"
 MANDIR = ENV['MANDIR'] || "#{DATAROOTDIR}/man"
 PKGDIR = ENV['PKGDIR'] || File.expand_path('pkg')
@@ -21,6 +22,7 @@ file "#{BUILDDIR}/foreman.yaml" => 'config/foreman.yaml' do |t|
   cp t.prerequisites[0], t.name
   sh 'sed -i "s#\(.*answer_file:\).*#\1 %s#" %s' % ["#{SYSCONFDIR}/foreman-installer/scenarios.d/foreman-answers.yaml", t.name]
   sh 'sed -i "s#\(.*installer_dir:\).*#\1 %s#" %s' % ["#{DATADIR}/foreman-installer", t.name]
+  sh 'sed -i "s#\(.*log_dir:\).*#\1 %s#" %s' % ["#{LOGDIR}/foreman-installer", t.name]
   sh 'sed -i "s#\(.*module_dirs:\).*#\1 %s#" %s' % ["#{DATADIR}/foreman-installer/modules", t.name]
   if ENV['KAFO_MODULES_DIR']
     sh 'sed -i "s#.*\(:kafo_modules_dir:\).*#\1 %s#" %s' % [ENV['KAFO_MODULES_DIR'], t.name]
@@ -29,7 +31,7 @@ end
 
 file "#{BUILDDIR}/foreman-installer" => 'bin/foreman-installer' do |t|
   cp t.prerequisites[0], t.name
-  sh 'sed -i "s#\(^.*CONFIG_DIR = \'/etc/foreman-installer/scenarios.d\'*.\).*#  CONFIG_DIR = %s#" %s' % ["'#{SYSCONFDIR}/foreman-installer/scenarios.d/'", t.name]
+  sh 'sed -i "s#\(^.*CONFIG_DIR = \).*#CONFIG_DIR = %s#" %s' % ["'#{SYSCONFDIR}/foreman-installer/scenarios.d/'", t.name]
 end
 
 file "#{BUILDDIR}/options.asciidoc" => "#{BUILDDIR}/modules" do |t|
@@ -121,6 +123,8 @@ task :install => :build do |t|
 
   mkdir_p "#{MANDIR}/man8"
   cp "#{BUILDDIR}/foreman-installer.8", "#{MANDIR}/man8/"
+
+  mkdir_p "#{LOGDIR}/foreman-installer"
 end
 
 task :default => :build

--- a/bin/foreman-installer
+++ b/bin/foreman-installer
@@ -2,11 +2,7 @@
 require 'rubygems'
 require 'kafo'
 
-if Dir.glob('config/*.yaml').any?
-  CONFIG_DIR = 'config/'
-else
-  CONFIG_DIR = '/etc/foreman-installer/scenarios.d/'
-end
+CONFIG_DIR = 'config/'
 
 # Run the install
 @result = Kafo::KafoConfigure.run

--- a/config/foreman.yaml
+++ b/config/foreman.yaml
@@ -9,7 +9,7 @@
 :module_dirs: ./_build/modules
 
 ## Useful for development, e.g. when you want to move log files to local directory
-:log_dir: '/var/log/foreman-installer'
+:log_dir: './_build/'
 :log_name: 'foreman.log'
 :log_level: :debug
 


### PR DESCRIPTION
Replace LOGDIR to work within the specified PREFIX, and replace
CONFIG_DIR to prevent config files from the local directory being used
in preference to those from the installation prefix.

---

This will exercise the Puppetfile as librarian-puppet's called during build, config migrations during the `--help` call, generation of man pages etc.
