### PR TITLE
Refs #28530 - Correctly set the hook_dirs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -106,6 +106,10 @@ SCENARIOS.each do |scenario|
       'parser_cache_path' => "#{DATADIR}/foreman-installer/parser_cache/#{scenario}.yaml",
     }
 
+    if ['foreman-proxy-content', 'katello'].include?(scenario)
+      scenario_config_replacements['hook_dirs'] = "['#{DATADIR}/foreman-installer/katello/hooks']"
+    end
+
     scenario_config_replacements.each do |setting, value|
       sh 'sed -i "s#\(.*%s:\).*#\1 %s#" %s' % [setting, value, t.name]
     end

--- a/config/foreman-proxy-content.yaml
+++ b/config/foreman-proxy-content.yaml
@@ -9,8 +9,7 @@
 :answer_file: ./config/foreman-proxy-content-answers.yaml
 :installer_dir: .
 :module_dirs: ./_build/modules
-:hook_dirs:
-  - ./katello/hooks
+:hook_dirs: ['./katello/hooks']
 :parser_cache_path: ./_build/parser_cache/foreman-proxy-content.yaml
 :hiera_config: ./config/foreman-hiera.yaml
 :facts:

--- a/config/katello.yaml
+++ b/config/katello.yaml
@@ -9,8 +9,7 @@
 :answer_file: ./config/katello-answers.yaml
 :installer_dir: .
 :module_dirs: ./_build/modules
-:hook_dirs:
-  - ./katello/hooks
+:hook_dirs: ['./katello/hooks']
 :parser_cache_path: ./_build/parser_cache/katello.yaml
 :hiera_config: ./config/foreman-hiera.yaml
 :facts:


### PR DESCRIPTION
3123236437240575416d5e698815151913bbc6db combined the hook dirs, but that broke the actual installation where it stayed as ./katello/hooks instead of /usr/share/foreman-installer/katello/hooks.

0ed385387d953cb1628a7d2e55014cf815f39d98 fixed one part of this, but left this out.