### PR TITLE
use pl-mysql 3.11.x with a fix for Debian/stretch

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,7 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 # Dependencies
-mod 'puppetlabs/mysql',         '>= 3.8.0'
+mod 'puppetlabs/mysql',         :git => 'https://github.com/theforeman/puppetlabs-mysql', :ref => '3.11.x'
 mod 'puppetlabs/postgresql',    '>= 4.8.0', '< 5.0.0'
 mod 'puppetlabs/concat',        '< 3.0.0'
 mod 'puppetlabs/puppetdb'


### PR DESCRIPTION
This is 3.11.0 with one commit cherry-picked, as it seems there will be no puppetlabs-mysql release in the near future. This should fix the current systest_foreman_mysql error on stretch.