### PR TITLE
Fixes #25564 - addedTargetOption

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -11,7 +11,7 @@ function usage () {
 Verifies, that custom SSL certificate files are usable
 as part of the Katello installation. When passing filenames use absolute paths.
 
-usage: $0 -t TARGET -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILEusage: $0 -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
+usage: $0 -t TARGET -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
 HELP
 }
 

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -18,7 +18,7 @@ HELP
 while getopts "t:c:k:b:" opt; do
     case $opt in
         t)
-            TARGET=`echo $OPTARG|tr '[:upper:]' '[:lower:]'`
+            TARGET=$(echo $OPTARG|tr '[:upper:]' '[:lower:]')
             ;;
         c)
             CERT_FILE="$(readlink -f $OPTARG)"
@@ -42,14 +42,8 @@ done
 
 EXIT_CODE=0
 
-if [ -z "$CERT_FILE" -o -z "$KEY_FILE" -o -z "$CA_BUNDLE_FILE" -o -z "$TARGET" ]; then
+if [ -z "$CERT_FILE" -o -z "$KEY_FILE" -o -z "$CA_BUNDLE_FILE" ]; then
     echo 'One of the required parameters is missing.' >&2
-    usage
-    exit 1
-fi
-
-if [[ $TARGET != "foreman" && $TARGET != "foreman-proxy" ]]; then
-    echo -e 'Target not specified or incorrect. Target value should be foreman or foreman-proxy \n' >&2
     usage
     exit 1
 fi
@@ -171,7 +165,7 @@ check-ca-bundle
 check-cert-san
 check-cert-usage-key-encipherment
 
-if [ $EXIT_CODE == "0" -a "$TARGET" == "foreman" ]; then
+if [[ $EXIT_CODE == "0" ]] && ([[ $TARGET == "foreman" ]] || [[ -z "$TARGET" ]]) ; then
     echo -e "${GREEN}Validation succeeded${RESET}\n"
     cat <<EOF
 
@@ -189,6 +183,8 @@ To update the certificates on a currently running Katello installation, run:
                       --certs-server-key "$(readlink -f $KEY_FILE)" \\
                       --certs-server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)" \\
                       --certs-update-server --certs-update-server-ca
+
+To use them inside a NEW \$FOREMAN_PROXY, rerun this command with -t foreman-proxy
 EOF
 elif [[ $EXIT_CODE == "0" ]]; then
   echo -e "${GREEN}Validation succeeded${RESET}\n"

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -11,14 +11,14 @@ function usage () {
 Verifies, that custom SSL certificate files are usable
 as part of the Katello installation. When passing filenames use absolute paths.
 
-usage: $0 -t TARGET -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
+usage: $0 -t [foreman|foreman-proxy] -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
 HELP
 }
 
 while getopts "t:c:k:b:" opt; do
     case $opt in
         t)
-            TARGET=$OPTARG
+            TARGET=`echo $OPTARG|tr '[:upper:]' '[:lower:]'`
             ;;
         c)
             CERT_FILE="$(readlink -f $OPTARG)"
@@ -49,7 +49,7 @@ if [ -z "$CERT_FILE" -o -z "$KEY_FILE" -o -z "$CA_BUNDLE_FILE" -o -z "$TARGET" ]
 fi
 
 if [[ $TARGET != "foreman" && $TARGET != "foreman-proxy" ]]; then
-    echo -e 'Target not specified or incorrect. Target value should be foreman or foreman-proxy \n' >&2
+    echo -e 'Target not specified or incorrect. Target value should be Foreman or Foreman-proxy \n' >&2
     usage
     exit 1
 fi

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -42,7 +42,7 @@ done
 
 EXIT_CODE=0
 
-if [ -z "$CERT_FILE" -o -z "$KEY_FILE" -o -z "$CA_BUNDLE_FILE" ]; then
+if [ -z "$CERT_FILE" -o -z "$KEY_FILE" -o -z "$CA_BUNDLE_FILE" -o -z "$TARGET" ]; then
     echo 'One of the required parameters is missing.' >&2
     usage
     exit 1

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -49,7 +49,7 @@ if [ -z "$CERT_FILE" -o -z "$KEY_FILE" -o -z "$CA_BUNDLE_FILE" -o -z "$TARGET" ]
 fi
 
 if [[ $TARGET != "foreman" && $TARGET != "foreman-proxy" ]]; then
-    echo -e 'Target not specified or incorrect. Target value should be Foreman or Foreman-proxy \n' >&2
+    echo -e 'Target not specified or incorrect. Target value should be foreman or foreman-proxy \n' >&2
     usage
     exit 1
 fi

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -11,12 +11,15 @@ function usage () {
 Verifies, that custom SSL certificate files are usable
 as part of the Katello installation. When passing filenames use absolute paths.
 
-usage: $0 -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
+usage: $0 -t TARGET -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILEusage: $0 -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
 HELP
 }
 
-while getopts "c:k:b:" opt; do
+while getopts "t:c:k:b:" opt; do
     case $opt in
+        t)
+            TARGET=$OPTARG
+            ;;
         c)
             CERT_FILE="$(readlink -f $OPTARG)"
             ;;
@@ -45,8 +48,11 @@ if [ -z "$CERT_FILE" -o -z "$KEY_FILE" -o -z "$CA_BUNDLE_FILE" ]; then
     exit 1
 fi
 
-HOSTNAME=$(hostname -f)
-CERT_HOSTNAME=$(openssl x509 -noout -subject -in $CERT_FILE | sed -e 's/^subject.*CN=\([a-zA-Z0-9\.\-]*\).*$/\1/')
+if [[ $TARGET != "foreman" && $TARGET != "foreman-proxy" ]]; then
+    echo -e 'Target not specified or incorrect. Target value should be foreman or foreman-proxy \n' >&2
+    usage
+    exit 1
+fi
 
 function error () {
     echo -e "\n${RED}[FAIL]${RESET}\n"
@@ -165,7 +171,7 @@ check-ca-bundle
 check-cert-san
 check-cert-usage-key-encipherment
 
-if [[ $EXIT_CODE == "0" ]] && [[ $CERT_HOSTNAME == $HOSTNAME ]]; then
+if [ $EXIT_CODE == "0" -a "$TARGET" == "foreman" ]; then
     echo -e "${GREEN}Validation succeeded${RESET}\n"
     cat <<EOF
 

--- a/spec/fixtures/katello-certs-check/missing-parameter.txt
+++ b/spec/fixtures/katello-certs-check/missing-parameter.txt
@@ -2,4 +2,4 @@ One of the required parameters is missing.
 Verifies, that custom SSL certificate files are usable
 as part of the Katello installation. When passing filenames use absolute paths.
 
-usage: |COMMAND| -t TARGET -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
+usage: |COMMAND| -t [foreman|foreman-proxy] -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE

--- a/spec/fixtures/katello-certs-check/missing-parameter.txt
+++ b/spec/fixtures/katello-certs-check/missing-parameter.txt
@@ -2,4 +2,4 @@ One of the required parameters is missing.
 Verifies, that custom SSL certificate files are usable
 as part of the Katello installation. When passing filenames use absolute paths.
 
-usage: |COMMAND| -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
+usage: |COMMAND| -t TARGET -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE


### PR DESCRIPTION
This issue was caused because of the fix in the following RFE.

[RFE] katello-certs-check to distinguish between Satellite and Capsule
https://projects.theforeman.org/issues/22694

Code snippet -
```
HOSTNAME=$(hostname -f)
CERT_HOSTNAME=$(openssl x509 -noout -subject -in $CERT_FILE | sed -e 's/^subject.*CN=\([a-zA-Z0-9\.\-]*\).*$/\1/')

if [ $EXIT_CODE == "0" -a $CERT_HOSTNAME == $HOSTNAME ]; then
echo -e "${GREEN}Validation succeeded${RESET}\n"
    cat <<EOF

To install the Katello main server with the custom certificates, run:

    satellite-installer --scenario satellite\\
                      --certs-server-cert "$(readlink -f $CERT_FILE)"\\
                      --certs-server-key "$(readlink -f $KEY_FILE)"\\
                      --certs-server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)"


```
Issue is, we are checking the hostname against the cert CN and in case of wildcard cert CN is *.example.com. So this condition fails in case of wildcard certs that are to be installed in the satellite server.

Need to modify the logic, better to give the user the ability to define target for which cert to be generated.

```
katello-certs-check -t foreman -c /customcerts/cert_crt.pem -k /customcerts/cert_key.pem -b /customcerts/CA_crt.pem
```

I have earlier opened the PR for the same but it was closed because of my some force commits and lack of git knowledge and I don't think I can reopen the same PR again so creating this new one.  We can refer the old PR for the discussion we had regarding to this. 
https://github.com/Katello/katello-installer/pull/718