### PR TITLE
Fixes #26409 - Locking of packages after installation

### DIFF
--- a/katello/hooks/boot/09-version_locking.rb
+++ b/katello/hooks/boot/09-version_locking.rb
@@ -1,9 +1,10 @@
-return nil unless system('command -v foreman-maintain > /dev/null')
-app_option(
-  '--[no-]lock-package-versions',
-  :flag,
-  "Let installer lock versions of the installed packages to prevent\n" \
-    "unexpected breakages during system updates. The choice is remembered\n" \
-    "and used in next installer runs.",
-  :default => nil
-)
+if system('command -v foreman-maintain > /dev/null')
+  app_option(
+    '--[no-]lock-package-versions',
+    :flag,
+    "Let installer lock versions of the installed packages to prevent\n" \
+      "unexpected breakages during system updates. The choice is remembered\n" \
+      "and used in next installer runs.",
+    :default => nil
+  )
+end

--- a/katello/hooks/boot/09-version_locking.rb
+++ b/katello/hooks/boot/09-version_locking.rb
@@ -1,3 +1,4 @@
+return nil unless system('command -v foreman-maintain > /dev/null')
 app_option(
   '--[no-]lock-package-versions',
   :flag,

--- a/katello/hooks/boot/09-version_locking.rb
+++ b/katello/hooks/boot/09-version_locking.rb
@@ -1,0 +1,8 @@
+app_option(
+  '--[no-]lock-package-versions',
+  :flag,
+  "Let installer lock versions of the installed packages to prevent\n" \
+    "unexpected breakages during system updates. The choice is remembered\n" \
+    "and used in next installer runs.",
+  :default => nil
+)

--- a/katello/hooks/post/09-version_locking.rb
+++ b/katello/hooks/post/09-version_locking.rb
@@ -1,0 +1,2 @@
+lock_packages = get_custom_config(:lock_package_versions)
+Kafo::Helpers.execute('foreman-maintain installation lock --assumeyes') if lock_packages

--- a/katello/hooks/post/09-version_locking.rb
+++ b/katello/hooks/post/09-version_locking.rb
@@ -1,2 +1,2 @@
 lock_packages = get_custom_config(:lock_package_versions)
-Kafo::Helpers.execute('foreman-maintain installation lock --assumeyes') if lock_packages
+Kafo::Helpers.execute('foreman-maintain packages lock --assumeyes') if lock_packages

--- a/katello/hooks/post/09-version_locking.rb
+++ b/katello/hooks/post/09-version_locking.rb
@@ -1,2 +1,4 @@
-lock_packages = get_custom_config(:lock_package_versions)
-Kafo::Helpers.execute('foreman-maintain packages lock --assumeyes') if lock_packages
+if get_custom_config(:lock_package_versions)
+  Kafo::Helpers.log_and_say :info, "Package versions are being locked."
+  Kafo::Helpers.execute('foreman-maintain packages lock --assumeyes', false)
+end

--- a/katello/hooks/pre_commit/09-version_locking.rb
+++ b/katello/hooks/pre_commit/09-version_locking.rb
@@ -9,11 +9,11 @@ if lock_versions != custom_config_value
 end
 
 if lock_versions
-  unless system('command -v foreman-maintain > dev/null')
+  unless system('command -v foreman-maintain > /dev/null')
     Kafo::Helpers.log_and_say :error, 'Locking of package versions was requested but foreman-maintain is not installed'
     kafo.class.exit 1
   end
-  unless system('foreman-maintain packages -h > /dev/null')
+  unless system('foreman-maintain packages -h > /dev/null 2>&1')
     Kafo::Helpers.log_and_say :error, 'Locking of package versions was requested but foreman-maintain version installed does not support it'
     kafo.class.exit 1
   end

--- a/katello/hooks/pre_commit/09-version_locking.rb
+++ b/katello/hooks/pre_commit/09-version_locking.rb
@@ -12,8 +12,8 @@ end
 `command -v foreman-maintain`
 if $?.success?
   `foreman-maintain installation is-locked --assumeyes`
-  if $?.exitstatus == 1
-    Kafo::Helpers.log_and_say :info, "Package versionss are locked. Continuing with unlock."
+  if $?.exitstatus == 0
+    Kafo::Helpers.log_and_say :info, "Package versions are locked. Continuing with unlock."
     Kafo::Helpers.execute('foreman-maintain installation unlock --assumeyes')
   end
 end

--- a/katello/hooks/pre_commit/09-version_locking.rb
+++ b/katello/hooks/pre_commit/09-version_locking.rb
@@ -1,0 +1,21 @@
+# evaluate version locking settings
+cli_param = app_value(:lock_package_versions)
+custom_config_value = get_custom_config(:lock_package_versions)
+lock_versions = cli_param.nil? ? !!custom_config_value : cli_param
+
+if lock_versions != custom_config_value
+  store_custom_config(:lock_package_versions, lock_versions)
+  kafo.config.configure_application
+end
+
+# unlock packages if locked
+`command -v foreman-maintain`
+if $?.success?
+  `foreman-maintain installation is-locked --assumeyes`
+  if $?.exitstatus == 1
+    Kafo::Helpers.log_and_say :info, "Package versionss are locked. Continuing with unlock."
+    Kafo::Helpers.execute('foreman-maintain installation unlock --assumeyes')
+  end
+end
+nil
+

--- a/katello/hooks/pre_commit/09-version_locking.rb
+++ b/katello/hooks/pre_commit/09-version_locking.rb
@@ -11,10 +11,10 @@ end
 # unlock packages if locked
 `command -v foreman-maintain`
 if $?.success?
-  `foreman-maintain installation is-locked --assumeyes`
+  `foreman-maintain packages is-locked --assumeyes`
   if $?.exitstatus == 0
     Kafo::Helpers.log_and_say :info, "Package versions are locked. Continuing with unlock."
-    Kafo::Helpers.execute('foreman-maintain installation unlock --assumeyes')
+    Kafo::Helpers.execute('foreman-maintain packages unlock --assumeyes')
   end
 end
 nil

--- a/katello/hooks/pre_commit/09-version_locking.rb
+++ b/katello/hooks/pre_commit/09-version_locking.rb
@@ -20,9 +20,8 @@ if lock_versions
 end
 
 # unlock packages if locked
-if system('foreman-maintain packages is-locked --assumeyes > /dev/null')
+if system('foreman-maintain packages is-locked --assumeyes > /dev/null 2>&1')
   Kafo::Helpers.log_and_say :info, "Package versions are locked. Continuing with unlock."
   Kafo::Helpers.execute('foreman-maintain packages unlock --assumeyes', false)
 end
 nil
-


### PR DESCRIPTION
This patch add a new option --[no-]lock-package-versions.
The option enables/disables version locking of installed packages.
Once used the choice is stored in the scenario "custom" hash and
is reused in the following installer runs.

If the packages are locked when the installer starts
unlock is performed before installer proceed with the installation.