### PR TITLE
Refs #26330 - Do not add Foreman to Puppet in Katello

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -28,6 +28,7 @@ foreman:
   passenger_ruby: /usr/bin/tfm-ruby
   passenger_ruby_package: tfm-rubygem-passenger-native
   keepalive: true
+  user_groups: []
 foreman_proxy_content:
   pulp_master: true
   qpid_router_broker_addr: localhost

--- a/config/katello.migrations/190314163941-remove-foreman-user-groups.rb
+++ b/config/katello.migrations/190314163941-remove-foreman-user-groups.rb
@@ -1,0 +1,5 @@
+if answers['foreman'].is_a?(Hash)
+  answers['foreman']['user_groups'] = []
+elsif answers['foreman']
+  answers['foreman'] = {'user_groups': []}
+end


### PR DESCRIPTION
In the Katello scenario we don't need Foreman to be able to read the Puppet certs. This is the only reason we add Foreman to the Puppet user group by default. This change allows users to install on systems without Puppet server present.

Until Puppet 4 the agent package also ensured the Puppet user group existed so this wasn't a problem with Puppet 3.