### PR TITLE
Fixes #21225 - Set passenger_min_instances globally to

### DIFF
--- a/config/foreman.hiera/tuning.yaml
+++ b/config/foreman.hiera/tuning.yaml
@@ -4,3 +4,4 @@ apache::mod::passenger::passenger_max_instances_per_app: 6
 apache::mod::passenger::passenger_max_request_queue_size: 250
 apache::mod::passenger::passenger_stat_throttle_rate: 120
 apache::mod::passenger::passenger_max_requests: 10000
+apache::mod::passenger::passenger_min_instances: 1


### PR DESCRIPTION
By default, puppet-puppet sets passenger_min_instances to processor
count which in some cases can starve out the Foreman passenger process
when. This sets the min to 1 globally to ensure Foreman and puppet
can share equally.