### PR TITLE
Fixes #27197 - check uppercase env vars

### DIFF
--- a/checks/env_variables.rb
+++ b/checks/env_variables.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-variables = %w(http_proxy https_proxy ssl_cert_file)
+variables = %w(http_proxy https_proxy ssl_cert_file
+               HTTP_PROXY HTTPS_PROXY SSL_CERT_FILE)
 
 if variables.map { |variable| ENV[variable] }.compact.any?
   $stderr.puts "Please unset the following environment variables before running the installer: #{variables.join(', ')}"


### PR DESCRIPTION
Checking for upper case environment variables would be helpful: https://community.theforeman.org/t/upgrade-katello-3-6-3-7-smartproxy-ssl-certificate-verification-failed/13229