### PR TITLE
fixes #16207 - allow users to provide custom hiera configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -115,7 +115,11 @@ task :build => [
 task :install => :build do |t|
   mkdir_p "#{DATADIR}/foreman-installer"
   cp_r Dir.glob('{checks,config,hooks,VERSION,README.md,LICENSE}'), "#{DATADIR}/foreman-installer"
+
   cp "#{BUILDDIR}/foreman-hiera.conf", "#{DATADIR}/foreman-installer/config/foreman-hiera.conf"
+  mkdir_p "#{SYSCONFDIR}/foreman-installer"
+  ln_s "#{DATADIR}/foreman-installer/config/foreman.hiera/custom.yaml", "#{SYSCONFDIR}/foreman-installer/custom_hiera.yaml"
+
   copy_entry "#{BUILDDIR}/foreman.migrations/.applied", "#{DATADIR}/foreman-installer/config/foreman.migrations/.applied"
   cp_r "#{BUILDDIR}/modules", "#{DATADIR}/foreman-installer", :preserve => true
   cp_r "#{BUILDDIR}/parser_cache", "#{DATADIR}/foreman-installer"

--- a/Rakefile
+++ b/Rakefile
@@ -118,7 +118,8 @@ task :install => :build do |t|
 
   cp "#{BUILDDIR}/foreman-hiera.conf", "#{DATADIR}/foreman-installer/config/foreman-hiera.conf"
   mkdir_p "#{SYSCONFDIR}/foreman-installer"
-  ln_s "#{DATADIR}/foreman-installer/config/foreman.hiera/custom.yaml", "#{SYSCONFDIR}/foreman-installer/custom-hiera.yaml"
+  mv "#{DATADIR}/foreman-installer/config/foreman.hiera/custom.yaml", "#{SYSCONFDIR}/foreman-installer/custom-hiera.yaml"
+  ln_s "#{SYSCONFDIR}/foreman-installer/custom-hiera.yaml", "#{DATADIR}/foreman-installer/config/foreman.hiera/custom.yaml"
 
   copy_entry "#{BUILDDIR}/foreman.migrations/.applied", "#{DATADIR}/foreman-installer/config/foreman.migrations/.applied"
   cp_r "#{BUILDDIR}/modules", "#{DATADIR}/foreman-installer", :preserve => true

--- a/Rakefile
+++ b/Rakefile
@@ -118,7 +118,7 @@ task :install => :build do |t|
 
   cp "#{BUILDDIR}/foreman-hiera.conf", "#{DATADIR}/foreman-installer/config/foreman-hiera.conf"
   mkdir_p "#{SYSCONFDIR}/foreman-installer"
-  ln_s "#{DATADIR}/foreman-installer/config/foreman.hiera/custom.yaml", "#{SYSCONFDIR}/foreman-installer/custom_hiera.yaml"
+  ln_s "#{DATADIR}/foreman-installer/config/foreman.hiera/custom.yaml", "#{SYSCONFDIR}/foreman-installer/custom-hiera.yaml"
 
   copy_entry "#{BUILDDIR}/foreman.migrations/.applied", "#{DATADIR}/foreman-installer/config/foreman.migrations/.applied"
   cp_r "#{BUILDDIR}/modules", "#{DATADIR}/foreman-installer", :preserve => true

--- a/config/foreman-hiera.conf
+++ b/config/foreman-hiera.conf
@@ -2,8 +2,8 @@
 :backends:
   - yaml
 :hierarchy:
+  - custom
   - kafo_answers
   - "%{::osfamily}"
-  - custom
 :yaml:
   :datadir: ./config/foreman.hiera

--- a/config/foreman-hiera.conf
+++ b/config/foreman-hiera.conf
@@ -4,5 +4,6 @@
 :hierarchy:
   - kafo_answers
   - "%{::osfamily}"
+  - custom
 :yaml:
   :datadir: ./config/foreman.hiera

--- a/config/foreman.hiera/custom.yaml
+++ b/config/foreman.hiera/custom.yaml
@@ -1,0 +1,17 @@
+---
+# This YAML file lets you set your own custom configuration in Hiera for the
+# installer puppet modules that might not be exposed to users directly through
+# installer arguments.
+#
+# For example, to set 'TraceEnable Off' in Apache, a common requirement for
+# security auditors, add this to this file:
+#
+#   apache::trace_enable: Off
+#
+# Consult the full module documentation on http://forge.puppetlabs.com,
+# or the actual puppet classes themselves, to discover options to configure.
+#
+# Do note, setting some values may have unintended consequences the affect the
+# performance or functionality of the application. Consider the impact of your
+# changes before applying them, and test them in a non-production environment
+# first.

--- a/config/foreman.hiera/custom.yaml
+++ b/config/foreman.hiera/custom.yaml
@@ -11,7 +11,7 @@
 # Consult the full module documentation on http://forge.puppetlabs.com,
 # or the actual puppet classes themselves, to discover options to configure.
 #
-# Do note, setting some values may have unintended consequences the affect the
+# Do note, setting some values may have unintended consequences that affect the
 # performance or functionality of the application. Consider the impact of your
 # changes before applying them, and test them in a non-production environment
 # first.


### PR DESCRIPTION
A lot of enterprise-y users have security requirements they're required to use on their servers - things like turning server signature, trace, etc off in Apache.  We've had other cases in Katello where users wanted to tweak qpid or pulp settings to allow for more threads/workers/etc, for example.

Not everything should be exposed at the top-level of the installer, exposing Apache configuration would be an absurd number of parameters.

This adds support for a user-supplied `custom.yaml` they'd drop into /usr/share/foreman-installer/config/foreman.hiera.

So for example, someone following a security guide that requires some things, they could do:

``` yaml

---
apache::server_tokens: Prod
apache::server_signature: Off
apache::trace_enable: Off
```
