### PR TITLE
Refactor Katello entry points

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -104,5 +104,9 @@ foreman_proxy::plugin::remote_execution::script: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false
 foreman_proxy_content: true
-katello: true
 puppet: false
+global: true
+application: true
+pulp: true
+candlepin: true
+qpid: true

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -8,20 +8,21 @@
 # shows up in the interactive menu
 #
 # See params.pp in each class for what options are available
+
 ---
 certs:
   group: foreman
 foreman:
-  client_ssl_ca: /etc/foreman/proxy_ca.pem
-  client_ssl_cert: /etc/foreman/client_cert.pem
-  client_ssl_key: /etc/foreman/client_key.pem
+  client_ssl_ca: "/etc/foreman/proxy_ca.pem"
+  client_ssl_cert: "/etc/foreman/client_cert.pem"
+  client_ssl_key: "/etc/foreman/client_key.pem"
   initial_location: Default Location
   initial_organization: Default Organization
-  server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
-  server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
-  server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
+  server_ssl_ca: "/etc/pki/katello/certs/katello-default-ca.crt"
+  server_ssl_cert: "/etc/pki/katello/certs/katello-apache.crt"
+  server_ssl_chain: "/etc/pki/katello/certs/katello-server-ca.crt"
   server_ssl_crl: ""
-  server_ssl_key: /etc/pki/katello/private/katello-apache.key
+  server_ssl_key: "/etc/pki/katello/private/katello-apache.key"
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
@@ -79,13 +80,13 @@ foreman::plugin::virt_who_configure: false
 foreman::plugin::webhooks: false
 foreman::plugin::wreckingball: false
 foreman_proxy:
-  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
-  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
-  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+  foreman_ssl_ca: "/etc/foreman-proxy/foreman_ssl_ca.pem"
+  foreman_ssl_cert: "/etc/foreman-proxy/foreman_ssl_cert.pem"
+  foreman_ssl_key: "/etc/foreman-proxy/foreman_ssl_key.pem"
   manage_puppet_group: false
-  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
-  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
-  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  ssl_ca: "/etc/foreman-proxy/ssl_ca.pem"
+  ssl_cert: "/etc/foreman-proxy/ssl_cert.pem"
+  ssl_key: "/etc/foreman-proxy/ssl_key.pem"
   ssl_port: '9090'
   puppet: false
   puppetca: false

--- a/config/katello.yaml
+++ b/config/katello.yaml
@@ -28,5 +28,23 @@
 # If using the Debian ruby-kafo package, uncomment this
 # :kafo_modules_dir: /usr/lib/ruby/vendor_ruby/kafo/modules
 
-# Unused, but remains present for older config migrations
-:mapping: {}
+:mapping:
+  :global:
+    :dir_name: 'katello'
+    :manifest_name: 'globals'
+  :pulp:
+    :dir_name: 'katello'
+    :manifest_name: 'pulp'
+    :params_name: 'params'
+  :candlepin:
+    :dir_name: 'katello'
+    :manifest_name: 'candlepin'
+    :params_name: 'params'
+  :qpid:
+    :dir_name: 'katello'
+    :manifest_name: 'qpid'
+    :params_name: 'params'
+  :application:
+    :dir_name: 'katello'
+    :manifest_name: 'application'
+    :params_name: 'params'


### PR DESCRIPTION
Depends on https://github.com/theforeman/puppet-katello/pull/308.

This uses the separate classes in puppet-katello to expose in a more logical way to the end user.

The generated help text is below. Note that there's now `--candlepin-*` and `--pulp-*`. The content types are `--global-*`. With Pulp 3 these can be moved to `--pulp-*` parameters but for Pulp 2 Katello 2 needs to be statically configured. There's qpid module with a rather advanced parameter. Currently Kafo can't hide a single parameter as advanced.

```
Usage:
    foreman-installer [OPTIONS]

Options:

= Generic:
    --reset                       This option will drop the Katello database and clear all subsequent backend data stores. You will lose all data!
                                  Unfortunately, we can't detect a failure, so you should verify success manually.
                                  Dropping can fail when the DB is in use. (default: false)
    --clear-pulp-content          This option will clear all Pulp content from disk located in '/var/lib/pulp/content/'. (default: false)
    --clear-puppet-environments   This option will clear all published Puppet environments from disk. (default: false)
    --tuning INSTALLATION_SIZE    Tune for an installation size. Choices: default, medium, large, extra-large, extra-extra-large (default: "default")
    --disable-system-checks       This option will skip the system checks for memory. (default: false)
    --force-upgrade-steps         This option will force upgrade steps to run that are normally only run once. (default: false)
    --certs-update-server         This option will enforce an update of the HTTPS certificates (default: false)
    --certs-update-server-ca      This option will enforce an update of the CA used for HTTPS certificates. (default: false)
    --certs-update-all            This option will enforce an update of all the certificates for given host (default: false)
    --certs-reset                 This option will reset any custom certificates and use the self-signed CA instead. Note that any clients will need to be updated with the latest katello-ca-consumer RPM, and any external proxies will need to have the certs updated by generating a new certs tarball. (default: false)
    --certs-skip-check            This option will cause skipping the certificates sanity check. Use with caution (default: false)
    --upgrade-mongo-storage-engine Run the steps necessary to upgrade the MongoDB storage engine. (default: false)
    --upgrade                     Run the steps necessary for an upgrade such as migrations, rake tasks, etc. (default: false)
    --disable-resolve-mismatches  This will disable the resolving of mismatches between the application and backend services, during upgrade.  The steps will still run in a non-commit mode to show what would have been changed. (default: false)
    --[no-]colors                 Use color output on STDOUT (default: true)
    --color-of-background COLOR   Your terminal background is :bright or :dark (default: :dark)
    --dont-save-answers           Skip saving answers to './config/katello-answers.yaml'? (default: false)
    --ignore-undocumented         Ignore inconsistent parameter documentation (default: false)
    -i, --interactive             Run in interactive mode
    --log-level LEVEL             Log level for log file output (default: "DEBUG")
    -n, --noop                    Run puppet in noop mode? (default: false)
    -p, --profile                 Run puppet in profile mode? (default: false)
    -s, --skip-checks-i-know-better Skip all system checks (default: false)
    --skip-puppet-version-check   Skip check for compatible Puppet versions (default: false)
    -v, --verbose                 Display log on STDOUT instead of progressbar
    -l, --verbose-log-level LEVEL Log level for verbose mode output (default: "info")
    -S, --scenario SCENARIO       Use installation scenario
    --disable-scenario SCENARIO   Disable installation scenario
    --enable-scenario SCENARIO    Enable installation scenario
    --list-scenarios              List available installation scenarios
    --force                       Force change of installation scenario
    --compare-scenarios           Show changes between last used scenario and the scenario specified with -S or --scenario argument
    --migrations-only             Apply migrations to a selected scenario and exit
    --[no-]parser-cache           Force use or bypass of Puppet module parser cache
    -h, --help                    print help
    --full-help                   print complete help
    --[no-]enable-application     Enable 'application' puppet module (default: true)
    --[no-]enable-candlepin       Enable 'candlepin' puppet module (default: true)
    --[no-]enable-certs           Enable 'certs' puppet module (default: true)
    --[no-]enable-foreman         Enable 'foreman' puppet module (default: true)
    --[no-]enable-foreman-cli     Enable 'foreman_cli' puppet module (default: true)
    --[no-]enable-foreman-cli-ansible Enable 'foreman_cli_ansible' puppet module (default: false)
    --[no-]enable-foreman-cli-azure Enable 'foreman_cli_azure' puppet module (default: false)
    --[no-]enable-foreman-cli-discovery Enable 'foreman_cli_discovery' puppet module (default: false)
    --[no-]enable-foreman-cli-kubevirt Enable 'foreman_cli_kubevirt' puppet module (default: false)
    --[no-]enable-foreman-cli-openscap Enable 'foreman_cli_openscap' puppet module (default: false)
    --[no-]enable-foreman-cli-remote-execution Enable 'foreman_cli_remote_execution' puppet module (default: false)
    --[no-]enable-foreman-cli-tasks Enable 'foreman_cli_tasks' puppet module (default: false)
    --[no-]enable-foreman-cli-templates Enable 'foreman_cli_templates' puppet module (default: false)
    --[no-]enable-foreman-cli-virt-who-configure Enable 'foreman_cli_virt_who_configure' puppet module (default: false)
    --[no-]enable-foreman-compute-ec2 Enable 'foreman_compute_ec2' puppet module (default: false)
    --[no-]enable-foreman-compute-gce Enable 'foreman_compute_gce' puppet module (default: false)
    --[no-]enable-foreman-compute-libvirt Enable 'foreman_compute_libvirt' puppet module (default: false)
    --[no-]enable-foreman-compute-openstack Enable 'foreman_compute_openstack' puppet module (default: false)
    --[no-]enable-foreman-compute-ovirt Enable 'foreman_compute_ovirt' puppet module (default: false)
    --[no-]enable-foreman-compute-rackspace Enable 'foreman_compute_rackspace' puppet module (default: false)
    --[no-]enable-foreman-compute-vmware Enable 'foreman_compute_vmware' puppet module (default: false)
    --[no-]enable-foreman-plugin-ansible Enable 'foreman_plugin_ansible' puppet module (default: false)
    --[no-]enable-foreman-plugin-bootdisk Enable 'foreman_plugin_bootdisk' puppet module (default: false)
    --[no-]enable-foreman-plugin-chef Enable 'foreman_plugin_chef' puppet module (default: false)
    --[no-]enable-foreman-plugin-default-hostgroup Enable 'foreman_plugin_default_hostgroup' puppet module (default: false)
    --[no-]enable-foreman-plugin-digitalocean Enable 'foreman_plugin_digitalocean' puppet module (default: false)
    --[no-]enable-foreman-plugin-discovery Enable 'foreman_plugin_discovery' puppet module (default: false)
    --[no-]enable-foreman-plugin-expire-hosts Enable 'foreman_plugin_expire_hosts' puppet module (default: false)
    --[no-]enable-foreman-plugin-hooks Enable 'foreman_plugin_hooks' puppet module (default: false)
    --[no-]enable-foreman-plugin-inventory-upload Enable 'foreman_plugin_inventory_upload' puppet module (default: false)
    --[no-]enable-foreman-plugin-kubevirt Enable 'foreman_plugin_kubevirt' puppet module (default: false)
    --[no-]enable-foreman-plugin-memcache Enable 'foreman_plugin_memcache' puppet module (default: false)
    --[no-]enable-foreman-plugin-monitoring Enable 'foreman_plugin_monitoring' puppet module (default: false)
    --[no-]enable-foreman-plugin-openscap Enable 'foreman_plugin_openscap' puppet module (default: false)
    --[no-]enable-foreman-plugin-puppetdb Enable 'foreman_plugin_puppetdb' puppet module (default: false)
    --[no-]enable-foreman-plugin-remote-execution Enable 'foreman_plugin_remote_execution' puppet module (default: false)
    --[no-]enable-foreman-plugin-remote-execution-cockpit Enable 'foreman_plugin_remote_execution_cockpit' puppet module (default: false)
    --[no-]enable-foreman-plugin-salt Enable 'foreman_plugin_salt' puppet module (default: false)
    --[no-]enable-foreman-plugin-setup Enable 'foreman_plugin_setup' puppet module (default: false)
    --[no-]enable-foreman-plugin-snapshot-management Enable 'foreman_plugin_snapshot_management' puppet module (default: false)
    --[no-]enable-foreman-plugin-tasks Enable 'foreman_plugin_tasks' puppet module (default: true)
    --[no-]enable-foreman-plugin-templates Enable 'foreman_plugin_templates' puppet module (default: false)
    --[no-]enable-foreman-plugin-virt-who-configure Enable 'foreman_plugin_virt_who_configure' puppet module (default: false)
    --[no-]enable-foreman-proxy   Enable 'foreman_proxy' puppet module (default: true)
    --[no-]enable-foreman-proxy-content Enable 'foreman_proxy_content' puppet module (default: true)
    --[no-]enable-foreman-proxy-plugin-ansible Enable 'foreman_proxy_plugin_ansible' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-chef Enable 'foreman_proxy_plugin_chef' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-dhcp-infoblox Enable 'foreman_proxy_plugin_dhcp_infoblox' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-dhcp-remote-isc Enable 'foreman_proxy_plugin_dhcp_remote_isc' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-discovery Enable 'foreman_proxy_plugin_discovery' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-dns-infoblox Enable 'foreman_proxy_plugin_dns_infoblox' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-monitoring Enable 'foreman_proxy_plugin_monitoring' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-openscap Enable 'foreman_proxy_plugin_openscap' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-pulp Enable 'foreman_proxy_plugin_pulp' puppet module (default: true)
    --[no-]enable-foreman-proxy-plugin-remote-execution-ssh Enable 'foreman_proxy_plugin_remote_execution_ssh' puppet module (default: false)
    --[no-]enable-foreman-proxy-plugin-salt Enable 'foreman_proxy_plugin_salt' puppet module (default: false)
    --[no-]enable-global          Enable 'global' puppet module (default: true)
    --[no-]enable-katello         Enable 'katello' puppet module (default: true)
    --[no-]enable-pulp            Enable 'pulp' puppet module (default: true)
    --[no-]enable-puppet          Enable 'puppet' puppet module (default: true)
    --[no-]enable-qpid            Enable 'qpid' puppet module (default: true)


= Module application:
    --application-cdn-ssl-version  SSL version used to communicate with the CDN (current: UNDEF)
    --application-proxy-host      URL of the proxy server (current: UNDEF)
    --application-proxy-password  Proxy password for authentication (current: UNDEF)
    --application-proxy-port      Port the proxy is running on (current: UNDEF)
    --application-proxy-username  Proxy username for authentication (current: UNDEF)
    --application-rest-client-timeout  Timeout for Katello rest API (current: 3600)


= Module candlepin:
    --candlepin-db-host           The database host (current: "localhost")
    --candlepin-db-name           The database name (current: "candlepin")
    --candlepin-db-password       The database password. A random password will be generated when
                                  unspecified. (current: UNDEF)
    --candlepin-db-port           The database port (current: UNDEF)
    --candlepin-db-ssl            Whether to connect using SSL (current: false)
    --candlepin-db-ssl-verify     Whether to verify the certificate of the database host (current: true)
    --candlepin-db-user           The database username (current: "candlepin")
    --candlepin-manage-db         Whether to manage the database. Set this to false when using a remote database (current: true)


= Module certs:
    --certs-cname                 The alternative names of the host the generated certificates
                                  should be for (current: [])
    --certs-node-fqdn             The fqdn of the host the generated certificates
                                  should be for (current: "host.example.com")
    --certs-server-ca-cert        Path to the CA that issued the ssl certificates for https
                                  if not specified, the default CA will be used (current: UNDEF)
    --certs-server-cert           Path to the ssl certificate for https
                                  if not specified, the default CA will generate one (current: UNDEF)
    --certs-server-cert-req       Path to the ssl certificate request for https
                                  if not specified, the default CA will generate one (current: UNDEF)
    --certs-server-key            Path to the ssl key for https
                                  if not specified, the default CA will generate one (current: UNDEF)
    --certs-tar-file              Use a tarball with certificates rather than generate
                                  new ones. This can be used on another node which is
                                  not the CA. (current: UNDEF)


= Module foreman:
    --foreman-db-manage           If enabled, will install and configure the database server on this host (current: true)
    --foreman-db-type             Database 'production' type (current: "postgresql")
    --foreman-email-delivery-method  Email delivery method (current: UNDEF)
    --foreman-email-smtp-address  SMTP server hostname, when delivery method is SMTP (current: UNDEF)
    --foreman-email-smtp-authentication  SMTP authentication method (current: "none")
    --foreman-email-smtp-domain   SMTP HELO domain (current: UNDEF)
    --foreman-email-smtp-password  Password for SMTP server auth, if authentication is enabled (current: UNDEF)
    --foreman-email-smtp-port     SMTP port (current: 25)
    --foreman-email-smtp-user-name  Username for SMTP server auth, if authentication is enabled (current: UNDEF)
    --foreman-initial-admin-email  Initial E-mail address of the admin user (current: UNDEF)
    --foreman-initial-admin-first-name  Initial first name of the admin user (current: UNDEF)
    --foreman-initial-admin-last-name  Initial last name of the admin user (current: UNDEF)
    --foreman-initial-admin-password  Initial password of the admin user, default is randomly generated (current: "aSVvWmDaCMBwra54")
    --foreman-initial-admin-username  Initial username for the admin user account, default is admin (current: "admin")
    --foreman-initial-location    Name of an initial location (current: "Default Location")
    --foreman-initial-organization  Name of an initial organization (current: "Default Organization")
    --foreman-ipa-authentication  Enable configuration for external authentication via IPA (current: false)


= Module foreman_cli:
    --foreman-cli-foreman-url     URL on which Foreman runs (current: UNDEF)
    --foreman-cli-password        Password for authentication (current: UNDEF)
    --foreman-cli-username        Username for authentication (current: UNDEF)


= Module foreman_compute_ec2:
    --foreman-compute-ec2-version  Package version to install, defaults to installed (current: "installed")


= Module foreman_compute_gce:
    --foreman-compute-gce-version  Package version to install, defaults to installed (current: "installed")


= Module foreman_compute_libvirt:
    --foreman-compute-libvirt-version  Package version to install, defaults to installed (current: "installed")


= Module foreman_compute_openstack:
    --foreman-compute-openstack-version  Package version to install, defaults to installed (current: "installed")


= Module foreman_compute_ovirt:
    --foreman-compute-ovirt-version  Package version to install, defaults to installed (current: "installed")


= Module foreman_compute_rackspace:
    --foreman-compute-rackspace-version  Package version to install, defaults to installed (current: "installed")


= Module foreman_compute_vmware:
    --foreman-compute-vmware-version  Package version to install, defaults to installed (current: "installed")


= Module foreman_plugin_memcache:
    --foreman-plugin-memcache-compress  will gzip-compress values larger than 1K (current: true)
    --foreman-plugin-memcache-expires-in  global default for key TTL in seconds (current: 86400)
    --foreman-plugin-memcache-hosts  an array of hosts running memcache (current: ["[]"])
    --foreman-plugin-memcache-namespace  prepends each key with this value to provide simple namespacing (current: "foreman")


= Module foreman_plugin_puppetdb:
    --foreman-plugin-puppetdb-address  Address of puppetdb API.
                                  Defaults to 'https://localhost:8081/pdb/cmd/v1' (current: "https://localhost:8081/pdb/cmd/v1")
    --foreman-plugin-puppetdb-api-version  PuppetDB API version.
                                  Defaults to '4' (current: "4")
    --foreman-plugin-puppetdb-package  Package name to install (current: "rubygem-puppetdb_foreman")
    --foreman-plugin-puppetdb-ssl-ca-file  CA certificate file which will be used to connect to the PuppetDB API.
                                  Defaults to client_ssl_ca (current: "/var/lib/puppet/ssl/certs/ca.pem")
    --foreman-plugin-puppetdb-ssl-certificate  Certificate file which will be used to connect to the PuppetDB API.
                                  Defaults to client_ssl_cert (current: "/var/lib/puppet/ssl/certs/host.example.com.pem")
    --foreman-plugin-puppetdb-ssl-private-key  Private key file which will be used to connect to the PuppetDB API.
                                  Defaults to client_ssl_key (current: "/var/lib/puppet/ssl/private_keys/host.example.com.pem")


= Module foreman_plugin_tasks:
    --foreman-plugin-tasks-automatic-cleanup  Enable automatic task cleanup using a cron job (current: false)
    --foreman-plugin-tasks-cron-line  Cron line defining when the cleanup cron job should run (current: "45 19 * * *")
    --foreman-plugin-tasks-package  Package name to install (current: "rubygem-foreman-tasks")


= Module foreman_proxy:
    --foreman-proxy-autosignfile  Hostname-Whitelisting only: Location of puppets autosign.conf (current: "/etc/puppet/autosign.conf")
    --foreman-proxy-bind-host     Host to bind ports to, e.g. *, localhost, 0.0.0.0 (current: ["*"])
    --foreman-proxy-bmc           Enable BMC feature (current: false)
    --foreman-proxy-bmc-default-provider  BMC default provider. (current: "ipmitool")
    --foreman-proxy-bmc-listen-on  BMC proxy to listen on https, http, or both (current: "https")
    --foreman-proxy-bmc-ssh-key   BMC SSH key location. (current: "/usr/share/foreman/.ssh/id_rsa")
    --foreman-proxy-bmc-ssh-powercycle  BMC SSH powercycle command. (current: "shutdown -r +1")
    --foreman-proxy-bmc-ssh-poweroff  BMC SSH poweroff command. (current: "shutdown +1")
    --foreman-proxy-bmc-ssh-poweron  BMC SSH poweron command. (current: "false")
    --foreman-proxy-bmc-ssh-powerstatus  BMC SSH powerstatus command. (current: "true")
    --foreman-proxy-bmc-ssh-user  BMC SSH user. (current: "root")
    --foreman-proxy-customrun-args  Puppet customrun command arguments (current: "-ay -f -s")
    --foreman-proxy-customrun-cmd  Puppet customrun command (current: "/bin/false")
    --foreman-proxy-dhcp          Enable DHCP feature (current: false)
    --foreman-proxy-dhcp-additional-interfaces  Additional DHCP listen interfaces (in addition to dhcp_interface). Note: as opposed to dhcp_interface
                                  *no* subnet will be provisioned for any of the additional DHCP listen interfaces. Please configure any
                                  additional subnets using `dhcp::pool` and related resource types (provided by the theforeman/puppet-dhcp
                                  module). (current: [])
    --foreman-proxy-dhcp-config   DHCP config file path (current: "/etc/dhcp/dhcpd.conf")
    --foreman-proxy-dhcp-gateway  DHCP pool gateway (current: UNDEF)
    --foreman-proxy-dhcp-interface  DHCP listen interface (current: "eth0")
    --foreman-proxy-dhcp-key-name  DHCP key name (current: UNDEF)
    --foreman-proxy-dhcp-key-secret  DHCP password (current: UNDEF)
    --foreman-proxy-dhcp-leases   DHCP leases file (current: "/var/lib/dhcpd/dhcpd.leases")
    --foreman-proxy-dhcp-listen-on  DHCP proxy to listen on https, http, or both (current: "https")
    --foreman-proxy-dhcp-managed  The DHCP daemon is managed by this module (current: true)
    --foreman-proxy-dhcp-nameservers  DHCP nameservers, comma-separated (current: "default")
    --foreman-proxy-dhcp-netmask  DHCP server netmask value, defaults otherwise to value based on IP of dhcp_interface (current: UNDEF)
    --foreman-proxy-dhcp-network  DHCP server network value, defaults otherwise to value based on IP of dhcp_interface (current: UNDEF)
    --foreman-proxy-dhcp-node-type  DHCP node type (current: "standalone")
    --foreman-proxy-dhcp-omapi-port  DHCP server OMAPI port (current: 7911)
    --foreman-proxy-dhcp-option-domain  DHCP use the dhcpd config option domain-name (current: ["example.com"])
    --foreman-proxy-dhcp-peer-address  The other DHCP servers address (current: UNDEF)
    --foreman-proxy-dhcp-provider  DHCP provider for the DHCP module (current: "isc")
    --foreman-proxy-dhcp-pxefilename  DHCP "filename" value, defaults otherwise to pxelinux.0 (current: "pxelinux.0")
    --foreman-proxy-dhcp-pxeserver  DHCP "next-server" value, defaults otherwise to IP of dhcp_interface (current: UNDEF)
    --foreman-proxy-dhcp-range    Space-separated DHCP pool range (current: UNDEF)
    --foreman-proxy-dhcp-search-domains  DHCP search domains option (current: UNDEF)
    --foreman-proxy-dhcp-server   Address of DHCP server to manage (current: "127.0.0.1")
    --foreman-proxy-dhcp-subnets  Subnets list to restrict DHCP management to (current: [])
    --foreman-proxy-dir           Foreman proxy install directory (current: "/usr/share/foreman-proxy")
    --foreman-proxy-dns           Enable DNS feature (current: false)
    --foreman-proxy-dns-forwarders  DNS forwarders (current: [])
    --foreman-proxy-dns-interface  DNS interface (current: "eth0")
    --foreman-proxy-dns-listen-on  DNS proxy to listen on https, http, or both (current: "https")
    --foreman-proxy-dns-managed   The DNS daemon is managed by this module. Only supported for the nsupdate and nsupdate_gss DNS providers. (current: true)
    --foreman-proxy-dns-provider  DNS provider (current: "nsupdate")
    --foreman-proxy-dns-reverse   DNS reverse zone name (current: UNDEF)
    --foreman-proxy-dns-server    Address of DNS server to manage (current: "127.0.0.1")
    --foreman-proxy-dns-tsig-keytab  Kerberos keytab for DNS updates using GSS-TSIG authentication (current: "/etc/foreman-proxy/dns.keytab")
    --foreman-proxy-dns-tsig-principal  Kerberos principal for DNS updates using GSS-TSIG authentication (current: "foremanproxy/host.example.com@EXAMPLE.COM")
    --foreman-proxy-dns-ttl       DNS default TTL override (current: 86400)
    --foreman-proxy-dns-zone      DNS zone name (current: "example.com")
    --foreman-proxy-ensure-packages-version  control extra packages version, it's passed to ensure parameter of package resource (current: "present")
    --foreman-proxy-foreman-base-url  Base Foreman URL used for REST interaction (current: "https://host.example.com")
    --foreman-proxy-foreman-ssl-ca  SSL CA used to verify connections when accessing the Foreman API.
                                  When not specified, the ssl_ca is used instead. (current: "/etc/foreman-proxy/foreman_ssl_ca.pem")
    --foreman-proxy-foreman-ssl-cert  SSL client certificate used when accessing the Foreman API
                                  When not specified, the ssl_cert is used instead. (current: "/etc/foreman-proxy/foreman_ssl_cert.pem")
    --foreman-proxy-foreman-ssl-key  Corresponding key to a foreman_ssl_cert certificate
                                  When not specified, the ssl_key is used instead. (current: "/etc/foreman-proxy/foreman_ssl_key.pem")
    --foreman-proxy-freeipa-config  Path to FreeIPA default.conf configuration file (current: "/etc/ipa/default.conf")
    --foreman-proxy-freeipa-remove-dns  Remove DNS entries from FreeIPA when deleting hosts from realm (current: true)
    --foreman-proxy-groups        Array of additional groups for the foreman proxy user (current: [])
    --foreman-proxy-http          Enable HTTP (current: true)
    --foreman-proxy-http-port     HTTP port to listen on (if http is enabled) (current: 8000)
    --foreman-proxy-keyfile       DNS server keyfile path (current: "/etc/rndc.key")
    --foreman-proxy-libvirt-connection  Connection string of libvirt DNS/DHCP provider (e.g. "qemu:///system") (current: "qemu:///system")
    --foreman-proxy-libvirt-network  Network for libvirt DNS/DHCP provider (current: "default")
    --foreman-proxy-log           Foreman proxy log file, 'STDOUT', 'SYSLOG' or 'JOURNAL' (current: "/var/log/foreman-proxy/proxy.log")
    --foreman-proxy-log-buffer    Log buffer size (current: 2000)
    --foreman-proxy-log-buffer-errors  Additional log buffer size for errors (current: 1000)
    --foreman-proxy-log-level     Foreman proxy log level (current: "INFO")
    --foreman-proxy-logs          Enable Logs (log buffer) feature (current: true)
    --foreman-proxy-logs-listen-on  Logs proxy to listen on https, http, or both (current: "https")
    --foreman-proxy-manage-puppet-group  Whether to ensure the $puppet_group exists.  Also ensures group owner of ssl keys and certs is $puppet_group
                                  Not applicable when ssl is false. (current: false)
    --foreman-proxy-manage-sudoersd  Whether to manage File['/etc/sudoers.d'] or not.  When reusing this module, this may be
                                  disabled to let a dedicated sudo module manage it instead. (current: true)
    --foreman-proxy-mcollective-user  The user for puppetrun_provider mcollective (current: "root")
    --foreman-proxy-oauth-consumer-key  OAuth key to be used for REST interaction (current: "EoB4hLN9VncwHcJM46LHRyLHAJz2HvPA")
    --foreman-proxy-oauth-consumer-secret  OAuth secret to be used for REST interaction (current: "C4WU8BVcUww7ArnhmiZVrNQV8bPSPHWi")
    --foreman-proxy-oauth-effective-user  User to be used for REST interaction (current: "admin")
    --foreman-proxy-plugin-version  foreman plugins version, it's passed to ensure parameter of plugins package resource (current: "installed")
    --foreman-proxy-puppet        Enable Puppet module for environment imports and Puppet runs (current: true)
    --foreman-proxy-puppet-api-timeout  Timeout in seconds when accessing Puppet environment classes API (current: 30)
    --foreman-proxy-puppet-group  Groups of Foreman proxy user (current: "puppet")
    --foreman-proxy-puppet-listen-on  Protocols for the Puppet feature to listen on (current: "https")
    --foreman-proxy-puppet-ssl-ca  SSL CA used to verify connections when accessing the Puppet master API (current: "/var/lib/puppet/ssl/certs/ca.pem")
    --foreman-proxy-puppet-ssl-cert  SSL certificate used when accessing the Puppet master API (current: "/var/lib/puppet/ssl/certs/host.example.com.pem")
    --foreman-proxy-puppet-ssl-key  SSL private key used when accessing the Puppet master API (current: "/var/lib/puppet/ssl/private_keys/host.example.com.pem")
    --foreman-proxy-puppet-url    URL of the Puppet master itself for API requests (current: "https://host.example.com:8140")
    --foreman-proxy-puppet-user   Which user to invoke sudo as to run puppet commands (current: "root")
    --foreman-proxy-puppetca      Enable Puppet CA feature (current: true)
    --foreman-proxy-puppetca-cmd  Puppet CA command to be allowed in sudoers (current: "/usr/bin/puppet cert")
    --foreman-proxy-puppetca-listen-on  Protocols for the Puppet CA feature to listen on (current: "https")
    --foreman-proxy-puppetca-tokens-file  Token-Whitelisting only: Location of the tokens.yaml (current: "/var/lib/foreman-proxy/tokens.yml")
    --foreman-proxy-puppetdir     Puppet var directory (current: "/etc/puppet")
    --foreman-proxy-puppetrun-provider  Provider for running/kicking Puppet agents (current: UNDEF)
    --foreman-proxy-puppetssh-command  The command used by puppetrun_provider puppetssh (current: "/usr/bin/puppet agent --onetime --no-usecacheonfailure")
    --foreman-proxy-puppetssh-keyfile  The keyfile for puppetrun_provider puppetssh commands (current: "/etc/foreman-proxy/id_rsa")
    --foreman-proxy-puppetssh-sudo  Whether to use sudo before commands when using puppetrun_provider puppetssh (current: false)
    --foreman-proxy-puppetssh-user  The user for puppetrun_provider puppetssh (current: "root")
    --foreman-proxy-puppetssh-wait  Whether to wait for completion of the Puppet command over SSH and return
                                  the exit code (current: false)
    --foreman-proxy-realm         Enable realm management feature (current: false)
    --foreman-proxy-realm-keytab  Kerberos keytab path to authenticate realm updates (current: "/etc/foreman-proxy/freeipa.keytab")
    --foreman-proxy-realm-listen-on  Realm proxy to listen on https, http, or both (current: "https")
    --foreman-proxy-realm-principal  Kerberos principal for realm updates (current: "realm-proxy@EXAMPLE.COM")
    --foreman-proxy-realm-provider  Realm management provider (current: "freeipa")
    --foreman-proxy-register-in-foreman  Register proxy back in Foreman (current: true)
    --foreman-proxy-registered-name  Proxy name which is registered in Foreman (current: "host.example.com")
    --foreman-proxy-registered-proxy-url  Proxy URL which is registered in Foreman (current: UNDEF)
    --foreman-proxy-salt-puppetrun-cmd  Salt command to trigger Puppet run (current: "puppet.run")
    --foreman-proxy-ssl           Enable SSL, ensure feature is added with "https://" protocol if true (current: true)
    --foreman-proxy-ssl-ca        SSL CA to validate the client certificates used to access the proxy (current: "/etc/foreman-proxy/ssl_ca.pem")
    --foreman-proxy-ssl-cert      SSL certificate to be used to run the foreman proxy via https. (current: "/etc/foreman-proxy/ssl_cert.pem")
    --foreman-proxy-ssl-disabled-ciphers  List of OpenSSL cipher suite names that will be disabled from the default (current: [])
    --foreman-proxy-ssl-key       Corresponding key to a ssl_cert certificate (current: "/etc/foreman-proxy/ssl_key.pem")
    --foreman-proxy-ssl-port      HTTPS port to listen on (if ssl is enabled) (current: 9090)
    --foreman-proxy-ssldir        Puppet CA SSL directory (current: "/var/lib/puppet/ssl")
    --foreman-proxy-template-url  URL a client should use for provisioning templates (current: "http://host.example.com:8000")
    --foreman-proxy-templates     Enable templates feature (current: true)
    --foreman-proxy-templates-listen-on  Templates proxy to listen on https, http, or both (current: "both")
    --foreman-proxy-tftp          Enable TFTP feature (current: true)
    --foreman-proxy-tftp-dirs     Directories to be create in $tftp_root (current: ["/var/lib/tftpboot/pxelinux.cfg", "/var/lib/tftpboot/grub", "/var/lib/tftpboot/grub2", "/var/lib/tftpboot/boot", "/var/lib/tftpboot/ztp.cfg", "/var/lib/tftpboot/poap.cfg"])
    --foreman-proxy-tftp-listen-on  TFTP proxy to listen on https, http, or both (current: "https")
    --foreman-proxy-tftp-manage-wget  If enabled will install the wget package (current: true)
    --foreman-proxy-tftp-managed  The TFTP daemon is managed by this module. (current: true)
    --foreman-proxy-tftp-replace-grub2-cfg  Determines if grub2.cfg will be replaced (current: false)
    --foreman-proxy-tftp-root     TFTP root directory (current: "/var/lib/tftpboot")
    --foreman-proxy-tftp-servername  Defines the TFTP Servername to use, overrides the name in the subnet declaration (current: UNDEF)
    --foreman-proxy-tftp-syslinux-filenames  Syslinux files to install on TFTP (full paths) (current: ["/usr/share/syslinux/chain.c32", "/usr/share/syslinux/mboot.c32", "/usr/share/syslinux/menu.c32", "/usr/share/syslinux/memdisk", "/usr/share/syslinux/pxelinux.0"])
    --foreman-proxy-tls-disabled-versions  List of TLS versions that will be disabled from the default (current: [])
    --foreman-proxy-trusted-hosts  Only hosts listed will be permitted, empty array to disable authorization (current: ["host.example.com"])
    --foreman-proxy-use-sudoers   Add contents to /etc/sudoers (true). This is ignored if $use_sudoersd is true. (current: true)
    --foreman-proxy-use-sudoersd  Add a file to /etc/sudoers.d (true). (current: true)
    --foreman-proxy-user          User under which foreman proxy will run (current: "foreman-proxy")
    --foreman-proxy-version       foreman package version, it's passed to ensure parameter of package resource
                                  can be set to specific version number, 'latest', 'present' etc. (current: "present")


= Module foreman_proxy_content:
    --foreman-proxy-content-enable-deb  Enable debian content plugin (current: true)
    --foreman-proxy-content-enable-docker  Enable docker content plugin (current: true)
    --foreman-proxy-content-enable-file  Enable file content plugin (current: true)
    --foreman-proxy-content-enable-ostree  Enable ostree content plugin, this requires an ostree install (current: false)
    --foreman-proxy-content-enable-puppet  Enable puppet content plugin (current: true)
    --foreman-proxy-content-enable-yum  Enable rpm content plugin, including syncing of yum content (current: true)
    --foreman-proxy-content-parent-fqdn  FQDN of the parent node. (current: "host.example.com")


= Module foreman_proxy_plugin_ansible:


= Module foreman_proxy_plugin_chef:
    --foreman-proxy-plugin-chef-client-name  chef client name used for authentication of other client requests (current: "host.example.com")
    --foreman-proxy-plugin-chef-private-key  path to file containing private key for $client_name client (current: "/etc/chef/client.pem")
    --foreman-proxy-plugin-chef-server-url  chef server url (current: "https://host.example.com")
    --foreman-proxy-plugin-chef-ssl-pem-file  if $ssl_verify is true you can specify a path to a file which
                                  contains certificate and related private key if the certificate
                                  is not globally trusted (current: UNDEF)
    --foreman-proxy-plugin-chef-ssl-verify  should we perform chef server ssl cert verification? this requires
                                  CA certificate installed and trusted (current: true)


= Module foreman_proxy_plugin_dhcp_infoblox:
    --foreman-proxy-plugin-dhcp-infoblox-dns-view  The DNS view to use (current: "default")
    --foreman-proxy-plugin-dhcp-infoblox-network-view  The network view to use (current: "default")
    --foreman-proxy-plugin-dhcp-infoblox-password  The password of the Infoblox user (current: UNDEF)
    --foreman-proxy-plugin-dhcp-infoblox-record-type  Record type to manage (current: "fixedaddress")
    --foreman-proxy-plugin-dhcp-infoblox-username  The username of the Infoblox user (current: UNDEF)


= Module foreman_proxy_plugin_dhcp_remote_isc:
    --foreman-proxy-plugin-dhcp-remote-isc-dhcp-config  DHCP config file path (current: "/etc/dhcp/dhcpd.conf")
    --foreman-proxy-plugin-dhcp-remote-isc-dhcp-leases  DHCP leases file (current: "/var/lib/dhcpd/dhcpd.leases")
    --foreman-proxy-plugin-dhcp-remote-isc-key-name  DHCP key name (current: UNDEF)
    --foreman-proxy-plugin-dhcp-remote-isc-key-secret  DHCP password (current: UNDEF)
    --foreman-proxy-plugin-dhcp-remote-isc-omapi-port  DHCP server OMAPI port (current: 7911)


= Module foreman_proxy_plugin_discovery:
    --foreman-proxy-plugin-discovery-image-name  tarball with images (current: "fdi-image-latest.tar")
    --foreman-proxy-plugin-discovery-install-images  should the discovery image be downloaded and extracted (current: false)
    --foreman-proxy-plugin-discovery-source-url  source URL to download from (current: "http://downloads.theforeman.org/discovery/releases/latest/")
    --foreman-proxy-plugin-discovery-tftp-root  tftp root to install image into (current: "/var/lib/tftpboot")


= Module foreman_proxy_plugin_dns_infoblox:
    --foreman-proxy-plugin-dns-infoblox-dns-server  The address of the Infoblox server (current: UNDEF)
    --foreman-proxy-plugin-dns-infoblox-dns-view  The Infoblox DNS View (current: "default")
    --foreman-proxy-plugin-dns-infoblox-password  The password of the Infoblox user (current: UNDEF)
    --foreman-proxy-plugin-dns-infoblox-username  The username of the Infoblox user (current: UNDEF)


= Module foreman_proxy_plugin_monitoring:
    --foreman-proxy-plugin-monitoring-collect-status  collect monitoring status from monitoring solution (current: true)
    --foreman-proxy-plugin-monitoring-providers  monitoring providers (current: ["icinga2"])


= Module foreman_proxy_plugin_openscap:
    --foreman-proxy-plugin-openscap-contentdir  Directory where OpenSCAP content XML are stored
                                  So we will not request the XML from Foreman each time (current: "/var/lib/foreman-proxy/openscap/content")
    --foreman-proxy-plugin-openscap-failed-dir  Directory where OpenSCAP report XML are stored
                                  In case sending to Foreman succeeded, yet failed to save to reportsdir (current: "/var/lib/foreman-proxy/openscap/failed")
    --foreman-proxy-plugin-openscap-openscap-send-log-file  Log file for the forwarding script (current: "/var/log/foreman-proxy/openscap-send.log")
    --foreman-proxy-plugin-openscap-proxy-name  Proxy name to send to Foreman with parsed report
                                  Foreman matches it against names of registered proxies to find the report source (current: UNDEF)
    --foreman-proxy-plugin-openscap-reportsdir  Directory where OpenSCAP report XML are stored
                                  So Foreman can request arf xml reports (current: "/var/lib/foreman-proxy/openscap/reports")
    --foreman-proxy-plugin-openscap-spooldir  Directory where OpenSCAP audits are stored
                                  before they are forwarded to Foreman (current: "/var/spool/foreman-proxy/openscap")
    --foreman-proxy-plugin-openscap-timeout  Timeout for sending ARF reports to foreman (current: 60)


= Module foreman_proxy_plugin_pulp:


= Module foreman_proxy_plugin_remote_execution_ssh:
    --foreman-proxy-plugin-remote-execution-ssh-generate-keys  Automatically generate SSH keys (current: true)
    --foreman-proxy-plugin-remote-execution-ssh-install-key  Automatically install generated SSH key to root authorized keys
                                  which allows managing this host through Remote Execution (current: false)
    --foreman-proxy-plugin-remote-execution-ssh-local-working-dir  Local working directory on the smart proxy (current: "/var/tmp")
    --foreman-proxy-plugin-remote-execution-ssh-remote-working-dir  Remote working directory on clients (current: "/var/tmp")
    --foreman-proxy-plugin-remote-execution-ssh-ssh-identity-dir  Directory where SSH keys are stored (current: "/var/lib/foreman-proxy/ssh")
    --foreman-proxy-plugin-remote-execution-ssh-ssh-identity-file  Provide an alternative name for the SSH keys (current: "id_rsa_foreman_proxy")
    --foreman-proxy-plugin-remote-execution-ssh-ssh-kerberos-auth  Enable kerberos authentication for SSH (current: false)
    --foreman-proxy-plugin-remote-execution-ssh-ssh-keygen  Location of the ssh-keygen binary (current: "/usr/bin/ssh-keygen")


= Module foreman_proxy_plugin_salt:
    --foreman-proxy-plugin-salt-api  Use Salt API (current: false)
    --foreman-proxy-plugin-salt-api-auth  Salt API auth mechanism (current: "pam")
    --foreman-proxy-plugin-salt-api-password  Salt API password (current: "saltpassword")
    --foreman-proxy-plugin-salt-api-url  Salt API URL (current: "https://localhost:8080")
    --foreman-proxy-plugin-salt-api-username  Salt API username (current: "saltuser")
    --foreman-proxy-plugin-salt-autosign-file  File to use for salt autosign (current: "/etc/salt/autosign.conf")
    --foreman-proxy-plugin-salt-saltfile  Path to Saltfile (current: UNDEF)
    --foreman-proxy-plugin-salt-user  User to run salt commands under (current: "root")


= Module global:
    --global-enable-deb           Enable debian content plugin (current: true)
    --global-enable-docker        Enable docker content plugin (current: true)
    --global-enable-file          Enable generic file content management (current: true)
    --global-enable-ostree        Enable ostree content plugin, this requires an ostree install (current: false)
    --global-enable-puppet        Enable puppet content plugin (current: true)
    --global-enable-yum           Enable rpm content plugin, including syncing of yum content (current: true)


= Module pulp:
    --pulp-manage-mongodb         Boolean to install and configure the mongodb. (current: true)
    --pulp-mongodb-ca-path        The ca_certs file contains a set of concatenated "certification authority"
                                  certificates, which are used to validate certificates passed from the other
                                  end of the connection. (current: "/etc/pki/tls/certs/ca-bundle.crt")
    --pulp-mongodb-name           Name of the database to use (current: "pulp_database")
    --pulp-mongodb-password       The password to use for authenticating to the MongoDB server (current: UNDEF)
    --pulp-mongodb-replica-set    The name of replica set configured in MongoDB, if one is in use (current: UNDEF)
    --pulp-mongodb-seeds          Comma-separated list of hostname:port of database replica seed hosts (current: "localhost:27017")
    --pulp-mongodb-ssl            Whether to connect to the database server using SSL. (current: false)
    --pulp-mongodb-ssl-certfile   The certificate file used to identify the local connection against mongod. (current: UNDEF)
    --pulp-mongodb-ssl-keyfile    A path to the private keyfile used to identify the local connection against
                                  mongod. If included with the certfile then only the ssl_certfile is needed. (current: UNDEF)
    --pulp-mongodb-unsafe-autoretry  If true, retry commands to the database if there is a connection error.
                                  Warning: if set to true, this setting can result in duplicate records. (current: false)
    --pulp-mongodb-username       The user name to use for authenticating to the MongoDB server (current: UNDEF)
    --pulp-mongodb-verify-ssl     Specifies whether a certificate is required from the other side of the
                                  connection, and whether it will be validated if provided. If it is true,
                                  then the ca_certs parameter must point to a file of CA certificates used to
                                  validate the connection. (current: true)
    --pulp-mongodb-write-concern  Write concern of 'majority' or 'all'. When 'all' is specified, 'w' is set
                                  to number of seeds specified.  Please note that 'all' will cause Pulp to
                                  halt if any of the replica set members is not available. 'majority' is used
                                  by default (current: UNDEF)
    --pulp-num-workers            The number of Pulp workers to use (current: UNDEF)
    --pulp-pub-dir-options        The Apache options to use on the `/pub` resource (current: "+FollowSymLinks +Indexes")
    --pulp-worker-timeout         The amount of time (in seconds) before considering a worker as missing. If
                                  Pulp's mongo database has slow I/O, then setting a higher number may
                                  resolve issues where workers are going missing incorrectly. (current: 60)
    --pulp-yum-max-speed          The maximum download speed per second for a Pulp task, such as a sync. (e.g. "4 Kb" (Uses SI KB), 4MB, or 1GB" ) (current: UNDEF)


= Module puppet:
    --puppet-additional-settings  A hash of additional main settings. (current: {})
    --puppet-autosign             If set to a boolean, autosign is enabled or disabled
                                  for all incoming requests. Otherwise this has to be
                                  set to the full file path of an autosign.conf file or
                                  an autosign script. If this is set to a script, make
                                  sure that script considers the content of autosign.conf
                                  as otherwise Foreman functionality might be broken. (current: "/etc/puppet/autosign.conf")
    --puppet-autosign-content     If set, write the autosign file content
                                  using the value of this parameter.
                                  Cannot be used at the same time as autosign_entries
                                  For example, could be a string, or
                                  file('another_module/autosign.sh') or
                                  template('another_module/autosign.sh.erb') (current: UNDEF)
    --puppet-autosign-entries     A list of certnames or domain name globs
                                  whose certificate requests will automatically be signed.
                                  Defaults to an empty Array. (current: [])
    --puppet-autosign-mode        mode of the autosign file/script (current: "0664")
    --puppet-autosign-source      If set, use this as the source for the autosign file,
                                  instead of autosign_content. (current: UNDEF)
    --puppet-ca-crl-filepath      Path to CA CRL file, dynamically resolves based on
                                  $::server_ca status. (current: UNDEF)
    --puppet-ca-port              Puppet CA port (current: UNDEF)
    --puppet-ca-server            Use a different ca server. Should be either
                                  a string with the location of the ca_server
                                  or 'false'. (current: UNDEF)
    --puppet-cron-cmd             Specify command to launch when runmode is
                                  set 'cron'. (current: UNDEF)
    --puppet-dns-alt-names        Use additional DNS names when generating a
                                  certificate.  Defaults to an empty Array. (current: [])
    --puppet-hiera-config         The hiera configuration file. (current: "$confdir/hiera.yaml")
    --puppet-http-connect-timeout  The maximum amount of time an agent waits
                                  when establishing an HTTP connection. (current: UNDEF)
    --puppet-http-read-timeout    The time an agent waits for one block to be
                                  read from an HTTP connection. If nothing is
                                  read after the elapsed interval then the
                                  connection will be closed. (current: UNDEF)
    --puppet-listen               Should the puppet agent listen for connections. (current: false)
    --puppet-listen-to            An array of servers allowed to initiate a puppet run.
                                  If $listen = true one of three things will happen:
                                  1) if $listen_to is not empty then this array
                                  will be used.
                                  2) if $listen_to is empty and $puppetmaster is
                                  defined then only $puppetmaster will be
                                  allowed.
                                  3) if $puppetmaster is not defined or empty,
                                  $fqdn will be used. (current: [])
    --puppet-manage-packages      Should this module install packages or not.
                                  Can also install only server packages with value
                                  of 'server' or only agent packages with 'agent'. (current: true)
    --puppet-module-repository    Use a different puppet module repository (current: UNDEF)
    --puppet-pluginsync           Enable pluginsync. (current: true)
    --puppet-port                 Override the port of the master we connect to. (current: 8140)
    --puppet-run-hour             The hour at which to run the puppet agent
                                  when runmode is cron or systemd.timer. (current: UNDEF)
    --puppet-run-minute           The minute at which to run the puppet agent
                                  when runmode is cron or systemd.timer. (current: UNDEF)
    --puppet-runinterval          Set up the interval (in seconds) to run
                                  the puppet agent. (current: 1800)
    --puppet-runmode              Select the mode to setup the puppet agent. (current: "service")
    --puppet-show-diff            Show and report changed files with diff output (current: false)
    --puppet-splay                Switch to enable a random amount of time
                                  to sleep before each run. (current: false)
    --puppet-splaylimit           The maximum time to delay before runs.
                                  Defaults to being the same as the run interval.
                                  This setting can be a time interval in seconds
                                  (30 or 30s), minutes (30m), hours (6h), days (2d),
                                  or years (5y). (current: 1800)
    --puppet-syslogfacility       Facility name to use when logging to syslog (current: UNDEF)
    --puppet-systemd-cmd          Specify command to launch when runmode is
                                  set 'systemd.timer'. (current: UNDEF)
    --puppet-systemd-randomizeddelaysec  Adds a random delay between 0 and this value
                                  (in seconds) to the timer. Only relevant when
                                  runmode is 'systemd.timer'. (current: 0)
    --puppet-usecacheonfailure    Switch to enable use of cached catalog on
                                  failure of run. (current: true)
    --puppet-version              Specify a specific version of a package to
                                  install. The version should be the exact
                                  match for your distro.
                                  You can also use certain values like 'latest'.
                                  Note that when you specify exact versions you
                                  should also override $server_version since
                                  that defaults to $version. (current: "present")


= Module qpid:
    --qpid-wcache-page-size       The size (in KB) of the pages in the write page cache (current: 4)

Only commonly used options have been displayed.
Use --full-help to view the complete list.
```