### PR TITLE
Fixes #27775 - Introduce tuning for installation size

### DIFF
--- a/config/foreman-hiera.yaml
+++ b/config/foreman-hiera.yaml
@@ -13,5 +13,6 @@ hierarchy:
       - "family/%{facts.os.family}-%{facts.os.release.major}.yaml"
       - "family/%{facts.os.family}.yaml"
       - "security.yaml"
-      - "tuning.yaml"
+      - "tuning/sizes/%{facts.kafo.scenario.custom.tuning}.yaml"
+      - "tuning/common.yaml"
       - "common.yaml"

--- a/config/foreman-proxy-content.migrations/190904144224-set_tuning_fact.rb
+++ b/config/foreman-proxy-content.migrations/190904144224-set_tuning_fact.rb
@@ -1,0 +1,2 @@
+scenario[:facts] = {} unless scenario.key?(:facts)
+scenario[:facts]['tuning'] ||= 'default'

--- a/config/foreman-proxy-content.yaml
+++ b/config/foreman-proxy-content.yaml
@@ -11,6 +11,8 @@
 :module_dirs: ./_build/modules
 :parser_cache_path: ./_build/parser_cache/foreman-proxy-content.yaml
 :hiera_config: ./config/foreman-hiera.yaml
+:facts:
+  tuning: 'default'
 
 :order:
   - certs

--- a/config/foreman.hiera/tuning/common.yaml
+++ b/config/foreman.hiera/tuning/common.yaml
@@ -11,6 +11,9 @@ apache::mod::passenger::passenger_max_requests: 10000
 apache::mod::passenger::passenger_min_instances: 1
 apache::mod::passenger::passenger_max_preloader_idle_time: 0
 
+qpid::open_file_limit: 65536
+qpid::router::open_file_limit: 150100
+
 postgresql::server::config_entries:
   checkpoint_completion_target: 0.9
   max_connections: 500

--- a/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
@@ -1,0 +1,17 @@
+---
+apache::mod::passenger::passenger_max_pool_size: 240
+apache::mod::passenger::passenger_max_request_queue_size: 1000
+
+apache::mod::prefork::serverlimit: 1024
+apache::mod::prefork::maxclients: 1024
+apache::mod::prefork::maxrequestsperchild: 4000
+
+candlepin::java_opts: "-Xms1024m -Xmx8192m"
+
+postgresql::server::config_entries:
+  max_connections: 1000
+  shared_buffers: 32GB
+  work_mem: 8MB
+  checkpoint_segments: 32
+  effective_cache_size: 32GB
+  autovacuum_vacuum_cost_limit: 2000

--- a/config/foreman.hiera/tuning/sizes/extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-large.yaml
@@ -1,0 +1,17 @@
+---
+apache::mod::passenger::passenger_max_pool_size: 120
+apache::mod::passenger::passenger_max_request_queue_size: 1000
+
+apache::mod::prefork::serverlimit: 1024
+apache::mod::prefork::maxclients: 1024
+apache::mod::prefork::maxrequestsperchild: 4000
+
+candlepin::java_opts: "-Xms1024m -Xmx8192m"
+
+postgresql::server::config_entries:
+  max_connections: 1000
+  shared_buffers: 16GB
+  work_mem: 8MB
+  checkpoint_segments: 32
+  effective_cache_size: 32GB
+  autovacuum_vacuum_cost_limit: 2000

--- a/config/foreman.hiera/tuning/sizes/large.yaml
+++ b/config/foreman.hiera/tuning/sizes/large.yaml
@@ -1,0 +1,14 @@
+---
+apache::mod::passenger::passenger_max_pool_size: 60
+apache::mod::passenger::passenger_max_request_queue_size: 1000
+
+apache::mod::prefork::serverlimit: 1024
+apache::mod::prefork::maxclients: 1024
+apache::mod::prefork::maxrequestsperchild: 4000
+
+postgresql::server::config_entries:
+  max_connections: 1000
+  shared_buffers: 8GB
+  checkpoint_segments: 32
+  effective_cache_size: 16GB
+  autovacuum_vacuum_cost_limit: 2000

--- a/config/foreman.hiera/tuning/sizes/medium.yaml
+++ b/config/foreman.hiera/tuning/sizes/medium.yaml
@@ -1,0 +1,14 @@
+---
+apache::mod::passenger::passenger_max_pool_size: 30
+apache::mod::passenger::passenger_max_request_queue_size: 1000
+
+apache::mod::prefork::serverlimit: 1024
+apache::mod::prefork::maxclients: 1024
+apache::mod::prefork::maxrequestsperchild: 4000
+
+postgresql::server::config_entries:
+  max_connections: 1000
+  shared_buffers: 4GB
+  checkpoint_segments: 32
+  effective_cache_size: 16GB
+  autovacuum_vacuum_cost_limit: 2000

--- a/config/katello.migrations/190904144224-set_tuning_fact.rb
+++ b/config/katello.migrations/190904144224-set_tuning_fact.rb
@@ -1,0 +1,2 @@
+scenario[:facts] = {} unless scenario.key?(:facts)
+scenario[:facts]['tuning'] ||= 'default'

--- a/config/katello.yaml
+++ b/config/katello.yaml
@@ -11,6 +11,8 @@
 :module_dirs: ./_build/modules
 :parser_cache_path: ./_build/parser_cache/katello.yaml
 :hiera_config: ./config/foreman-hiera.yaml
+:facts:
+  tuning: 'default'
 
 :order:
   - certs

--- a/katello/hooks/boot/13-hiera.rb
+++ b/katello/hooks/boot/13-hiera.rb
@@ -1,0 +1,11 @@
+# TODO automatically get the tuning sizes - standard doesn't exist and only
+# loads base. The rest maps to config/foreman.hiera/tuning/sizes/$size.yaml
+TUNING_SIZES = ['default'] + ['medium', 'large', 'extra-large', 'extra-extra-large']
+TUNING_FACT = 'tuning'
+
+app_option(
+  '--tuning',
+  'INSTALLATION_SIZE',
+  "Tune for an installation size. Choices: #{TUNING_SIZES.join(', ')}",
+  :default => get_custom_fact(TUNING_FACT)
+)

--- a/katello/hooks/pre_commit/13-hiera.rb
+++ b/katello/hooks/pre_commit/13-hiera.rb
@@ -1,0 +1,17 @@
+TUNING_SIZES = ['default'] + ['medium', 'large', 'extra-large', 'extra-extra-large']
+TUNING_FACT = 'tuning'
+
+current = get_custom_fact(TUNING_FACT)
+new = app_value(:tuning)
+
+if current != new
+  unless TUNING_SIZES.include?(new)
+    say "<%= color('Invalid tuning profile', :bad) %>"
+    say "'#{new}' is not one of #{TUNING_SIZES.join(', ')}"
+    exit 101
+  end
+
+  store_custom_fact(TUNING_FACT, new)
+  # Store the app config to disk
+  kafo.config.configure_application
+end

--- a/spec/fixtures/merged-installer/foreman-proxy-content-after.yaml
+++ b/spec/fixtures/merged-installer/foreman-proxy-content-after.yaml
@@ -27,3 +27,5 @@
 - foreman_proxy_content
 - puppet
 :password: -C1PSvjt9STtiNvbX5hpVYejjBS_t6mCN-FYYw8XxyE
+:facts:
+  tuning: 'default'

--- a/spec/fixtures/merged-installer/katello-after.yaml
+++ b/spec/fixtures/merged-installer/katello-after.yaml
@@ -29,3 +29,5 @@
 - foreman_proxy_content
 - puppet
 :password: X1ypkCgMu0qolU2eBR5ytNtxENH7zdmLiXriju7khZw
+:facts:
+  tuning: 'default'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'kafo'
 require 'rspec'
 require 'yaml'
 
-CONFIG_DIR = File.expand_path(File.join(__dir__, '../config'))
+CONFIG_DIR = File.expand_path(File.join(__dir__, '..', 'config'))
 FIXTURE_DIR = File.expand_path(File.join(__dir__, 'fixtures'))
 
 def config_path(filename)


### PR DESCRIPTION
This introduces a --tuning parameter to Katello/Content proxies to optimize for a small/medium/large installation. To achieve this, it needs Kafo 4 which allows setting custom facts which are usable in the Hiera config.