### PR TITLE
Add a script to show module versions

### DIFF
--- a/bin/module-versions
+++ b/bin/module-versions
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require 'librarian/puppet'
+
+def manifests(lockfile)
+  unless File.exist?(lockfile)
+    raise ArgumentError, "Lockfile #{lockfile} doesn't exist"
+  end
+
+  librarian_environment = Librarian::Puppet::Environment.new(pwd: lockfile)
+  librarian_environment.lock.manifests.sort_by { |manifest| manifest.name.split('-').last }
+end
+
+path = ARGV[0] || 'Puppetfile.lock'
+
+begin
+  manifests(path).each do |manifest|
+    author, name = manifest.name.split('-')
+    if ['theforeman', 'katello'].include?(author)
+      branch = "#{manifest.version.to_s.split('.')[0..1].join('.')}-stable"
+      puts "puppet-#{name} #{manifest.version} #{branch}"
+    end
+  end
+rescue ArgumentError => error
+  puts error
+  exit 1
+end


### PR DESCRIPTION
This is a helper script to easily read the module versions from a lockfile. This makes it much easier what is bundled in a certain installer branch. The branch is a guess and might be incorrect. For example, when it's still being released from master.