### PR TITLE
Add a puppet version check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ script:
   - bundle exec $INSTDIR/sbin/foreman-installer --help --scenario foreman-proxy-content
   - bundle exec $INSTDIR/sbin/foreman-installer --help --scenario katello
   #
+  # Run rspec tests again for Puppet version support in modules.
+  # This requires all modules to be built.
+  #
+  - bundle exec rake spec
+  #
   # Test separate build/installation steps with different prefixes
   # No references to INSTDIR should be present when built with PREFIX=/
   #

--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -1,0 +1,25 @@
+require 'json'
+require 'semantic_puppet'
+
+describe 'Puppet module' do
+  VERSIONS = ['5.5.8', '6.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
+
+  Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|
+    context File.basename(File.dirname(filename)) do
+      let(:metadata) { JSON.parse(File.read(filename)) }
+      let(:requirements) { metadata['requirements'] || [] }
+      let(:puppet_requirement) do
+        requirement = requirements.find { |req| req['name'] == 'puppet' }
+        version_requirement = requirement['version_requirement'] if requirement
+        version_requirement ||= '>= 0'
+        SemanticPuppet::VersionRange.parse(version_requirement)
+      end
+
+      VERSIONS.each do |puppet_version|
+        it "should support Puppet #{puppet_version}" do
+          expect(puppet_requirement.include?(puppet_version)).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This means we execute the tests twice, but that's not a lot of overhead.  It does mean we can run our cheap tests before doing the expensive full build.

This currently fails and lead to https://community.theforeman.org/t/dropping-puppet-4-support-in-our-installer/13029