### PR TITLE
Fix foreman_proxy answers migration when module's disabled

### DIFF
--- a/config/foreman.migrations/20160518125928_foreman_proxy_puppetrun_rename.rb
+++ b/config/foreman.migrations/20160518125928_foreman_proxy_puppetrun_rename.rb
@@ -1,4 +1,4 @@
 # Rename foreman_proxy puppetrun parameters to puppet
 # https://github.com/theforeman/puppet-foreman_proxy/commit/c26cac15
-answers['foreman_proxy']['puppet'] = answers['foreman_proxy'].delete('puppetrun') if answers['foreman_proxy'].has_key?('puppetrun')
-answers['foreman_proxy']['puppet_listen_on'] = answers['foreman_proxy'].delete('puppetrun_listen_on') if answers['foreman_proxy'].has_key?('puppetrun_listen_on')
+answers['foreman_proxy']['puppet'] = answers['foreman_proxy'].delete('puppetrun') if answers['foreman_proxy'] && answers['foreman_proxy'].has_key?('puppetrun')
+answers['foreman_proxy']['puppet_listen_on'] = answers['foreman_proxy'].delete('puppetrun_listen_on') if answers['foreman_proxy'] && answers['foreman_proxy'].has_key?('puppetrun_listen_on')


### PR DESCRIPTION
When the foreman_proxy module is disabled, the value of the answer will
be false rather than a hash, causing a migration error:

```
20160518125928_foreman_proxy_puppetrun_rename.rb:3:in `block
(2 levels) in load_migrations': undefined method `has_key?' for
false:FalseClass (NoMethodError)
```

Also for 1.12-stable please, as that's where the migration was introduced.
