### PR TITLE
Fixes #27424 - Ensure DB is seeded

### DIFF
--- a/katello/hooks/post/30-upgrade.rb
+++ b/katello/hooks/post/30-upgrade.rb
@@ -1,5 +1,10 @@
 require 'fileutils'
 
+def db_seed
+  status = Kafo::Helpers.execute('foreman-rake db:seed')
+  fail_and_exit "Upgrade failed while seeding the DB" unless status
+end
+
 def upgrade_tasks
   status = Kafo::Helpers.execute('foreman-rake upgrade:run')
   fail_and_exit "Application Upgrade Failed" unless status
@@ -12,7 +17,11 @@ end
 
 if app_value(:upgrade)
   if [0, 2].include?(@kafo.exit_code)
-    upgrade_tasks if module_enabled?('foreman')
+    if module_enabled?('foreman')
+      db_seed
+      upgrade_tasks
+    end
+
     Kafo::Helpers.log_and_say :info, 'Upgrade completed!'
   else
     Kafo::Helpers.log_and_say :error, 'Upgrade failed during the installation phase. Fix the error and re-run the upgrade.'


### PR DESCRIPTION
Based on discussion in https://github.com/theforeman/foreman-packaging/pull/3937 I'm moving this to the installer. It does seem more appropriate to do here which was the behavior for Katello prior to using Foreman's UpgradeTask approach.

Once merged I'll cherry-pick to katello-installer for downstream concerns.

**To test**

- Apply this patch to your favorite VM - centos7-katello-nightly for example
- Delete all the upgrade tasks in the DB:

```
> foreman-rake console
> UpgradeTask.delete_all
```

- run the installer
```
foreman-installer --upgrade --scenario katello --disable-system-checks
```

The installer output should indicate that upgrade tasks were executed:

```
foreman-rake db:seed finished successfully!                                                                                                       
=============================================                                                                                                     
Upgrade Step 1/10: katello:correct_repositories. This may take a long while.                                                                      
=============================================                                                                                                     
Upgrade Step 2/10: katello:correct_puppet_environments. This may take a long while.                                                               
=============================================                                                                                                     
Upgrade Step 3/10: katello:clean_backend_objects. This may take a long while.                                                                     
0 orphaned consumer id(s) found in candlepin.                                                                                                     
Candlepin orphaned consumers: []                                                                                                                  
0 orphaned consumer id(s) found in pulp.                                                                                                          
Pulp orphaned consumers: []                                                                                                                       
=============================================                                                                                                     
Upgrade Step 4/10: katello:upgrades:3.8:clear_checksum_type. =============================================                                        
Upgrade Step 5/10: katello:upgrades:3.10:clear_invalid_repo_credentials. =============================================                            
Upgrade Step 6/10: katello:upgrades:3.10:update_gpg_key_urls. =============================================                                                                  
Upgrade Step 7/10: katello:upgrades:3.11:import_yum_metadata. Importing Yum Metadata Files                                                        
=============================================                                                                                                     
Upgrade Step 8/10: katello:upgrades:3.11:update_puppet_repos. =============================================                                       
Upgrade Step 9/10: katello:upgrades:3.11:clear_checksum_type. =============================================                                       
Upgrade Step 10/10: katello:upgrades:3.12:remove_pulp2_notifier. foreman-rake upgrade:run finished successfully! 
```