### PR TITLE
Refs #28496: Drop upgrade step check on status

### DIFF
--- a/katello/hooks/pre/30-upgrade.rb
+++ b/katello/hooks/pre/30-upgrade.rb
@@ -52,8 +52,7 @@ def upgrade_step(step, options = {})
   if run_always || app_value(:force_upgrade_steps) || !step_ran?(step)
     log_and_say :info, "Upgrade Step: #{step}#{long_running}#{noop}..."
     unless app_value(:noop)
-      status = send(step)
-      fail_and_exit "Upgrade step #{step} failed. Check logs for more information." unless status
+      send(step)
       touch_step(step)
     end
   end


### PR DESCRIPTION
The execute command now exits when it fails so this log statement
can never be reached.