### PR TITLE
Fixes #28712 - Verify MongoDB is on before upgrade

### DIFF
--- a/katello/hooks/pre_validations/30-mongo_storage_engine.rb
+++ b/katello/hooks/pre_validations/30-mongo_storage_engine.rb
@@ -35,6 +35,10 @@ if app_value(:upgrade_mongo_storage_engine)
     fail_and_exit 'Upgrading is not supported on remote MongoDB database connections' unless mongo_host == 'localhost:27017'
   end
 
+  # Make sure MongoDB is running before start of engine upgrade
+  log_and_say :info, 'Ensuring MongoDB is running before upgrade.'
+  execute('foreman-maintain service start --only rh-mongodb34-mongod')
+
   log_and_say :info, "Starting disk space check for upgrade"
   disk_space
 end


### PR DESCRIPTION
This PR addresses an issue where if MongoDB is not running before the storage engine upgrade, we blow away the database leaving the system in a bad state.

To test I had to spin up a Satellite 6.3 and populated it with content and upgraded it all the way to 6.6

Tested on 6.6 with both MongoDB running before starting the upgrade and with it off and it worked correctly.

The only difference between downstream and upstream was the following:

`Kafo::Helpers.` instead of just `execute('blah')`

didn't use `Kafo::Helpers.execute` for the service status because it creates a nasty red error if the service is not running defaulted to `systemctl`. Didn't use `foreman-maintain` for the service status because it dumps all this in the console:
```ruby

Running Status Services
================================================================================
Get status of applicable services: Displaying the following service(s):

rh-mongodb34-mongod
\ displaying rh-mongodb34-mongod
● rh-mongodb34-mongod.service - High-performance, schema-free document-oriented database
   Loaded: loaded (/usr/lib/systemd/system/rh-mongodb34-mongod.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Fri 2020-01-10 11:13:56 EST; 1min 55s ago
 Main PID: 42582 (code=exited, status=0/SUCCESS)

Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [signalProcessingThread] journalCleanup...
Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [signalProcessingThread] removeJournalFiles
Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [signalProcessingThread] old journal file will be removed: /var/lib/mongodb/journal/j._0
Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [signalProcessingThread] Terminating durability thread ...
Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [journal writer] Journal writer thread stopped
Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [durability] Durability thread stopped
Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [signalProcessingThread] shutdown: closing all files...
Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [signalProcessingThread] closeAllFiles() finished
Jan 10 11:13:56 mongo.katello.lan mongod.27017[42582]: [signalProcessingThread] shutdown: removing fs lock...
Jan 10 11:13:56 mongo.katello.lan systemd[1]: Stopped High-performance, schema-free document-oriented database.
\ All services displayed                                              [FAIL]
Some services are not running (rh-mongodb34-mongod)
--------------------------------------------------------------------------------
Scenario [Status Services] failed.

The following steps ended up in failing state:

  [service-status]

Resolve the failed steps and rerun
the command. In case the failures are false positives,
use --whitelist="service-status"

foreman-maintain service status --only rh-mongodb34-mongod failed! Check the output for error!
[ERROR 2020-01-10T11:15:52 verbose] foreman-maintain service status --only rh-mongodb34-mongod failed! Check the output for error!
```