### PR TITLE
Drop repository parameters from Katello

### DIFF
--- a/config/katello.migrations/191209155854-drop-repo-params.rb
+++ b/config/katello.migrations/191209155854-drop-repo-params.rb
@@ -1,0 +1,5 @@
+if answers['katello'].is_a?(Hash)
+  ['manage_repo', 'repo_version', 'repo_gpgcheck', 'repo_gpgkey'].each do |param|
+    answers['katello'].delete(param)
+  end
+end


### PR DESCRIPTION
https://github.com/theforeman/puppet-katello/commit/6d57a691451d509ce1ab684711164db9307029ec dropped these parameters. This cleans them from the answers file.