### PR TITLE
Fixes #28738: Reset bind host if :: is present

### DIFF
--- a/config/foreman-proxy-content.migrations/200113133837-reset-bind-host-foreman-proxy.rb
+++ b/config/foreman-proxy-content.migrations/200113133837-reset-bind-host-foreman-proxy.rb
@@ -1,0 +1,7 @@
+if answers['foreman_proxy'].is_a?(Hash) &&
+    answers['foreman_proxy']['bind_host'].is_a?(Array) &&
+    answers['foreman_proxy']['bind_host'].include?('::') &&
+    facts[:os][:release][:major] == '7' &&
+    facts[:os][:family] == 'RedHat'
+  answers['foreman_proxy']['bind_host'].delete
+end

--- a/config/foreman.migrations/20200113133837_reset_bind-host-foreman-proxy.rb
+++ b/config/foreman.migrations/20200113133837_reset_bind-host-foreman-proxy.rb
@@ -1,0 +1,7 @@
+if answers['foreman_proxy'].is_a?(Hash) &&
+    answers['foreman_proxy']['bind_host'].is_a?(Array) &&
+    answers['foreman_proxy']['bind_host'].include?('::') &&
+    facts[:os][:release][:major] == '7' &&
+    facts[:os][:family] == 'RedHat'
+  answers['foreman_proxy']['bind_host'].delete
+end

--- a/config/katello.migrations/200113133837-reset-bind-host-foreman-proxy.rb
+++ b/config/katello.migrations/200113133837-reset-bind-host-foreman-proxy.rb
@@ -1,0 +1,7 @@
+if answers['foreman_proxy'].is_a?(Hash) &&
+    answers['foreman_proxy']['bind_host'].is_a?(Array) &&
+    answers['foreman_proxy']['bind_host'].include?('::') &&
+    facts[:os][:release][:major] == '7' &&
+    facts[:os][:family] == 'RedHat'
+  answers['foreman_proxy']['bind_host'].delete
+end


### PR DESCRIPTION
This is necessary with smart proxy moving away from Ruby 2.0 via
RPM packaging changes to use SCLs.