### PR TITLE
Sunsetting foreman_cockpit because functionality being integrated in remote execution

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -26,7 +26,6 @@ foreman::plugin::ansible: false
 foreman::plugin::azure: false
 foreman::plugin::bootdisk: false
 foreman::plugin::chef: false
-foreman::plugin::cockpit: false
 foreman::plugin::default_hostgroup: false
 foreman::plugin::dhcp_browser: false
 foreman::plugin::digitalocean: false

--- a/config/foreman.migrations/20190903120000_remove-cockpit-plugin.rb
+++ b/config/foreman.migrations/20190903120000_remove-cockpit-plugin.rb
@@ -1,0 +1,3 @@
+['foreman::plugin::cockpit'].each do |plugin|
+  answers.delete(plugin) if answers.include?(plugin)
+end


### PR DESCRIPTION
According to https://community.theforeman.org/t/sunsetting-foreman-cockpit/14787

I have not removed a setting from the installer before so it is copy and paste from another migration, so please double check and tell me if changes are required.