### PR TITLE
fixes #18113 - change dhcp_range from false to undef

### DIFF
--- a/config/foreman.migrations/20170118105627_foreman_proxy_dhcp_range_false.rb
+++ b/config/foreman.migrations/20170118105627_foreman_proxy_dhcp_range_false.rb
@@ -1,0 +1,2 @@
+# false is no longer a valid value, the param should be undef/nil to be disabled
+answers['foreman_proxy']['dhcp_range'] = nil if answers['foreman_proxy'] && answers['foreman_proxy']['dhcp_range'] == false


### PR DESCRIPTION
The module permits `Optional[String]` for this parameter, so it's
preferred to use undef/nil instead of false to disable it.