### PR TITLE
Fixes #24998 - Add timestamps back to postgresql

### DIFF
--- a/config/foreman.hiera/tuning.yaml
+++ b/config/foreman.hiera/tuning.yaml
@@ -16,3 +16,4 @@ postgresql::server::config_entries:
   max_connections: 500
   shared_buffers: 512MB
   work_mem: 4MB
+  log_line_prefix: '%t '


### PR DESCRIPTION
This PR removed it:

https://github.com/puppetlabs/puppetlabs-postgresql/commit/f46ecf6dd28e1cfbdc1536c1add83a17fc979849