### PR TITLE
Fixes #27848 - Disable HTTP by default on Katello's proxy

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -28,9 +28,7 @@ puppet:
   server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
   server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
 foreman_proxy:
-  http: true
   ssl_port: '9090'
-  templates: true
   ssl_ca: /etc/foreman-proxy/ssl_ca.pem
   ssl_cert: /etc/foreman-proxy/ssl_cert.pem
   ssl_key: /etc/foreman-proxy/ssl_key.pem

--- a/config/katello.migrations/171030135054-foreman-proxy-update.rb
+++ b/config/katello.migrations/171030135054-foreman-proxy-update.rb
@@ -1,4 +1,0 @@
-# foreman_proxy defaults for templates
-
-answers['foreman_proxy']['http'] = true if answers['foreman_proxy']
-answers['foreman_proxy']['templates'] = true if answers['foreman_proxy']


### PR DESCRIPTION
The HTTP and templates features are useful when a host needs to be provisioned and can't reach the Foreman server directly. Since this is by definition the Foreman server, the client should be able to reach it.

The values are dropped since they match the module defaults. It doesn't implement a migration to not touch existing installations which might have started to rely on it.