### PR TITLE
Refs #28353 - Move fail_and_exit to HookContextExtension

### DIFF
--- a/katello/hooks/boot/01-helpers.rb
+++ b/katello/hooks/boot/01-helpers.rb
@@ -16,11 +16,6 @@ class Kafo::Helpers
       Kafo::KafoConfigure.logger.send(level, message) if do_log
     end
 
-    def fail_and_exit(message)
-      log_and_say :error, message
-      exit 1
-    end
-
     def read_cache_data(param)
       YAML.load_file("/opt/puppetlabs/puppet/cache/foreman_cache_data/#{param}")
     end
@@ -56,6 +51,11 @@ module HookContextExtension
   # FIXME: remove when #23332 is released
   def param_value(mod, name)
     param(mod, name).value if param(mod, name)
+  end
+
+  def fail_and_exit(message)
+    Kafo::Helpers.log_and_say :error, message
+    exit 1
   end
 
   def local_postgresql?

--- a/katello/hooks/post/30-upgrade.rb
+++ b/katello/hooks/post/30-upgrade.rb
@@ -10,11 +10,6 @@ def upgrade_tasks
   fail_and_exit "Application Upgrade Failed" unless status
 end
 
-def fail_and_exit(message)
-  Kafo::Helpers.log_and_say :error, message
-  kafo.class.exit 1
-end
-
 if app_value(:upgrade)
   if [0, 2].include?(@kafo.exit_code)
     if module_enabled?('foreman')

--- a/katello/hooks/pre/30-upgrade.rb
+++ b/katello/hooks/pre/30-upgrade.rb
@@ -51,7 +51,7 @@ def upgrade_step(step, options = {})
     Kafo::Helpers.log_and_say :info, "Upgrade Step: #{step}#{long_running}#{noop}..."
     unless app_value(:noop)
       status = send(step)
-      Kafo::Helpers.fail_and_exit "Upgrade step #{step} failed. Check logs for more information." unless status
+      fail_and_exit "Upgrade step #{step} failed. Check logs for more information." unless status
       touch_step(step)
     end
   end

--- a/katello/hooks/pre/31-mongo_storage_engine.rb
+++ b/katello/hooks/pre/31-mongo_storage_engine.rb
@@ -1,8 +1,4 @@
 require 'fileutils'
-def fail_and_exit(message)
-  Kafo::Helpers.log_and_say :error, message
-  kafo.class.exit 1
-end
 
 def migration
   katello = module_enabled?('katello')

--- a/katello/hooks/pre_validations/30-mongo_storage_engine.rb
+++ b/katello/hooks/pre_validations/30-mongo_storage_engine.rb
@@ -1,9 +1,5 @@
 MONGO_DIR = '/var/lib/mongodb/'
 
-def fail_and_exit(message)
-  Kafo::Helpers.fail_and_exit message
-end
-
 def disk_space
   # Check diskspace in /var/tmp
   logger.info 'Checking available diskspace in /var/tmp for upgrade'

--- a/katello/hooks/pre_validations/32-upgrade.rb
+++ b/katello/hooks/pre_validations/32-upgrade.rb
@@ -7,10 +7,10 @@ def check_postgresql_storage
     postgres_size = `du -b -s #{current_postgres_dir}`.split[0].to_i
 
     if available_space(new_postgres_dir) < postgres_size
-      Kafo::Helpers.fail_and_exit "The postgres upgrade requires at least #{(postgres_size / 1024) / 1024} MB of storage."
+      fail_and_exit "The postgres upgrade requires at least #{(postgres_size / 1024) / 1024} MB of storage."
     end
   rescue StandardError
-    Kafo::Helpers.fail_and_exit 'Failed to verify available disk space'
+    fail_and_exit 'Failed to verify available disk space'
   end
 end
 


### PR DESCRIPTION
By placing it in HookContextExtension, it can be used in every hook without redefining it.