### PR TITLE
[WIP] Bump theforeman_proxy to 7.2.4

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -53,7 +53,7 @@ FORGE
       puppetlabs-concat (< 5.0.0, >= 1.0.0)
       puppetlabs-postgresql (< 6.0.0, >= 4.2.0)
       puppetlabs-stdlib (< 5.0.0, >= 4.13.0)
-    theforeman-foreman_proxy (7.2.3)
+    theforeman-foreman_proxy (7.2.4)
       puppet-extlib (< 3.0.0, >= 0.10.4)
       puppetlabs-stdlib (< 5.0.0, >= 4.19.0)
       richardc-datacat (< 1.0.0, >= 0.6.0)


### PR DESCRIPTION
This is needed to fix https://projects.theforeman.org/issues/24628. Note that such a release doesn't actually exist yet and this is now a placeholder so I don't forget.