### PR TITLE
Fixes #28370 - set the default tuning profile to default

### DIFF
--- a/katello/hooks/boot/13-hiera.rb
+++ b/katello/hooks/boot/13-hiera.rb
@@ -2,10 +2,11 @@
 # loads base. The rest maps to config/foreman.hiera/tuning/sizes/$size.yaml
 TUNING_SIZES = ['default'] + ['medium', 'large', 'extra-large', 'extra-extra-large']
 TUNING_FACT = 'tuning'
+TUNING_DEFAULT = get_custom_fact(TUNING_FACT) || 'default'
 
 app_option(
   '--tuning',
   'INSTALLATION_SIZE',
   "Tune for an installation size. Choices: #{TUNING_SIZES.join(', ')}",
-  :default => get_custom_fact(TUNING_FACT)
+  :default => TUNING_DEFAULT
 )


### PR DESCRIPTION
when there is no tuning profile applied yet, `get_custom_fact` will return
`nil` and that's not a sensible default for the tuning profile