### PR TITLE
Test foreman-installer under Puppet 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ addons:
     - xsltproc
     - docbook-xsl
     - ca-certificates
-rvm: 2.1.0
+rvm: 2.3.1
 env:
-  - PUPPET_VERSION=3.5
+  - PUPPET_VERSION=4.6
 script:
   #
   # Run rspec tests on migrations

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 
 gem 'kafo', '>= 1.0.5'
 gem 'librarian-puppet'
-gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 3.0'
+gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 4.6'
+gem 'puppet-strings'
 gem 'rake'
 
 group :test do


### PR DESCRIPTION
Additionally requires the puppet-strings gem as a parser under 4, which
is a weak dependency of kafo_parsers.