### PR TITLE
[WIP] Add checks on the system based on the scenario

### DIFF
--- a/hooks/pre/05-check_scenario_requirements.rb
+++ b/hooks/pre/05-check_scenario_requirements.rb
@@ -1,0 +1,76 @@
+require 'pathname'
+
+PREFIX = %W(PiB TiB GiB MiB KiB B).freeze
+
+# From https://codereview.stackexchange.com/questions/9107/printing-human-readable-number-of-bytes
+def as_size(s)
+  s = s.to_f
+  i = PREFIX.length - 1
+  while s > 512 && i > 0
+    i -= 1
+    s /= 1024
+  end
+  ((s > 9 || s.modulo(1) < 0.1 ? '%d' : '%.1f') % s) + ' ' + PREFIX[i]
+end
+
+def available_space(directory)
+  mountpoints = facts[:mountpoints]
+  until (mountpoint = mountpoints[directory.to_sym])
+    directory = File.dirname(directory)
+  end
+  mountpoint[:available_bytes]
+end
+
+def scenario_requirements
+  scenario_data[:required] || {}
+end
+
+def ram
+  facts[:memory][:system][:total_bytes]
+end
+
+def cores
+  facts[:processors][:count]
+end
+
+def check
+  requirements = scenario_requirements
+
+  if requirements.nil? || requirements.empty?
+    logger.debug 'No requirements for this scenario'
+    return
+  end
+
+  if facts.empty?
+    raise Exception, 'Failed to load facts'
+  end
+
+  if (min_ram = requirements['memory']) && ram < (min_ram * 0.9)
+    raise Exception, "This system has #{as_size(ram)} of total memory. Please ensure at least #{as_size(min_ram)} of total memory before running the installer."
+  end
+
+  if (min_cores = requirements['cores']) && cores < min_cores
+    raise Exception, "This system has #{cores} CPU cores. Please ensure at least #{min_cores} cores before running the installer."
+  end
+
+  if directories = requirements['directories']
+    (directories['minimum'] || {}).each do |directory, min_available|
+      available = available_space(directory)
+
+      if available < min_available
+        raise Exception, "Please ensure directory #{directory} has at least #{as_size(min_available)} available."
+      end
+    end
+  end
+end
+
+if app_value(:disable_system_checks)
+  logger.warn 'Skipping system checks.'
+else
+  begin
+    check
+  rescue Exception => e
+    logger.error e.message
+    exit(1)
+  end
+end

--- a/spec/hooks_pre_requirements_spec.rb
+++ b/spec/hooks_pre_requirements_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+require 'yaml'
+require 'kafo'
+
+HOOK_DIR = File.expand_path(File.join(__FILE__, "../../hooks"))
+
+describe 'scenario requirements' do
+  let(:kafo) do
+    double('Kafo::KafoConfigure')
+  end
+
+  let(:hook_path) do
+    File.join(HOOK_DIR, 'pre', '05-check_scenario_requirements.rb')
+  end
+
+  let(:hook) do
+    hook = File.read(hook_path)
+    proc { instance_eval(hook, '05-check_scenario_requirements.rb', 1) }
+  end
+
+  let(:logger) do
+    double('Logger')
+  end
+
+  let(:scenario_data) do
+    {
+      required: required,
+    }
+  end
+
+  let(:facts) do
+    {
+      memory: {
+        system: {
+          total_bytes: 8 * 1024 ** 3,
+        },
+      },
+      processors: {
+        count: 4,
+      },
+      mountpoints: {
+        '/': {
+          available_bytes: 3 * 1024 ** 3,
+        },
+        '/var': {
+          available_bytes: 100 * 1024 ** 3,
+        },
+      },
+    }
+  end
+
+  let(:disable_system_checks) do
+    false
+  end
+
+  let(:context) do
+    ctx = double('Kafo::HookContext')
+    allow(ctx).to receive(:app_value).with(:disable_system_checks).and_return(disable_system_checks)
+    allow(ctx).to receive(:facts).and_return(facts)
+    allow(ctx).to receive(:logger).and_return(logger)
+    allow(ctx).to receive(:scenario_data).and_return(scenario_data)
+    ctx
+  end
+
+  let(:executor) do
+    context.instance_exec(kafo, &hook)
+  end
+
+  describe 'without requirements' do
+    let(:required) do
+      nil
+    end
+
+    it 'should return nil' do
+      expect(logger).to receive(:debug).with('No requirements for this scenario')
+      expect(executor).to be_nil
+    end
+  end
+
+  describe 'insufficient memory' do
+    let(:required) do
+      {
+        'memory' => 10 * 1024 ** 3,
+        'cores'  => 4,
+      }
+    end
+
+    it 'should exit with 1' do
+      expect(logger).to receive(:error).with('This system has 8 GiB of total memory. Please ensure at least 10 GiB of total memory before running the installer.')
+      expect(context).to receive(:exit).with(1)
+
+      expect(executor).to be_nil
+    end
+  end
+
+  describe 'insufficient cores' do
+    let(:required) do
+      {
+        'memory' => 1024 * 1024,
+        'cores'  => 8,
+      }
+    end
+
+    it 'should exit with 1' do
+      expect(logger).to receive(:error).with('This system has 4 CPU cores. Please ensure at least 8 cores before running the installer.')
+      expect(context).to receive(:exit).with(1)
+
+      expect(executor).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Currently katello installer has a check_memory hook[1] that isn't very generic. This allows us to replace that hook with generic code and overrides in the scenario.

[1]: https://github.com/Katello/katello-installer/blob/a0a897dd62b5e0b57f105d073569b66a21564fe4/hooks/pre/17-memory_check.rb