### PR TITLE
Refs #27846 - Correct log_min_duration_statement

### DIFF
--- a/config/foreman.hiera/tuning.yaml
+++ b/config/foreman.hiera/tuning.yaml
@@ -17,4 +17,4 @@ postgresql::server::config_entries:
   shared_buffers: 512MB
   work_mem: 4MB
   log_line_prefix: '%t '
-  log_min_duration: 1000
+  log_min_duration_statement: 1000


### PR DESCRIPTION
Due to a copy paste error an invalid configuration option was used. This corrects it to the actual configuration option.