### PR TITLE
Remove unused variable

### DIFF
--- a/katello/hooks/pre/30-upgrade.rb
+++ b/katello/hooks/pre/30-upgrade.rb
@@ -1,7 +1,6 @@
 require 'fileutils'
 
 STEP_DIRECTORY = '/etc/foreman-installer/applied_hooks/pre/'
-SSL_BUILD_DIR = param('certs', 'ssl_build_dir').value
 
 def stop_services
   Kafo::Helpers.execute('foreman-maintain service stop')


### PR DESCRIPTION
6542e61e3f2dba1098e61727e14b7d13dec1034b removed the use of this variable but left the variable itself.