### PR TITLE
fixes #14789 - disable apache::mod::passenger::manage_repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'kafo', '>= 0.8.0'
+gem 'kafo', '>= 0.9.0'
 gem 'librarian-puppet'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 3.0'
 gem 'rake'

--- a/config/foreman-hiera.conf
+++ b/config/foreman-hiera.conf
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - kafo_answers
+  - "%{::osfamily}"
+:yaml:
+  :datadir: ./config/foreman.hiera

--- a/config/foreman.hiera/RedHat.yaml
+++ b/config/foreman.hiera/RedHat.yaml
@@ -1,0 +1,3 @@
+---
+# Disable additional Phusion Passenger repo on EL, preferring EPEL/Foreman's
+apache::mod::passenger::manage_repo: false

--- a/config/foreman.migrations/20160609094052_hiera_config.rb
+++ b/config/foreman.migrations/20160609094052_hiera_config.rb
@@ -1,0 +1,1 @@
+scenario[:hiera_config] ||= File.join(scenario[:installer_dir], 'config', 'foreman-hiera.conf')

--- a/config/foreman.yaml
+++ b/config/foreman.yaml
@@ -7,6 +7,7 @@
 :installer_dir: .
 # Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default
 :module_dirs: ./_build/modules
+:hiera_config: ./_build/foreman-hiera.conf
 # Location of an optional cache of parsed module data, generate with kafo-export-params -f parsercache
 :parser_cache_path: ./_build/parser_cache/foreman.yaml
 


### PR DESCRIPTION
Add Hiera configuration using Kafo 0.9.0's hiera_config option to set
the Passenger class' manage_repo parameter to false on "RedHat" OSes,
preferring the EPEL or Foreman packages.

Hiera data files are installed as data files rather than configuration
files, as they're shipped by the installer only to configure modules
rather than for the user to configure the installer.
