### PR TITLE
Fixes #27269 - force no_prefix to false for f-proxy-content

### DIFF
--- a/config/foreman-proxy-content.migrations/190710195757-force_no_prefix_false.rb
+++ b/config/foreman-proxy-content.migrations/190710195757-force_no_prefix_false.rb
@@ -1,0 +1,1 @@
+scenario.delete(:no_prefix) if scenario[:no_prefix]


### PR DESCRIPTION
Katello Capsules (Content Proxies) before Katello 3.0 had no_prefix: true in
their Installer config because the installer was quite different back then.

However, this option was never properly migrated to false on upgrades from
2.x to 3.0 (or later), resulting in Capsules that would have their Installer
options being prefix-less.

As you usually don't need to pass many options to the installer when you
upgrade, this went largely unnoticed until now when we renamed the
certs-tar-file option in Foreman 1.22/Katello 3.12 which broke upgrades
that would regenerate the certs tarball on each upgrade
(this is not required, but should work).

This change force no_prefix to false on content proxies, thus finally
fixing this issue.