### PR TITLE
Fixes #25059 - Remove local module_enabled? method

### DIFF
--- a/katello/hooks/boot/01-helpers.rb
+++ b/katello/hooks/boot/01-helpers.rb
@@ -1,11 +1,5 @@
 class Kafo::Helpers
   class << self
-    def module_enabled?(kafo, name)
-      mod = kafo.module(name)
-      return false if mod.nil?
-      mod.enabled?
-    end
-
     def log_and_say(level, message, do_say = true, do_log = true)
       style = case level
               when :error

--- a/katello/hooks/post/10-post_install.rb
+++ b/katello/hooks/post/10-post_install.rb
@@ -12,11 +12,11 @@ end
 
 if [0, 2].include?(@kafo.exit_code)
   if !app_value(:upgrade)
-    if Kafo::Helpers.module_enabled?(@kafo, 'katello')
+    if module_enabled?('katello')
       Kafo::Helpers.server_success_message(@kafo)
       Kafo::Helpers.new_install_message(@kafo) if @kafo.param('foreman', 'authentication').value == true && new_install?
       Kafo::Helpers.certs_generate_command_message
-    elsif Kafo::Helpers.module_enabled?(@kafo, 'katello_devel')
+    elsif module_enabled?('katello_devel')
       Kafo::Helpers.dev_server_success_message(@kafo)
       Kafo::Helpers.dev_new_install_message(@kafo) if new_install?
     end

--- a/katello/hooks/post/30-upgrade.rb
+++ b/katello/hooks/post/30-upgrade.rb
@@ -12,7 +12,7 @@ end
 
 if app_value(:upgrade)
   if [0, 2].include?(@kafo.exit_code)
-    upgrade_tasks if Kafo::Helpers.module_enabled?(@kafo, 'foreman')
+    upgrade_tasks if module_enabled?('foreman')
     Kafo::Helpers.log_and_say :info, 'Upgrade completed!'
   else
     Kafo::Helpers.log_and_say :error, 'Upgrade failed during the installation phase. Fix the error and re-run the upgrade.'

--- a/katello/hooks/post/31-mongo_syspath.rb
+++ b/katello/hooks/post/31-mongo_syspath.rb
@@ -8,9 +8,7 @@ def install_syspaths
   end
 end
 
-katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
-foreman_proxy_content = Kafo::Helpers.module_enabled?(@kafo, 'foreman_proxy_content')
-if katello || foreman_proxy_content
+if module_enabled?('katello') || module_enabled?('foreman_proxy_content')
   install_syspaths
 else
   logger.debug 'Selected scenario is not applicable for rh-mongodb34-syspaths install, skipping'

--- a/katello/hooks/pre/15-check-disk.rb
+++ b/katello/hooks/pre/15-check-disk.rb
@@ -1,4 +1,4 @@
-if Kafo::Helpers.module_enabled?(@kafo, 'foreman_proxy_content')
+if module_enabled?('foreman_proxy_content')
   DISK_SIZE = 'The installation requires at least 5G of storage.'
   MONGODB_DIR = '/var/lib/mongodb'
   MIN_FREE_KB = 5 * 1024 * 1024

--- a/katello/hooks/pre/15-check_java.rb
+++ b/katello/hooks/pre/15-check_java.rb
@@ -15,7 +15,7 @@ def error_exit(message, code)
   kafo.class.exit code
 end
 
-if Kafo::Helpers.module_enabled?(@kafo, 'katello')
+if module_enabled?('katello')
   java_version_string = `/usr/bin/java -version 2>&1`
   java_version = java_version_string.split("\n")[0].split('"')[1]
 

--- a/katello/hooks/pre/20-certs_update.rb
+++ b/katello/hooks/pre/20-certs_update.rb
@@ -23,7 +23,7 @@ ca_file   = param('certs', 'server_ca_cert').value
 cert_file = param('certs', 'server_cert').value
 key_file  = param('certs', 'server_key').value
 
-if app_value('certs_update_server_ca') && !Kafo::Helpers.module_enabled?(@kafo, 'katello')
+if app_value('certs_update_server_ca') && !module_enabled?('katello')
   error "--certs-update-server-ca needs to be used with katello"
 end
 

--- a/katello/hooks/pre/30-upgrade.rb
+++ b/katello/hooks/pre/30-upgrade.rb
@@ -218,8 +218,8 @@ if app_value(:upgrade)
   Kafo::Helpers.log_and_say :info, '  foreman-tail | tee upgrade-$(date +%Y-%m-%d-%H%M).log'
   sleep 3
 
-  katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
-  foreman_proxy_content = @kafo.param('foreman_proxy_plugin_pulp', 'pulpnode_enabled').value
+  katello = module_enabled?('katello')
+  foreman_proxy_content = param('foreman_proxy_plugin_pulp', 'pulpnode_enabled').value
 
   upgrade_step :stop_services, :run_always => true
 

--- a/katello/hooks/pre/31-mongo_storage_engine.rb
+++ b/katello/hooks/pre/31-mongo_storage_engine.rb
@@ -5,7 +5,7 @@ def fail_and_exit(message)
 end
 
 def migration
-  katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
+  katello = module_enabled?('katello')
   export_dir = '/var/tmp/mongodb_engine_upgrade'
   mongo_dir = '/var/lib/mongodb'
   hiera_file = '/etc/foreman-installer/custom-hiera.yaml'

--- a/katello/hooks/pre_validations/30-mongo_storage_engine.rb
+++ b/katello/hooks/pre_validations/30-mongo_storage_engine.rb
@@ -28,9 +28,9 @@ if app_value(:upgrade_mongo_storage_engine)
   end
 
   # Fail if we are not using the Katello/Foreman Proxy Content scenario.
-  katello = Kafo::Helpers.module_enabled?(@kafo, 'katello')
-  foreman_proxy_content = Kafo::Helpers.module_enabled?(@kafo, 'foreman_proxy_content')
-  fail_and_exit 'MongoDB storage engine upgrade is not currently supported for the chosen scenario.' unless katello || foreman_proxy_content
+  unless module_enabled?('katello') || module_enabled?('foreman_proxy_content')
+    fail_and_exit 'MongoDB storage engine upgrade is not currently supported for the chosen scenario.'
+  end
 
   # Fail if Katello MongoDB is not localhost, does not have a valid db connection, or an invalid value in the answerfile.
   if katello


### PR DESCRIPTION
Until Kafo 3.0 its hook method didn't handle non-existing modules. Now there's no more need for this additional check.