### PR TITLE
Revert "Pin puppetdb for Puppet 5 compatibility (#284)"

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,8 +3,7 @@ forge 'https://forgeapi.puppetlabs.com'
 # Dependencies
 mod 'puppetlabs/mysql',         '>= 4.0.0'
 mod 'puppetlabs/postgresql',    '>= 5.6.0'
-# 7.0.0 doesn't allow Puppet 5 - https://github.com/puppetlabs/puppetlabs-puppetdb/commit/9d93483fada0dd4c0d55ab9e18d8940a3b4e3de8
-mod 'puppetlabs/puppetdb',      '< 7.0.0'
+mod 'puppetlabs/puppetdb'
 mod 'theforeman/dhcp',          :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',           :git => 'https://github.com/theforeman/puppet-dns'
 mod 'theforeman/git',           :git => 'https://github.com/theforeman/puppet-git'


### PR DESCRIPTION
This reverts commit 9c01a05ba1f23b45a8a29c53b9b7a237270ed3af.