### PR TITLE
Revert "Fixes #20889 - Use the Apache MPM event worker"

### DIFF
--- a/config/foreman.hiera/tuning.yaml
+++ b/config/foreman.hiera/tuning.yaml
@@ -1,5 +1,4 @@
 ---
-apache::mpm_module: "event"
 apache::mod::passenger::passenger_max_pool_size: 12
 apache::mod::passenger::passenger_max_instances_per_app: 6
 apache::mod::passenger::passenger_max_request_queue_size: 250


### PR DESCRIPTION
This reverts commit 4da2dee800b604033eeeb0a509b1a53a0ae5ab03. It turns
out there's a bug in Apache <2.4.25 which makes it unreliable. Since EL7
and Ubuntu 16.04 both ship a version with this bug, it'd only benefit
Debian Stretch.