### PR TITLE
Remove unmaintained ovirt_provision plugin

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -27,7 +27,6 @@ foreman::plugin::discovery: false
 foreman::plugin::docker: false
 foreman::plugin::memcache: false
 foreman::plugin::openscap: false
-foreman::plugin::ovirt_provision: false
 foreman::plugin::tasks: false
 foreman::plugin::hooks: false
 foreman::plugin::puppetdb: false

--- a/config/foreman.migrations/20160516143923_remove_ovirt_provision.rb
+++ b/config/foreman.migrations/20160516143923_remove_ovirt_provision.rb
@@ -1,0 +1,3 @@
+# Remove unmaintained ovirt_provision plugin
+answers.delete('foreman::plugin::ovirt_provision')
+scenario[:mapping].delete(:'foreman::plugin::ovirt_provision')

--- a/config/foreman.yaml
+++ b/config/foreman.yaml
@@ -83,10 +83,6 @@
     :dir_name: foreman
     :params_name: plugin/openscap/params
     :manifest_name: plugin/openscap
-  :foreman::plugin::ovirt_provision:
-    :dir_name: foreman
-    :params_name: plugin/ovirt_provision/params
-    :manifest_name: plugin/ovirt_provision
   :foreman::plugin::chef:
     :dir_name: foreman
     :manifest_name: plugin/chef


### PR DESCRIPTION
per https://github.com/theforeman/foreman-packaging/commit/60ca1687bc1588f547cfe722d4bbd99b0cf90d78

We can optionally remove the class later (https://github.com/theforeman/puppet-foreman/issues/443).
