### PR TITLE
Fixes #27462 - Capture the openssl error correctly

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -128,11 +128,13 @@ function check-priv-key () {
 function check-ca-bundle () {
     printf "Checking CA bundle against the certificate file: "
     CHECK=$(openssl verify -CAfile $CA_BUNDLE_FILE -purpose sslserver -verbose $CERT_FILE 2>&1)
-    if [[ $? == "0" ]]; then
-        success
+
+    ERROR_PATTERN="error [0-9]+ at"
+    if [[ $CHECK =~ $ERROR_PATTERN || $? != "0" ]]; then
+        error 4 "The $CA_BUNDLE_FILE does not verify the $CERT_FILE"
+        echo "${CHECK/OK/}"
     else
-        error 4  "The $CA_BUNDLE_FILE does not verify the $CERT_FILE"
-        echo $CHECK
+       success
     fi
 }
 


### PR DESCRIPTION
Older openssl version will still return 0 exit code and "OK" message
for some errors, such as the openssl in RHEL 7. This cause the
katello-certs-check script not capturing certificate error correctly.
This patch fixed the issue.