### PR TITLE
[WIP] Clean up mongo migration

### DIFF
--- a/katello/hooks/pre/30-upgrade.rb
+++ b/katello/hooks/pre/30-upgrade.rb
@@ -2,7 +2,6 @@ require 'fileutils'
 
 STEP_DIRECTORY = '/etc/foreman-installer/applied_hooks/pre/'
 SSL_BUILD_DIR = param('certs', 'ssl_build_dir').value
-MONGO_ENGINE_MMAPV1 = '/etc/foreman-installer/.mongo_engine_mmapv1'.freeze
 
 def stop_services
   Kafo::Helpers.execute('foreman-maintain service stop')
@@ -63,10 +62,6 @@ def mongo_mmapv1_check
         f << "mongodb::server::storage_engine: 'mmapv1'\n"
       end
 
-      # Create engine file so we know Mongo is in mmapv1 for engine upgrade hook.
-      File.open(MONGO_ENGINE_MMAPV1, 'w') do |file|
-        file.write("Mongo storage engine set to mmapv1 on #{Time.now}")
-      end
     end
   else
     logger.debug 'No changed needed, Mongo storage engine will installed/kept with WiredTiger.'

--- a/katello/hooks/pre/30-upgrade.rb
+++ b/katello/hooks/pre/30-upgrade.rb
@@ -46,9 +46,9 @@ def mongo_mmapv1_check
   custom_hiera = '/etc/foreman-installer/custom-hiera.yaml'
   mongodb_dir = '/var/lib/mongodb/'
   # check and see if we have a pulp_database already from MMAPv1.
-  if File.file?("#{mongodb_dir}/pulp_database.0")
+  if File.file?(File.join(mongodb_dir, 'pulp_database.0'))
     # check if we have modifed the custom_hiera file or if there is a WiredTiger file in the db directory.
-    if File.foreach("#{custom_hiera}").grep(/mongodb::server::storage_engine:/).any? || File.file?("#{mongodb_dir}/WiredTiger.wt")
+    if File.foreach("#{custom_hiera}").grep(/mongodb::server::storage_engine:/).any? || File.file?(File.join(mongodb_dir, 'WiredTiger.wt'))
       logger.info 'No changed needed, Mongo storage engine will installed/kept with WiredTiger'
     else
       # Stop Mongo 2.x

--- a/katello/hooks/pre/31-mongo_storage_engine.rb
+++ b/katello/hooks/pre/31-mongo_storage_engine.rb
@@ -8,7 +8,6 @@ def migration
   katello = module_enabled?('katello')
   export_dir = '/var/tmp/mongodb_engine_upgrade'
   mongo_dir = '/var/lib/mongodb'
-  hiera_file = '/etc/foreman-installer/custom-hiera.yaml'
   mongodb_backup = '/var/tmp/mongodb_backup'
   mongo_conf = '/etc/opt/rh/rh-mongodb34/mongod.conf'
 
@@ -55,9 +54,8 @@ def migration
   Kafo::Helpers.execute("rm -rf #{mongodb_backup} #{export_dir}")
 
   # Update Hiera to wiredTiger for installer run
-  logger.info 'Changing custom Hiera to use wiredTiger for installer Puppet run.'
-  Kafo::Helpers.execute("sed -i -e 's/Added by foreman-installer during upgrade, run the installer with --upgrade-mongo-storage-engine to upgrade to WiredTiger./Do not remove'/g #{hiera_file}")
-  Kafo::Helpers.execute("sed -i -e 's/mmapv1/wiredTiger/g' #{hiera_file}")
+  logger.info 'Changing installer to configure wiredTiger'
+  set_internal_hiera_variable('mongodb::server::storage_engine', 'wiredTiger')
 end
 
 if app_value(:upgrade_mongo_storage_engine)

--- a/katello/hooks/pre/31-mongo_storage_engine.rb
+++ b/katello/hooks/pre/31-mongo_storage_engine.rb
@@ -11,7 +11,6 @@ def migration
   hiera_file = '/etc/foreman-installer/custom-hiera.yaml'
   mongodb_backup = '/var/tmp/mongodb_backup'
   mongo_conf = '/etc/opt/rh/rh-mongodb34/mongod.conf'
-  pulp_db_param = param('katello', 'pulp_db_name')
 
   # Create export directory and dump MongoDB
   logger.info 'Stopping Pulp services except MongoDB'


### PR DESCRIPTION
This uses [sg]et_internal_hiera_variable to store the mongodb storage engine. This avoids writing to custom-hiera.yaml. Also does some other cleanups.

This doesn't handle conversion from custom-hiera and requires https://github.com/theforeman/kafo/pull/238 so is a draft