### PR TITLE
Refs #26330 - Fix syntax on user group migration

### DIFF
--- a/config/katello.migrations/190314163941-remove-foreman-user-groups.rb
+++ b/config/katello.migrations/190314163941-remove-foreman-user-groups.rb
@@ -1,5 +1,5 @@
 if answers['foreman'].is_a?(Hash)
   answers['foreman']['user_groups'] = []
 elsif answers['foreman']
-  answers['foreman'] = {'user_groups': []}
+  answers['foreman'] = {'user_groups' => []}
 end


### PR DESCRIPTION
002af7bb53b652f86709e879e72270b385161afa introduced a bug in the migration by using 2.0 incompatible syntax.