### PR TITLE
Add a DHCP warning

### DIFF
--- a/config/foreman-hiera.conf
+++ b/config/foreman-hiera.conf
@@ -8,5 +8,6 @@
   - tuning
   - "mongo-%{::osfamily}-%{::operatingsystemmajrelease}"
   - "%{::osfamily}"
+  - common
 :yaml:
   :datadir: ./config/foreman.hiera

--- a/config/foreman.hiera/common.yml
+++ b/config/foreman.hiera/common.yml
@@ -1,0 +1,13 @@
+---
+dhcp::config_comment: >
+  READ: This file was written the foreman-installer and not by the Foreman
+
+  application. Any updates to subnets in the Foreman database are not
+
+  automatically reflected in this configuration and vice versa. Configuration
+
+  updates like DNS servers or adding/removing subnets must be done both in
+
+  Foreman application and in this configuration preferably via
+
+  foreman-installer. Use custom-hiera.yaml for multiple subnets.


### PR DESCRIPTION
It is not obvious to users that the DHCP config is not automatically managed by Foreman. This adds a warning to the file instructing the user.

The text was written by Lukáš Zapletal.

It depends on https://github.com/theforeman/puppet-dhcp/pull/149. This makes it easy to customize the message in downstream, for example to include specific help URLs.