### PR TITLE
Fixes #28366 - Drop default Apache vhost

### DIFF
--- a/config/foreman.hiera/common.yml
+++ b/config/foreman.hiera/common.yml
@@ -1,4 +1,5 @@
 ---
+apache::default_vhost: false
 dhcp::config_comment: >
   READ: This file was written the foreman-installer and not by the Foreman
 


### PR DESCRIPTION
Apache always ships a default vhost in /etc/httpd/conf.d/15-default.conf (or Debian equivalent) that isn't used. Not enabling this will make the setup easier to understand.