### PR TITLE
Fixes #27357 - properly check for katello scenario

### DIFF
--- a/katello/hooks/pre_validations/30-mongo_storage_engine.rb
+++ b/katello/hooks/pre_validations/30-mongo_storage_engine.rb
@@ -33,7 +33,7 @@ if app_value(:upgrade_mongo_storage_engine)
   end
 
   # Fail if Katello MongoDB is not localhost, does not have a valid db connection, or an invalid value in the answerfile.
-  if katello
+  if module_enabled?('katello')
     pulp_host_param = param('katello', 'pulp_db_seeds')
     fail_and_exit('No value set for MongoDB connection') unless pulp_host_param
     mongo_host = pulp_host_param.value


### PR DESCRIPTION
In ff9143a4a38fd2b0bd35c8103546014effb6b96b we removed the `katello` var
that contained "is this runnining with katello enabled" fact, but only
replaced one of the two uses of said var in the code.

This commit also updates the second place to use
`module_enabled?('katello')` directly