### PR TITLE
refs #14788 - pull in Ubuntu/xenial cherry-picks in modules (1.11)

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,8 +1,9 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 # Dependencies
-mod 'puppetlabs/mysql'
-mod 'puppetlabs/postgresql'
+mod 'puppetlabs/mysql',         :git => 'https://github.com/theforeman/puppetlabs-mysql.git', :ref => '3.7.x'
+mod 'puppetlabs/postgresql',    :git => 'https://github.com/theforeman/puppetlabs-postgresql.git', :ref => '4.7.x'
+mod 'puppetlabs/apache',        :git => 'https://github.com/theforeman/puppetlabs-apache.git', :ref => '1.8.x'
 mod 'puppetlabs/puppetdb',      '< 5.0.0'
 mod 'theforeman/dhcp',          '>= 2.3.0 < 2.4.0'
 mod 'theforeman/dns',           '>= 3.2.0 < 3.3.0'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -5,22 +5,12 @@ FORGE
     nanliu-staging (1.0.3)
     puppet-extlib (0.11.0)
       puppetlabs-stdlib (>= 0)
-    puppetlabs-apache (1.8.1)
-      puppetlabs-concat (< 3.0.0, >= 1.1.1)
-      puppetlabs-stdlib (< 5.0.0, >= 2.4.0)
     puppetlabs-apt (2.2.1)
       puppetlabs-stdlib (< 5.0.0, >= 4.5.0)
     puppetlabs-concat (2.1.0)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-firewall (1.8.0)
     puppetlabs-inifile (1.4.3)
-    puppetlabs-mysql (3.6.2)
-      nanliu-staging (< 2.0.0, >= 1.0.1)
-      puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
-    puppetlabs-postgresql (4.7.1)
-      puppetlabs-apt (< 3.0.0, >= 1.8.0)
-      puppetlabs-concat (< 3.0.0, >= 1.1.0)
-      puppetlabs-stdlib (~> 4.0)
     puppetlabs-puppetdb (4.3.0)
       puppetlabs-firewall (< 2.0.0, >= 1.1.3)
       puppetlabs-inifile (< 2.0.0, >= 1.1.3)
@@ -61,7 +51,36 @@ FORGE
       puppetlabs-stdlib (< 5.0.0, >= 2.3.0)
       puppetlabs-xinetd (< 2.0.0, >= 1.1.0)
 
+GIT
+  remote: https://github.com/theforeman/puppetlabs-apache.git
+  ref: 1.8.x
+  sha: 439b96dbe6608078f647345d1aefd4ab84870e57
+  specs:
+    puppetlabs-apache (1.8.1)
+      puppetlabs-concat (< 3.0.0, >= 1.1.1)
+      puppetlabs-stdlib (< 5.0.0, >= 2.4.0)
+
+GIT
+  remote: https://github.com/theforeman/puppetlabs-mysql.git
+  ref: 3.7.x
+  sha: f5ebdf635ca751d9ece29c3a85f1ac90ca5b62ec
+  specs:
+    puppetlabs-mysql (3.7.0)
+      nanliu-staging (< 2.0.0, >= 1.0.1)
+      puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
+
+GIT
+  remote: https://github.com/theforeman/puppetlabs-postgresql.git
+  ref: 4.7.x
+  sha: 8e2012aaa54afcae0e72624e48170c7875fe4427
+  specs:
+    puppetlabs-postgresql (4.7.1)
+      puppetlabs-apt (< 3.0.0, >= 1.8.0)
+      puppetlabs-concat (< 3.0.0, >= 1.1.0)
+      puppetlabs-stdlib (~> 4.0)
+
 DEPENDENCIES
+  puppetlabs-apache (>= 0)
   puppetlabs-mysql (>= 0)
   puppetlabs-postgresql (>= 0)
   puppetlabs-puppetdb (< 5.0.0)


### PR DESCRIPTION
This is what would be needed to get successful installer runs on Ubuntu/xenial. For -apache and -postgresql this is what we have plus one commit each, for -mysql it's 3.6.x -> 3.7.x and one additional commit. Note that -mysql and -postgresql do not have versioned releases with the required fixes.
