### PR TITLE
Update theforeman/tftp for Ubuntu 16.04 service fix

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,7 @@ mod 'puppetlabs/puppetdb',      '< 5.0.0'
 mod 'theforeman/dhcp',          '>= 2.3.0 < 2.4.0'
 mod 'theforeman/dns',           '>= 3.2.0 < 3.3.0'
 mod 'theforeman/git',           '>= 1.6.0 < 1.7.0'
-mod 'theforeman/tftp',          '>= 1.7.0 < 1.8.0'
+mod 'theforeman/tftp',          '>= 1.8.0 < 1.9.0'
 
 # Top-level modules
 mod 'theforeman/foreman',       '>= 5.1.0 < 5.2.0'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -47,7 +47,7 @@ FORGE
       puppetlabs-apache (< 2.0.0, >= 1.2.0)
       puppetlabs-concat (< 3.0.0, >= 1.0.0)
       puppetlabs-stdlib (< 5.0.0, >= 4.2.0)
-    theforeman-tftp (1.7.0)
+    theforeman-tftp (1.8.0)
       puppetlabs-stdlib (< 5.0.0, >= 2.3.0)
       puppetlabs-xinetd (< 2.0.0, >= 1.1.0)
 
@@ -90,5 +90,5 @@ DEPENDENCIES
   theforeman-foreman_proxy (< 2.6.0, >= 2.5.0)
   theforeman-git (< 1.7.0, >= 1.6.0)
   theforeman-puppet (< 4.4.0, >= 4.3.0)
-  theforeman-tftp (< 1.8.0, >= 1.7.0)
+  theforeman-tftp (< 1.9.0, >= 1.8.0)
 


### PR DESCRIPTION
The minor version introduces a couple of new parameters, but I think it's low risk.
