### PR TITLE
Fixes #28496: exit 1 on execute command

### DIFF
--- a/katello/hooks/boot/01-kafo-hook-extensions.rb
+++ b/katello/hooks/boot/01-kafo-hook-extensions.rb
@@ -32,10 +32,14 @@ module HookContextExtension
   def execute(commands, do_say = true, do_log = true)
     commands = commands.is_a?(Array) ? commands : [commands]
     results = []
+
     commands.each do |command|
       results << execute_command(command, do_say, do_log)
     end
-    !results.include? false
+
+    if results.include? false
+      exit 1
+    end
   end
 
   def execute_command(command, do_say, do_log)

--- a/katello/hooks/post/30-upgrade.rb
+++ b/katello/hooks/post/30-upgrade.rb
@@ -1,13 +1,11 @@
 require 'fileutils'
 
 def db_seed
-  status = execute('foreman-rake db:seed')
-  fail_and_exit "Upgrade failed while seeding the DB" unless status
+  execute('foreman-rake db:seed')
 end
 
 def upgrade_tasks
-  status = execute('foreman-rake upgrade:run')
-  fail_and_exit "Application Upgrade Failed" unless status
+  execute('foreman-rake upgrade:run')
 end
 
 if app_value(:upgrade)

--- a/katello/hooks/pre_validations/31-upgrade-puppet.rb
+++ b/katello/hooks/pre_validations/31-upgrade-puppet.rb
@@ -1,6 +1,6 @@
 unless app_value(:noop)
-  if File.exist?('/opt/puppetlabs/puppet/bin/ruby') && execute("rpm -q puppet-agent-oauth", false, false)
-    unless execute("/opt/puppetlabs/puppet/bin/ruby -e \"require 'oauth'\"", false, false)
+  if File.exist?('/opt/puppetlabs/puppet/bin/ruby') && system("rpm -q puppet-agent-oauth")
+    unless system("/opt/puppetlabs/puppet/bin/ruby -e \"require 'oauth'\"")
       execute("yum -y reinstall puppet-agent-oauth")
     end
   end


### PR DESCRIPTION
This makes a change for all commands calling execute that if they fail this will stop execution of the installer. I think this is a safe change given it would stop things like upgrade in its tracks if something fails.