### PR TITLE
Fixes #25304 - Correct handle kafo_modules_dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,12 +79,13 @@ SCENARIOS.each do |scenario|
       'module_dirs' => "#{DATADIR}/foreman-installer/modules",
       'parser_cache_path' => "#{DATADIR}/foreman-installer/parser_cache/#{scenario}.yaml",
     }
-    if ENV['KAFO_MODULES_DIR']
-      scenario_config_replacements['kafo_modules_dir'] = ENV['KAFO_MODULES_DIR']
-    end
 
     scenario_config_replacements.each do |setting, value|
       sh 'sed -i "s#\(.*%s:\).*#\1 %s#" %s' % [setting, value, t.name]
+    end
+
+    if ENV['KAFO_MODULES_DIR']
+      sh 'sed -i "s#.*\(:kafo_modules_dir:\).*#\1 %s#" %s' % [ENV['KAFO_MODULES_DIR'], t.name]
     end
   end
 


### PR DESCRIPTION
In 9929fe2ed9009fdec146a6ee75f2f2d7f084f6f7 the building process was changed. A regression was introduced that no longer uncommented the kafo_modules_dir.

Source (config/foreman.yaml):

    # :kafo_modules_dir: /usr/lib/ruby/vendor_ruby/kafo/modules

With the command:

    KAFO_MODULES_DIR=/path/to/kafo/modules bundle exec rake

Before the regression it produced:

    :kafo_modules_dir: /path/to/kafo/modules

After the regression it didn't uncomment the setting:

    # :kafo_modules_dir: /path/to/kafo/modules

This patch restores the old behavior.