### PR TITLE
Add migration test from post-merge to current

### DIFF
--- a/spec/fixtures/foreman-1.21/katello-answers.yaml
+++ b/spec/fixtures/foreman-1.21/katello-answers.yaml
@@ -1,0 +1,85 @@
+---
+certs:
+  generate: true
+  deploy: true
+  group: foreman
+katello:
+  package_names:
+  - katello
+  - tfm-rubygem-katello
+foreman:
+  initial_organization: Default Organization
+  initial_location: Default Location
+  configure_epel_repo: false
+  configure_scl_repo: false
+  max_keepalive_requests: 10000
+  ssl: true
+  server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+  server_ssl_key: /etc/pki/katello/private/katello-apache.key
+  server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
+  server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
+  server_ssl_crl: ""
+  client_ssl_cert: /etc/foreman/client_cert.pem
+  client_ssl_key: /etc/foreman/client_key.pem
+  client_ssl_ca: /etc/foreman/proxy_ca.pem
+  websockets_encrypt: true
+  websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
+  websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+  passenger_ruby: /usr/bin/tfm-ruby
+  passenger_ruby_package: tfm-rubygem-passenger-native
+  keepalive: true
+foreman_proxy_content:
+  pulp_master: true
+  qpid_router_broker_addr: localhost
+puppet:
+  server: true
+  server_environments_owner: apache
+  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
+foreman_proxy:
+  http: true
+  ssl_port: '9090'
+  templates: true
+  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+  ssl_key: /etc/foreman-proxy/ssl_key.pem
+  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+  manage_puppet_group: false
+foreman_proxy::plugin::pulp:
+  enabled: true
+  pulpnode_enabled: false
+foreman::plugin::ansible: false
+foreman::plugin::bootdisk: false
+foreman::plugin::chef: false
+foreman::plugin::default_hostgroup: false
+foreman::plugin::discovery: false
+foreman::plugin::hooks: false
+foreman::plugin::openscap: false
+foreman::plugin::puppetdb: false
+foreman::plugin::remote_execution: false
+foreman::plugin::setup: false
+foreman::plugin::tasks: true
+foreman::plugin::templates: false
+foreman_proxy::plugin::ansible: false
+foreman_proxy::plugin::chef: false
+foreman_proxy::plugin::dhcp::infoblox: false
+foreman_proxy::plugin::dns::infoblox: false
+foreman_proxy::plugin::openscap: false
+foreman_proxy::plugin::remote_execution::ssh: false
+foreman_proxy::plugin::discovery: false
+foreman::compute::ec2: false
+foreman::compute::gce: false
+foreman::compute::libvirt: false
+foreman::compute::openstack: false
+foreman::compute::ovirt: false
+foreman::compute::rackspace: false
+foreman::compute::vmware: false
+foreman::cli: true
+foreman::cli::openscap: false
+foreman::cli::discovery: false
+foreman::cli::tasks: false
+foreman::cli::templates: false
+foreman::cli::remote_execution: false

--- a/spec/fixtures/foreman-1.21/katello.yaml
+++ b/spec/fixtures/foreman-1.21/katello.yaml
@@ -1,0 +1,28 @@
+---
+:name: Katello
+:description: Install Foreman with Katello
+
+:log_dir: './_build/'
+:log_name: 'katello.log'
+:log_level: DEBUG
+
+:answer_file: ./config/katello-answers.yaml
+:installer_dir: ./katello
+:module_dirs: ./_build/modules
+:parser_cache_path: ./_build/parser_cache/katello.yaml
+:hiera_config: ./_build/foreman-hiera.conf
+
+:order:
+  - certs
+  - foreman
+  - katello
+  - foreman_proxy
+  - foreman_proxy::plugin::pulp
+  - foreman_proxy_content
+  - puppet
+
+# If using the Debian ruby-kafo package, uncomment this
+# :kafo_modules_dir: /usr/lib/ruby/vendor_ruby/kafo/modules
+
+# Unused, but remains present for older config migrations
+:mapping: {}

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -27,13 +27,14 @@ describe 'migrations' do
     end
   end
 
-  %w(foreman-proxy-content katello).each do |scenario_name|
-    context "migrates #{scenario_name} split installer" do
-      let(:config_after) { load_fixture_yaml('merged-installer', "#{scenario_name}-after.yaml") }
+  %w(katello).each do |scenario_name|
+    context "on #{scenario_name} migrated from Foreman 1.21" do
+      let(:answers) { load_config_yaml("#{scenario_name}-answers.yaml") }
+      let(:config) { load_config_yaml("#{scenario_name}.yaml") }
       let(:scenario) do
         {
-          :answers    => load_config_yaml("#{scenario_name}-answers.yaml"),
-          :config     => load_fixture_yaml('merged-installer', "#{scenario_name}-before.yaml"),
+          :answers    => load_fixture_yaml("foreman-1.21", "#{scenario_name}-answers.yaml"),
+          :config     => load_fixture_yaml("foreman-1.21", "#{scenario_name}.yaml"),
           :migrations => config_path("#{scenario_name}.migrations")
         }
       end
@@ -42,7 +43,12 @@ describe 'migrations' do
 
       it 'does not change scenario config' do
         after, = migrator
-        expect(after).to eq config_after
+        expect(config).to eq after
+      end
+
+      it 'does not change scenario answers' do
+        _, after = migrator
+        expect(answers).to eq after
       end
     end
   end


### PR DESCRIPTION
I wanted to explore the idea of testing old config and answers to latest state to ensure nothing is missed. I purposefully only did katello to start and left it failing to show the kinds of things this finds. 

 1) Does this make sense?
 2) Are the things being caught useful?

Is there a more robust test perhaps that can be done with a fully built out answer and config file generated with all parameters? Perhaps both tests would be useful and this is the first step.