### PR TITLE
Remove custom postgresql branch, 4.8.0 released

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,8 +2,8 @@ forge 'https://forgeapi.puppetlabs.com'
 
 # Dependencies
 mod 'puppet/extlib',            '<= 0.11.3'
-mod 'puppetlabs/mysql'
-mod 'puppetlabs/postgresql',    :git => 'https://github.com/theforeman/puppetlabs-postgresql.git', :ref => '4.7.x'
+mod 'puppetlabs/mysql',         '>= 3.8.0'
+mod 'puppetlabs/postgresql',    '>= 4.8.0'
 mod 'puppetlabs/puppetdb',      '< 5.0.0'
 mod 'theforeman/dhcp',          :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',           :git => 'https://github.com/theforeman/puppet-dns'


### PR DESCRIPTION
Contains support for Ubuntu 16.04 and Fedora 24.

https://forge.puppet.com/puppetlabs/postgresql/changelog
