### PR TITLE
Fixes #27846 - Add Postgresql log_min_duration

### DIFF
--- a/config/foreman.hiera/tuning.yaml
+++ b/config/foreman.hiera/tuning.yaml
@@ -17,3 +17,4 @@ postgresql::server::config_entries:
   shared_buffers: 512MB
   work_mem: 4MB
   log_line_prefix: '%t '
+  log_min_duration: 1000


### PR DESCRIPTION
With this change, queries taking longer than a second will be logged. This makes it easier to debug performance issues.

Users can disable this by setting the value to -1 via another hiera layer.