### PR TITLE
Fixes #28084 - Store non-default answers separate

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -11,18 +11,22 @@
 ---
 foreman:
   configure_epel_repo: false
-foreman_proxy: {}
-puppet:
-  server: true
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
 foreman::cli::discovery: false
+foreman::cli::kubevirt: false
 foreman::cli::openscap: false
 foreman::cli::remote_execution: false
 foreman::cli::tasks: false
 foreman::cli::templates: false
-foreman::cli::kubevirt: false
+foreman::compute::ec2: false
+foreman::compute::gce: false
+foreman::compute::libvirt: false
+foreman::compute::openstack: false
+foreman::compute::ovirt: false
+foreman::compute::rackspace: false
+foreman::compute::vmware: false
 foreman::plugin::ansible: false
 foreman::plugin::azure: false
 foreman::plugin::bootdisk: false
@@ -32,29 +36,23 @@ foreman::plugin::dhcp_browser: false
 foreman::plugin::digitalocean: false
 foreman::plugin::discovery: false
 foreman::plugin::expire_hosts: false
-foreman::plugin::kubevirt: false
+foreman::plugin::hooks: false
 foreman::plugin::host_extra_validator: false
+foreman::plugin::kubevirt: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
 foreman::plugin::omaha: false
 foreman::plugin::openscap: false
 foreman::plugin::ovirt_provision: false
-foreman::plugin::tasks: false
-foreman::plugin::hooks: false
 foreman::plugin::puppetdb: false
 foreman::plugin::remote_execution: false
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::salt: false
 foreman::plugin::setup: false
 foreman::plugin::snapshot_management: false
+foreman::plugin::tasks: false
 foreman::plugin::templates: false
-foreman::compute::ec2: false
-foreman::compute::gce: false
-foreman::compute::libvirt: false
-foreman::compute::openstack: false
-foreman::compute::ovirt: false
-foreman::compute::rackspace: false
-foreman::compute::vmware: false
+foreman_proxy: {}
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::chef: false
 foreman_proxy::plugin::dhcp::infoblox: false
@@ -69,3 +67,5 @@ foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::pulp: false
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
+puppet:
+  server: true

--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -9,8 +9,7 @@
 #
 # See params.pp in each class for what options are available
 ---
-foreman:
-  configure_epel_repo: false
+foreman: true
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
@@ -52,7 +51,7 @@ foreman::plugin::setup: false
 foreman::plugin::snapshot_management: false
 foreman::plugin::tasks: false
 foreman::plugin::templates: false
-foreman_proxy: {}
+foreman_proxy: true
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::chef: false
 foreman_proxy::plugin::dhcp::infoblox: false
@@ -67,5 +66,4 @@ foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::pulp: false
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
-puppet:
-  server: true
+puppet: true

--- a/config/foreman-hiera.yaml
+++ b/config/foreman-hiera.yaml
@@ -8,6 +8,8 @@ hierarchy:
     path: "custom.yaml"
   - name: "Kafo Answers"
     path: "%{facts.kafo.scenario.answer_file}"
+  - name: "Scenario defaults"
+    path: "scenario/%{facts.kafo.scenario.id}.yaml"
   - name: "Built in"
     paths:
       - "scenario/%{facts.kafo.scenario.id}/family/%{facts.os.family}-%{facts.os.release.major}.yaml"

--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -1,31 +1,41 @@
+# Format:
+# <classname>: false - don't include this class
+# <classname>: true - include and use the defaults
+# <classname>:
+#   <param>: <value> - include and override the default(s)
+#
+# Every support plugin/compute class is listed, so that it
+# shows up in the interactive menu
+#
+# See params.pp in each class for what options are available
 ---
 certs:
   generate: false
 foreman_proxy_content: true
-puppet:
-  server: true
-  server_environments_owner: apache
-  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
-  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
-  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
 foreman_proxy:
-  http: true
-  ssl_port: '9090'
-  templates: true
-  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
-  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
-  ssl_key: /etc/foreman-proxy/ssl_key.pem
   foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
   foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
   foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+  http: true
   manage_puppet_group: false
-foreman_proxy::plugin::pulp:
-  enabled: false
-  pulpnode_enabled: true
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  ssl_port: '9090'
+  templates: true
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false
+foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::openscap: false
+foreman_proxy::plugin::pulp:
+  enabled: false
+  pulpnode_enabled: true
 foreman_proxy::plugin::remote_execution::ssh: false
-foreman_proxy::plugin::discovery: false
+puppet:
+  server: true
+  server_environments_owner: apache
+  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -9,33 +9,15 @@
 #
 # See params.pp in each class for what options are available
 ---
-certs:
-  generate: false
-foreman_proxy_content: true
-foreman_proxy:
-  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
-  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
-  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
-  http: true
-  manage_puppet_group: false
-  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
-  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
-  ssl_key: /etc/foreman-proxy/ssl_key.pem
-  ssl_port: '9090'
-  templates: true
+certs: true
+foreman_proxy: true
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::openscap: false
-foreman_proxy::plugin::pulp:
-  enabled: false
-  pulpnode_enabled: true
+foreman_proxy::plugin::pulp: true
 foreman_proxy::plugin::remote_execution::ssh: false
-puppet:
-  server: true
-  server_environments_owner: apache
-  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
-  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
-  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
+foreman_proxy_content: true
+puppet: true

--- a/config/foreman-proxy-content.migrations/180111142132-foreman_proxy_autosignfile.rb
+++ b/config/foreman-proxy-content.migrations/180111142132-foreman_proxy_autosignfile.rb
@@ -1,4 +1,5 @@
 if answers['foreman_proxy']
+  answers['foreman_proxy'] = {} unless answers['foreman_proxy'].is_a?(Hash)
   answers['foreman_proxy']['use_autosignfile'] = true
   if answers['foreman_proxy'].key?('puppetdir')
     puppetdir = answers['foreman_proxy']['puppetdir']

--- a/config/foreman.hiera/scenario/foreman-proxy-content.yaml
+++ b/config/foreman.hiera/scenario/foreman-proxy-content.yaml
@@ -1,0 +1,19 @@
+---
+certs::generate: false
+foreman_proxy::foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+foreman_proxy::foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+foreman_proxy::foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::http: true
+foreman_proxy::manage_puppet_group: false
+foreman_proxy::plugin::pulp::enabled: false
+foreman_proxy::plugin::pulp::pulpnode_enabled: true
+foreman_proxy::ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+foreman_proxy::ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+foreman_proxy::ssl_key: /etc/foreman-proxy/ssl_key.pem
+foreman_proxy::ssl_port: '9090'
+foreman_proxy::templates: true
+puppet::server: true
+puppet::server_environments_owner: apache
+puppet::server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+puppet::server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+puppet::server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/config/foreman.hiera/scenario/foreman.yaml
+++ b/config/foreman.hiera/scenario/foreman.yaml
@@ -1,0 +1,3 @@
+foreman::configure_epel_repo: false
+foreman::configure_scl_repo: false
+puppet::server: true

--- a/config/foreman.hiera/scenario/katello.yaml
+++ b/config/foreman.hiera/scenario/katello.yaml
@@ -1,0 +1,35 @@
+---
+certs::group: foreman
+foreman::client_ssl_ca: /etc/foreman/proxy_ca.pem
+foreman::client_ssl_cert: /etc/foreman/client_cert.pem
+foreman::client_ssl_key: /etc/foreman/client_key.pem
+foreman::configure_epel_repo: false
+foreman::configure_scl_repo: false
+foreman::initial_location: Default Location
+foreman::initial_organization: Default Organization
+foreman::max_keepalive_requests: 10000
+foreman::server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
+foreman::server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+foreman::server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
+foreman::server_ssl_crl: ""
+foreman::server_ssl_key: /etc/pki/katello/private/katello-apache.key
+foreman::user_groups: []
+foreman::websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+foreman::websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
+foreman_proxy::foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+foreman_proxy::foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+foreman_proxy::foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::http: true
+foreman_proxy::manage_puppet_group: false
+foreman_proxy::plugin::pulp::pulpcore_enabled: true
+foreman_proxy::ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+foreman_proxy::ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+foreman_proxy::ssl_key: /etc/foreman-proxy/ssl_key.pem
+foreman_proxy::ssl_port: '9090'
+foreman_proxy::templates: true
+foreman_proxy_content::pulp_master: true
+puppet::server: true
+puppet::server_environments_owner: apache
+puppet::server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+puppet::server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+puppet::server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/config/foreman.migrations/20160405122117_passenger_ruby.rb
+++ b/config/foreman.migrations/20160405122117_passenger_ruby.rb
@@ -1,2 +1,2 @@
 # Redetermine the value of passenger_ruby, as it changed on Debian in puppet-foreman f9329b6
-answers['foreman'].delete('passenger_ruby') if answers['foreman']
+answers['foreman'].delete('passenger_ruby') if answers['foreman'].is_a?(Hash)

--- a/config/foreman.migrations/20160420224417_puppet_autosign.rb
+++ b/config/foreman.migrations/20160420224417_puppet_autosign.rb
@@ -1,7 +1,7 @@
 # Redetermine the value of autosign, as it changed from string/boolean to path/boolean
 # in puppet-puppet a2325f1 and was deleted from puppet-foreman_proxy 9f3c9aa
-if answers['puppet']
+if answers['puppet'].is_a?(Hash)
   current_autosign = answers['puppet']['autosign']
   answers['puppet'].delete('autosign') unless !!current_autosign == current_autosign # rubocop:disable Style/DoubleNegation
 end
-answers['foreman_proxy'].delete('autosign_location') if answers['foreman_proxy']
+answers['foreman_proxy'].delete('autosign_location') if answers['foreman_proxy'].is_a?(Hash)

--- a/config/foreman.migrations/20160518125928_foreman_proxy_puppetrun_rename.rb
+++ b/config/foreman.migrations/20160518125928_foreman_proxy_puppetrun_rename.rb
@@ -1,4 +1,6 @@
 # Rename foreman_proxy puppetrun parameters to puppet
 # https://github.com/theforeman/puppet-foreman_proxy/commit/c26cac15
-answers['foreman_proxy']['puppet'] = answers['foreman_proxy'].delete('puppetrun') if answers['foreman_proxy'] && answers['foreman_proxy'].has_key?('puppetrun')
-answers['foreman_proxy']['puppet_listen_on'] = answers['foreman_proxy'].delete('puppetrun_listen_on') if answers['foreman_proxy'] && answers['foreman_proxy'].has_key?('puppetrun_listen_on')
+if answers['foreman_proxy'].is_a?(Hash)
+  answers['foreman_proxy']['puppet'] = answers['foreman_proxy'].delete('puppetrun') if answers['foreman_proxy'].has_key?('puppetrun')
+  answers['foreman_proxy']['puppet_listen_on'] = answers['foreman_proxy'].delete('puppetrun_listen_on') if answers['foreman_proxy'].has_key?('puppetrun_listen_on')
+end

--- a/config/foreman.migrations/20160607133050_foreman_proxy_puppetssh_rename.rb
+++ b/config/foreman.migrations/20160607133050_foreman_proxy_puppetssh_rename.rb
@@ -1,3 +1,3 @@
 # Rename foreman_proxy provider "puppetssh" to "ssh"
 # http://projects.theforeman.org/issues/15323
-answers['foreman_proxy']['puppetrun_provider'] = 'ssh' if answers['foreman_proxy'] && answers['foreman_proxy']['puppetrun_provider'] == 'puppetssh'
+answers['foreman_proxy']['puppetrun_provider'] = 'ssh' if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['puppetrun_provider'] == 'puppetssh'

--- a/config/foreman.migrations/20160722161820_environment_to_rails_env.rb
+++ b/config/foreman.migrations/20160722161820_environment_to_rails_env.rb
@@ -1,3 +1,3 @@
 # rename foreman environment parameter to rails_env
 # https://github.com/theforeman/puppet-foreman_proxy/commit/d239f0b
-answers['foreman']['rails_env'] = answers['foreman'].delete('environment') if answers['foreman'] && answers['foreman'].has_key?('environment')
+answers['foreman']['rails_env'] = answers['foreman'].delete('environment') if answers['foreman'].is_a?(Hash) && answers['foreman'].has_key?('environment')

--- a/config/foreman.migrations/20160831180000_foreman_proxy_tftp_grub2.rb
+++ b/config/foreman.migrations/20160831180000_foreman_proxy_tftp_grub2.rb
@@ -1,4 +1,4 @@
-if answers['foreman_proxy']
+if answers['foreman_proxy'].is_a?(Hash)
   root = answers['foreman_proxy']['tftp_root']
   if answers['foreman_proxy']['tftp_dirs']
     dirs = answers['foreman_proxy']['tftp_dirs']

--- a/config/foreman.migrations/20160906121542_puppetserver_whitelist.rb
+++ b/config/foreman.migrations/20160906121542_puppetserver_whitelist.rb
@@ -1,6 +1,6 @@
 # Redetermine the value of API whitelists, as it changed
 # in puppet-puppet f9b4e87cd855d7d5d0bbf3a1831b5daf22cdb413
-if answers['puppet']
+if answers['puppet'].is_a?(Hash)
   answers['puppet'].delete('server_admin_api_whitelist')
   answers['puppet'].delete('server_ca_client_whitelist')
 end

--- a/config/foreman.migrations/20161125153500_foreman_email_config_method.rb
+++ b/config/foreman.migrations/20161125153500_foreman_email_config_method.rb
@@ -1,1 +1,1 @@
-answers['foreman']['email_config_method'] = 'database' if answers['foreman']
+answers['foreman']['email_config_method'] = 'database' if answers['foreman'].is_a?(Hash)

--- a/config/foreman.migrations/20170118105627_foreman_proxy_dhcp_range_false.rb
+++ b/config/foreman.migrations/20170118105627_foreman_proxy_dhcp_range_false.rb
@@ -1,2 +1,2 @@
 # false is no longer a valid value, the param should be undef/nil to be disabled
-answers['foreman_proxy']['dhcp_range'] = nil if answers['foreman_proxy'] && answers['foreman_proxy']['dhcp_range'] == false
+answers['foreman_proxy']['dhcp_range'] = nil if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['dhcp_range'] == false

--- a/config/foreman.migrations/20170213123300_foreman_proxy_realm_split_configs.rb
+++ b/config/foreman.migrations/20170213123300_foreman_proxy_realm_split_configs.rb
@@ -1,1 +1,1 @@
-answers['foreman_proxy']['realm_split_config_files'] = true if answers['foreman_proxy']
+answers['foreman_proxy']['realm_split_config_files'] = true if answers['foreman_proxy'].is_a?(Hash)

--- a/config/foreman.migrations/20170405155121_foreman_proxy_bind_host_array.rb
+++ b/config/foreman.migrations/20170405155121_foreman_proxy_bind_host_array.rb
@@ -1,3 +1,3 @@
-if answers['foreman_proxy'] && answers['foreman_proxy']['bind_host'].is_a?(String)
+if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['bind_host'].is_a?(String)
   answers['foreman_proxy']['bind_host'] = [answers['foreman_proxy']['bind_host']]
 end

--- a/config/foreman.migrations/20170530141108_foreman_proxy_autosignfile.rb
+++ b/config/foreman.migrations/20170530141108_foreman_proxy_autosignfile.rb
@@ -1,4 +1,4 @@
-if answers['foreman_proxy'] && !answers['foreman_proxy'].has_key?('use_autosignfile')
+if answers['foreman_proxy'].is_a?(Hash) && !answers['foreman_proxy'].has_key?('use_autosignfile')
   answers['foreman_proxy']['use_autosignfile'] = true
   if answers['foreman_proxy'].has_key?('puppetdir')
     puppetdir = answers['foreman_proxy']['puppetdir']

--- a/config/foreman.migrations/20170708010605_puppet_profiler_metrics.rb
+++ b/config/foreman.migrations/20170708010605_puppet_profiler_metrics.rb
@@ -1,6 +1,6 @@
 # server_puppetserver_metrics also controls if the Ruby profiler gets enabled
 # in puppet-puppet since 94ff77740a27d458ce1444db016645ab763cba42
-if answers['puppet'] && answers['puppet'].has_key?('server_enable_ruby_profiler')
+if answers['puppet'].is_a?(Hash) && answers['puppet'].has_key?('server_enable_ruby_profiler')
   if answers['puppet']['server_enable_ruby_profiler'] == true
     answers['puppet']['server_puppetserver_metrics'] = true
   end

--- a/config/foreman.migrations/20190111180118_delete_removed_settings.rb
+++ b/config/foreman.migrations/20190111180118_delete_removed_settings.rb
@@ -67,6 +67,6 @@ CLEAR.each do |mod, parameters|
   end
 end
 
-if (mod_answers = answers['foreman_proxy'])
+if (mod_answers = answers['foreman_proxy']) && mod_answers.is_a?(Hash)
   mod_answers['dhcp_gateway'] = nil if mod_answers['dhcp_gateway'] == '192.168.100.1'
 end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -1,42 +1,50 @@
+# Format:
+# <classname>: false - don't include this class
+# <classname>: true - include and use the defaults
+# <classname>:
+#   <param>: <value> - include and override the default(s)
+#
+# Every support plugin/compute class is listed, so that it
+# shows up in the interactive menu
+#
+# See params.pp in each class for what options are available
 ---
 certs:
   group: foreman
-katello: true
 foreman:
-  initial_organization: Default Organization
-  initial_location: Default Location
-  configure_epel_repo: false
-  configure_scl_repo: false
-  max_keepalive_requests: 10000
-  server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
-  server_ssl_key: /etc/pki/katello/private/katello-apache.key
-  server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
-  server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
-  server_ssl_crl: ""
+  client_ssl_ca: /etc/foreman/proxy_ca.pem
   client_ssl_cert: /etc/foreman/client_cert.pem
   client_ssl_key: /etc/foreman/client_key.pem
-  client_ssl_ca: /etc/foreman/proxy_ca.pem
-  websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
-  websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+  configure_epel_repo: false
+  configure_scl_repo: false
+  initial_location: Default Location
+  initial_organization: Default Organization
+  max_keepalive_requests: 10000
+  server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
+  server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+  server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
+  server_ssl_crl: ""
+  server_ssl_key: /etc/pki/katello/private/katello-apache.key
   user_groups: []
-foreman_proxy_content: true
-puppet:
-  server: true
-  server_environments_owner: apache
-  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
-  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
-  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
-foreman_proxy:
-  ssl_port: '9090'
-  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
-  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
-  ssl_key: /etc/foreman-proxy/ssl_key.pem
-  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
-  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
-  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
-  manage_puppet_group: false
-foreman_proxy::plugin::pulp:
-  pulpcore_enabled: true
+  websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+  websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
+foreman::cli: true
+foreman::cli::ansible: false
+foreman::cli::azure: false
+foreman::cli::discovery: false
+foreman::cli::kubevirt: false
+foreman::cli::openscap: false
+foreman::cli::remote_execution: false
+foreman::cli::tasks: false
+foreman::cli::templates: false
+foreman::cli::virt_who_configure: false
+foreman::compute::ec2: false
+foreman::compute::gce: false
+foreman::compute::libvirt: false
+foreman::compute::openstack: false
+foreman::compute::ovirt: false
+foreman::compute::rackspace: false
+foreman::compute::vmware: false
 foreman::plugin::ansible: false
 foreman::plugin::azure: false
 foreman::plugin::bootdisk: false
@@ -60,6 +68,15 @@ foreman::plugin::snapshot_management: false
 foreman::plugin::tasks: true
 foreman::plugin::templates: false
 foreman::plugin::virt_who_configure: false
+foreman_proxy:
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+  manage_puppet_group: false
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  ssl_port: '9090'
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::chef: false
 foreman_proxy::plugin::dhcp::infoblox: false
@@ -68,22 +85,15 @@ foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::openscap: false
+foreman_proxy::plugin::pulp:
+  pulpcore_enabled: true
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
-foreman::compute::ec2: false
-foreman::compute::gce: false
-foreman::compute::libvirt: false
-foreman::compute::openstack: false
-foreman::compute::ovirt: false
-foreman::compute::rackspace: false
-foreman::compute::vmware: false
-foreman::cli: true
-foreman::cli::ansible: false
-foreman::cli::azure: false
-foreman::cli::discovery: false
-foreman::cli::kubevirt: false
-foreman::cli::openscap: false
-foreman::cli::remote_execution: false
-foreman::cli::tasks: false
-foreman::cli::templates: false
-foreman::cli::virt_who_configure: false
+foreman_proxy_content: true
+katello: true
+puppet:
+  server: true
+  server_environments_owner: apache
+  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -9,25 +9,8 @@
 #
 # See params.pp in each class for what options are available
 ---
-certs:
-  group: foreman
-foreman:
-  client_ssl_ca: /etc/foreman/proxy_ca.pem
-  client_ssl_cert: /etc/foreman/client_cert.pem
-  client_ssl_key: /etc/foreman/client_key.pem
-  configure_epel_repo: false
-  configure_scl_repo: false
-  initial_location: Default Location
-  initial_organization: Default Organization
-  max_keepalive_requests: 10000
-  server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
-  server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
-  server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
-  server_ssl_crl: ""
-  server_ssl_key: /etc/pki/katello/private/katello-apache.key
-  user_groups: []
-  websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
-  websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
+certs: true
+foreman: true
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
@@ -68,15 +51,7 @@ foreman::plugin::snapshot_management: false
 foreman::plugin::tasks: true
 foreman::plugin::templates: false
 foreman::plugin::virt_who_configure: false
-foreman_proxy:
-  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
-  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
-  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
-  manage_puppet_group: false
-  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
-  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
-  ssl_key: /etc/foreman-proxy/ssl_key.pem
-  ssl_port: '9090'
+foreman_proxy: true
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::chef: false
 foreman_proxy::plugin::dhcp::infoblox: false
@@ -85,15 +60,9 @@ foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::openscap: false
-foreman_proxy::plugin::pulp:
-  pulpcore_enabled: true
+foreman_proxy::plugin::pulp: true
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
 foreman_proxy_content: true
 katello: true
-puppet:
-  server: true
-  server_environments_owner: apache
-  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
-  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
-  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
+puppet: true

--- a/config/katello.migrations/180111142132-foreman_proxy_autosignfile.rb
+++ b/config/katello.migrations/180111142132-foreman_proxy_autosignfile.rb
@@ -1,4 +1,5 @@
 if answers['foreman_proxy']
+  answers['foreman_proxy'] = {} unless answers['foreman_proxy'].is_a?(Hash)
   answers['foreman_proxy']['use_autosignfile'] = true
   if answers['foreman_proxy'].key?('puppetdir')
     puppetdir = answers['foreman_proxy']['puppetdir']


### PR DESCRIPTION
By storing the non-default answers in a different layer, resetting works as expected. This relies on Kafo 4.

Currently a draft since the migrations do not like this.

Includes https://github.com/theforeman/foreman-installer/pull/398