### PR TITLE
fixes #14023 - set passenger tuning options

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -10,6 +10,10 @@ mod 'theforeman/dns',           :git => 'https://github.com/theforeman/puppet-dn
 mod 'theforeman/git',           :git => 'https://github.com/theforeman/puppet-git'
 mod 'theforeman/tftp',          :git => 'https://github.com/theforeman/puppet-tftp'
 
+# From git until PassengerMaxInstancesPerApp is available in released version
+#   https://github.com/puppetlabs/puppetlabs-apache/commit/d14e1a83e7e778fc6a000f8b28124fdb36834c43
+mod 'puppetlabs/apache',        :git => 'https://github.com/theforeman/puppetlabs-apache.git', :ref => '1.10.x'
+
 # Top-level modules
 mod 'theforeman/foreman',       :git => 'https://github.com/theforeman/puppet-foreman'
 mod 'theforeman/foreman_proxy', :git => 'https://github.com/theforeman/puppet-foreman_proxy'

--- a/config/foreman-hiera.conf
+++ b/config/foreman-hiera.conf
@@ -4,6 +4,7 @@
 :hierarchy:
   - custom
   - kafo_answers
+  - tuning
   - "%{::osfamily}"
 :yaml:
   :datadir: ./config/foreman.hiera

--- a/config/foreman.hiera/tuning.yaml
+++ b/config/foreman.hiera/tuning.yaml
@@ -1,0 +1,5 @@
+---
+apache::mod::passenger::passenger_max_pool_size: 12
+apache::mod::passenger::passenger_max_instances_per_app: 6
+apache::mod::passenger::passenger_max_request_queue_size: 250
+apache::mod::passenger::passenger_stat_throttle_rate: 120


### PR DESCRIPTION
It's worth noting, puppet-puppet even used to do this but the setting wasn't actually used correctly and was removed from the module: https://github.com/theforeman/puppet-puppet/pull/389

This has been a frequent request from users.  See https://github.com/theforeman/puppet-puppet/pull/294, https://github.com/theforeman/puppet-puppet/pull/310, https://github.com/theforeman/puppet-puppet/pull/333.

It causes a lot of issues on even moderately used foreman servers, especially when Puppet 3 is also running.  There's an additional setting that's relevant in this case, PassengerMaxInstancesPerApp, but it was only recently added to puppetlabs-apache which hasn't had a release since May :-1:  This is actually somewhat important to solving the problem since it ensures foreman has resources to respond to UI requests.  We should include this in the tuning once they actually release this.... https://github.com/puppetlabs/puppetlabs-apache/blame/master/manifests/mod/passenger.pp#L17

Anyway, I realize puppet 3 is on it's way out, but we have a number of users of Katello who are hitting this problem.  

Since the passenger config is on the foreman side and this is a widespread issue, I would rather the installer carry some higher defaults, rather than telling users to use the new custom-hiera.conf config, or carrying this config ourselves in  Katello.
