### PR TITLE
Fixes #25740 - Ensure a user is a member when removing

### DIFF
--- a/katello/hooks/pre/30-upgrade.rb
+++ b/katello/hooks/pre/30-upgrade.rb
@@ -163,8 +163,19 @@ def upgrade_qpid_paths
   end
 end
 
+def remove_user_from_group(user, group)
+  begin
+    is_member = Etc.getgrnam(group).mem.include?(user)
+  rescue ArgumentError
+    is_member = false
+  end
+  if is_member
+    Kafo::Helpers.execute("gpasswd -d '#{user}' '#{group}'")
+  end
+end
+
 def drop_apache_foreman_group
-  Kafo::Helpers.execute("gpasswd -d apache foreman")
+  remove_user_from_group(apache, foreman)
 end
 
 def upgrade_step(step, options = {})


### PR DESCRIPTION
When a user is not part of a group, the removal fails. Because this is
the desired end state, the upgrade should not fail on that.