### PR TITLE
Fixes #26256 - Fix proxy cert generation hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - bundle exec $INSTDIR/sbin/foreman-installer --help --scenario foreman
   - bundle exec $INSTDIR/sbin/foreman-installer --help --scenario foreman-proxy-content
   - bundle exec $INSTDIR/sbin/foreman-installer --help --scenario katello
+  - bundle exec $INSTDIR/sbin/foreman-proxy-certs-generate --help
   #
   # Run rspec tests again for Puppet version support in modules.
   # This requires all modules to be built.

--- a/Rakefile
+++ b/Rakefile
@@ -217,12 +217,6 @@ file "#{BUILDDIR}/modules" => BUILDDIR do |t|
   end
 end
 
-directory "#{BUILDDIR}/katello"
-directory "#{BUILDDIR}/katello/hooks"
-file "#{BUILDDIR}/katello/hooks" => "#{BUILDDIR}/katello" do |t|
-  cp_r "katello/hooks", "#{BUILDDIR}/katello"
-end
-
 directory "#{BUILDDIR}/config"
 
 file "#{BUILDDIR}/config/config_header.txt" => ['config/config_header.txt', "#{BUILDDIR}/config"] do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -296,7 +296,10 @@ task :install => :build do
     copy_entry "#{BUILDDIR}/#{scenario}.migrations/.applied", "#{DATADIR}/foreman-installer/config/#{scenario}.migrations/.applied"
   end
 
-  mkdir_p "#{DATADIR}/foreman-installer/katello-certs/scenarios.d" if CERTS_SCENARIOS.any?
+  if CERTS_SCENARIOS.any?
+    mkdir_p "#{DATADIR}/foreman-installer/katello-certs/scenarios.d"
+    cp_r 'katello_certs/hooks', "#{DATADIR}/foreman-installer/katello-certs"
+  end
   CERTS_SCENARIOS.each do |scenario|
     cp "#{BUILDDIR}/#{scenario}.yaml", "#{DATADIR}/foreman-installer/katello-certs/scenarios.d/#{scenario}.yaml"
     cp "katello_certs/config/#{scenario}-answers.yaml", "#{DATADIR}/foreman-installer/katello-certs/scenarios.d/#{scenario}-answers.yaml"

--- a/katello/hooks/boot/02-message-helpers.rb
+++ b/katello/hooks/boot/02-message-helpers.rb
@@ -40,50 +40,5 @@ MSG
     def dev_new_install_message(kafo)
       say "      Initial credentials are <%= color('admin', :info) %> / <%= color('#{kafo.param('katello_devel', 'admin_password').value}', :info) %>"
     end
-
-    def proxy_instructions_message(kafo)
-      fqdn = if kafo.param('foreman_proxy_certs', 'parent_fqdn')
-               kafo.param('foreman_proxy_certs', 'parent_fqdn').value
-             else
-               `hostname -f`
-             end
-
-      certs_tar = kafo.param('foreman_proxy_certs', 'certs_tar').value
-      foreman_proxy_fqdn    = kafo.param('foreman_proxy_certs', 'foreman_proxy_fqdn').value
-      foreman_oauth_key     = Kafo::Helpers.read_cache_data("oauth_consumer_key")
-      foreman_oauth_secret  = Kafo::Helpers.read_cache_data("oauth_consumer_secret")
-      org                   = kafo.param('certs', 'org').value
-
-      success_message
-      say <<MSG
-
-  To finish the installation, follow these steps:
-
-  If you do not have the smartproxy registered to the Katello instance, then please do the following:
-
-  1. yum -y localinstall http://#{fqdn}/pub/katello-ca-consumer-latest.noarch.rpm
-  2. subscription-manager register --org "<%= color('#{org}', :info) %>"
-
-  Once this is completed run the steps below to start the smartproxy installation:
-
-  1. Ensure that the foreman-installer-katello package is installed on the system.
-  2. Copy the following file <%= color("#{certs_tar}", :info) %> to the system <%= color("#{foreman_proxy_fqdn}", :info) %> at the following location <%= color("#{File.join('/root', File.basename(certs_tar))}", :info) %>
-  scp <%= color("#{certs_tar}", :info) %> root@<%= color("#{foreman_proxy_fqdn}", :info) %>:<%= color("#{File.join('/root', File.basename(certs_tar))}", :info) %>
-  3. Run the following commands on the Foreman proxy (possibly with the customized
-     parameters, see <%= color("foreman-installer --scenario foreman-proxy-content --help", :info) %> and
-     documentation for more info on setting up additional services):
-
-  foreman-installer --scenario foreman-proxy-content\\
-                    --certs-tar-file                              "<%= color("#{File.join('/root', File.basename(certs_tar))}", :info) %>"\\
-                    --foreman-proxy-content-parent-fqdn           "<%= "#{fqdn}" %>"\\
-                    --foreman-proxy-register-in-foreman           "true"\\
-                    --foreman-proxy-foreman-base-url              "https://<%= "#{fqdn}" %>"\\
-                    --foreman-proxy-trusted-hosts                 "<%= "#{fqdn}" %>"\\
-                    --foreman-proxy-trusted-hosts                 "<%= "#{foreman_proxy_fqdn}" %>"\\
-                    --foreman-proxy-oauth-consumer-key            "<%= "#{foreman_oauth_key}" %>"\\
-                    --foreman-proxy-oauth-consumer-secret         "<%= "#{foreman_oauth_secret}" %>"\\
-                    --puppet-server-foreman-url                   "https://<%= "#{fqdn}" %>"
-MSG
-    end
   end
 end

--- a/katello/hooks/post/10-post_install.rb
+++ b/katello/hooks/post/10-post_install.rb
@@ -21,7 +21,6 @@ if [0, 2].include?(@kafo.exit_code)
       Kafo::Helpers.dev_new_install_message(@kafo) if new_install?
     end
 
-    Kafo::Helpers.proxy_instructions_message(@kafo) if Kafo::Helpers.module_enabled?(@kafo, 'foreman_proxy_certs')
     Kafo::Helpers.proxy_success_message(@kafo) if proxy?
   end
 

--- a/katello/hooks/pre/17-memory_check.rb
+++ b/katello/hooks/pre/17-memory_check.rb
@@ -3,7 +3,7 @@ total_ram = `grep MemTotal /proc/meminfo | awk '{print $2}'`.to_i
 min_ram = 7_900_000
 
 # call mem_check if flag is called
-if app_value(:disable_system_checks) || Kafo::Helpers.module_enabled?(@kafo, 'foreman_proxy_certs')
+if app_value(:disable_system_checks)
   logger.warn 'Skipping system checks.'
 elsif min_ram > total_ram
   $stderr.puts 'This system has less than 8 GB of total memory. Please have at least 8 GB of total ram free before running the installer.'

--- a/katello/hooks/pre_validations/12-check_capsule_tar.rb
+++ b/katello/hooks/pre_validations/12-check_capsule_tar.rb
@@ -4,8 +4,7 @@ def error(message)
   kafo.class.exit 101
 end
 
-certs_tar = param('foreman_proxy_certs', 'certs_tar') ||
-  param('certs', 'tar_file')
+certs_tar = param('certs', 'tar_file')
 
 if certs_tar.value
   certs_tar.value = File.expand_path(certs_tar.value)

--- a/katello_certs/hooks/boot/01-helper.rb
+++ b/katello_certs/hooks/boot/01-helper.rb
@@ -1,0 +1,7 @@
+class Kafo::Helpers
+  class << self
+    def read_cache_data(param)
+      YAML.load_file("/opt/puppetlabs/puppet/cache/foreman_cache_data/#{param}")
+    end
+  end
+end

--- a/katello_certs/hooks/boot/02-message-helpers.rb
+++ b/katello_certs/hooks/boot/02-message-helpers.rb
@@ -1,0 +1,51 @@
+class Kafo::Helpers
+  class << self
+    def proxy_instructions_message(kafo)
+      fqdn = if kafo.param('foreman_proxy_certs', 'parent_fqdn')
+               kafo.param('foreman_proxy_certs', 'parent_fqdn').value
+             else
+               `hostname -f`
+             end
+
+      certs_tar = kafo.param('foreman_proxy_certs', 'certs_tar').value
+      foreman_proxy_fqdn    = kafo.param('foreman_proxy_certs', 'foreman_proxy_fqdn').value
+      foreman_oauth_key     = Kafo::Helpers.read_cache_data("oauth_consumer_key")
+      foreman_oauth_secret  = Kafo::Helpers.read_cache_data("oauth_consumer_secret")
+      org                   = kafo.param('certs', 'org').value
+
+      certs_tar_file = File.join('/root', File.basename(certs_tar))
+      foreman_url = "https://#{fqdn}"
+
+      say <<MSG
+  <%= color('Success!', :good) %>
+
+  To finish the installation, follow these steps:
+
+  If you do not have the smartproxy registered to the Katello instance, then please do the following:
+
+  1. yum -y localinstall http://#{fqdn}/pub/katello-ca-consumer-latest.noarch.rpm
+  2. subscription-manager register --org "<%= color('#{org}', :info) %>"
+
+  Once this is completed run the steps below to start the smartproxy installation:
+
+  1. Ensure that the foreman-installer-katello package is installed on the system.
+  2. Copy the following file <%= color("#{certs_tar}", :info) %> to the system <%= color("#{foreman_proxy_fqdn}", :info) %> at the following location <%= color("#{certs_tar_file}", :info) %>
+  scp <%= color("#{certs_tar}", :info) %> root@<%= color("#{foreman_proxy_fqdn}", :info) %>:<%= color("#{certs_tar_file}", :info) %>
+  3. Run the following commands on the Foreman proxy (possibly with the customized
+     parameters, see <%= color("foreman-installer --scenario foreman-proxy-content --help", :info) %> and
+     documentation for more info on setting up additional services):
+
+  foreman-installer --scenario foreman-proxy-content\\
+                    --certs-tar-file                              "<%= color("#{certs_tar_file}", :info) %>"\\
+                    --foreman-proxy-content-parent-fqdn           "#{fqdn}"\\
+                    --foreman-proxy-register-in-foreman           "true"\\
+                    --foreman-proxy-foreman-base-url              "#{foreman_url}"\\
+                    --foreman-proxy-trusted-hosts                 "#{fqdn}"\\
+                    --foreman-proxy-trusted-hosts                 "#{foreman_proxy_fqdn}"\\
+                    --foreman-proxy-oauth-consumer-key            "#{foreman_oauth_key}"\\
+                    --foreman-proxy-oauth-consumer-secret         "#{foreman_oauth_secret}"\\
+                    --puppet-server-foreman-url                   "#{foreman_url}"
+MSG
+    end
+  end
+end

--- a/katello_certs/hooks/post/10-post_generation.rb
+++ b/katello_certs/hooks/post/10-post_generation.rb
@@ -1,0 +1,3 @@
+if [0, 2].include?(@kafo.exit_code)
+  Kafo::Helpers.proxy_instructions_message(@kafo)
+end

--- a/katello_certs/hooks/pre_validations/10-absolute_certs_tar_path.rb
+++ b/katello_certs/hooks/pre_validations/10-absolute_certs_tar_path.rb
@@ -1,0 +1,5 @@
+certs_tar = param('foreman_proxy_certs', 'certs_tar')
+
+if certs_tar.value
+  certs_tar.value = File.expand_path(certs_tar.value)
+end


### PR DESCRIPTION
When merging the installers, the hooks were removed from the certificate generation process because most hooks are irrelevant. Not all, so this caused a regression.

Rather than enabling all hooks again, this takes the more minimal route of only adding the relevant hooks.