### PR TITLE
Fixes #18821 - set PassengerMaxRequests to keep processes healthy

### DIFF
--- a/config/foreman.hiera/tuning.yaml
+++ b/config/foreman.hiera/tuning.yaml
@@ -3,3 +3,4 @@ apache::mod::passenger::passenger_max_pool_size: 12
 apache::mod::passenger::passenger_max_instances_per_app: 6
 apache::mod::passenger::passenger_max_request_queue_size: 250
 apache::mod::passenger::passenger_stat_throttle_rate: 120
+apache::mod::passenger::passenger_max_requests: 10000


### PR DESCRIPTION
I have *no idea* how this should work, but the goal is to set
PassengerMaxRequests for all passenger processes.