### PR TITLE
Fixes #22169 - Don't enable foreman_setup by default

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -42,7 +42,7 @@ foreman::plugin::hooks: false
 foreman::plugin::puppetdb: false
 foreman::plugin::remote_execution: false
 foreman::plugin::salt: false
-foreman::plugin::setup: true
+foreman::plugin::setup: false
 foreman::plugin::templates: false
 foreman::compute::ec2: false
 foreman::compute::gce: false


### PR DESCRIPTION
This is partially inspired by the fact that we'd have to get plugin RPMs fixed before the pipeline passed and partially due to that fact that if Foreman is the core and has it's own stand-alone repository, the base level Foreman scenario should not require anything outside of the mainline repository.