### PR TITLE
Add dynflow_in_core to deploy dynflow executor

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -12,6 +12,7 @@
 foreman:
   custom_repo: true
   email_config_method: database
+  dynflow_in_core: true
 foreman_proxy:
   custom_repo: true
 puppet:


### PR DESCRIPTION
puppet-foreman supports a parameter dynflow_in_core that tells the module 
whether to run the foreman-tasks service when foreman is installed (1.15+) or
when foreman-tasks is installed (1.14)

Depends on https://github.com/theforeman/puppet-foreman/pull/530