### PR TITLE
Refs #27847 - Set parameter mapping

### DIFF
--- a/katello_certs/config/foreman-proxy-certs.yaml
+++ b/katello_certs/config/foreman-proxy-certs.yaml
@@ -20,6 +20,9 @@
   :foreman_proxy_certs:
     :manifest_name: foreman_proxy_content
     :dir_name: certs
+    :params_name: foreman_proxy_content::params
+    # https://projects.theforeman.org/issues/27909
+    :params_path: certs/manifests/foreman_proxy_content/params.pp
 :order:
   - certs
   - foreman_proxy_certs


### PR DESCRIPTION
In puppet-certs master the default values are loaded via params.pp to workaround kafo limitations. This configures kafo to actually find it.  Otherwise it can't load the defaults and the values are nil.