### PR TITLE
Refs #28549: Turn message helpers into hook extensions

### DIFF
--- a/hooks/boot/02-message-helpers.rb
+++ b/hooks/boot/02-message-helpers.rb
@@ -1,54 +1,52 @@
-class Kafo
-  class MessageHelpers
-    class << self
-      def success_message
-        say "  <%= color('Success!', :good) %>"
-      end
+module MessageHookContextExtension
+  def success_message
+    say "  <%= color('Success!', :good) %>"
+  end
 
-      def server_success_message(kafo)
-        success_message
-        say "  * <%= color('Foreman', :info) %> is running at <%= color('#{kafo.param('foreman', 'foreman_url').value}', :info) %>"
-      end
+  def server_success_message(kafo)
+    success_message
+    say "  * <%= color('Foreman', :info) %> is running at <%= color('#{kafo.param('foreman', 'foreman_url').value}', :info) %>"
+  end
 
-      def dev_server_success_message(kafo)
-        success_message
-        say "  * To run the <%= color('Katello', :info) %> dev server log in using SSH"
-        say "  * Run `cd foreman && bundle exec foreman start`"
-        say "  * The server is running at <%= color('https://#{`hostname -f`}', :info) %>"
-        if kafo.param('katello_devel', 'webpack_dev_server').value
-          say "  * On Firefox you need to accept the certificate at <%= color('https://#{`hostname -f`}:3808', :info) %>"
-        end
-      end
-
-      def certs_generate_command_message
-        say <<MSG
-    * To install an additional Foreman proxy on separate machine continue by running:
-
-        foreman-proxy-certs-generate --foreman-proxy-fqdn "<%= color('$FOREMAN_PROXY', :info) %>" --certs-tar "<%= color('/root/$FOREMAN_PROXY-certs.tar', :info) %>"
-MSG
-      end
-
-      def proxy_success_message(kafo)
-        success_message
-        foreman_proxy_url = kafo.param('foreman_proxy', 'registered_proxy_url').value || "https://#{kafo.param('foreman_proxy', 'registered_name').value}:#{kafo.param('foreman_proxy', 'ssl_port').value}"
-        say "  * <%= color('Foreman Proxy', :info) %> is running at <%= color('#{foreman_proxy_url}', :info) %>"
-      end
-
-      def new_install_message(kafo)
-        say "      Initial credentials are <%= color('#{kafo.param('foreman', 'initial_admin_username').value}', :info) %> / <%= color('#{kafo.param('foreman', 'initial_admin_password').value}', :info) %>"
-      end
-
-      def dev_new_install_message(kafo)
-        say "      Initial credentials are <%= color('admin', :info) %> / <%= color('#{kafo.param('katello_devel', 'admin_password').value}', :info) %>"
-      end
-
-      def failure_message
-        say "  <%= color('Something went wrong!', :bad) %> Check the log for ERROR-level output"
-      end
-
-      def log_message(kafo)
-        say "  The full log is at <%= color('#{kafo.config.log_file}', :info) %>"
-      end
+  def dev_server_success_message(kafo)
+    success_message
+    say "  * To run the <%= color('Katello', :info) %> dev server log in using SSH"
+    say "  * Run `cd foreman && bundle exec foreman start`"
+    say "  * The server is running at <%= color('https://#{`hostname -f`}', :info) %>"
+    if kafo.param('katello_devel', 'webpack_dev_server').value
+      say "  * On Firefox you need to accept the certificate at <%= color('https://#{`hostname -f`}:3808', :info) %>"
     end
   end
+
+  def certs_generate_command_message
+    say <<MSG
+* To install an additional Foreman proxy on separate machine continue by running:
+
+    foreman-proxy-certs-generate --foreman-proxy-fqdn "<%= color('$FOREMAN_PROXY', :info) %>" --certs-tar "<%= color('/root/$FOREMAN_PROXY-certs.tar', :info) %>"
+MSG
+  end
+
+  def proxy_success_message(kafo)
+    success_message
+    foreman_proxy_url = kafo.param('foreman_proxy', 'registered_proxy_url').value || "https://#{kafo.param('foreman_proxy', 'registered_name').value}:#{kafo.param('foreman_proxy', 'ssl_port').value}"
+    say "  * <%= color('Foreman Proxy', :info) %> is running at <%= color('#{foreman_proxy_url}', :info) %>"
+  end
+
+  def new_install_message(kafo)
+    say "      Initial credentials are <%= color('#{kafo.param('foreman', 'initial_admin_username').value}', :info) %> / <%= color('#{kafo.param('foreman', 'initial_admin_password').value}', :info) %>"
+  end
+
+  def dev_new_install_message(kafo)
+    say "      Initial credentials are <%= color('admin', :info) %> / <%= color('#{kafo.param('katello_devel', 'admin_password').value}', :info) %>"
+  end
+
+  def failure_message
+    say "  <%= color('Something went wrong!', :bad) %> Check the log for ERROR-level output"
+  end
+
+  def log_message(kafo)
+    say "  The full log is at <%= color('#{kafo.config.log_file}', :info) %>"
+  end
 end
+
+Kafo::HookContext.send(:include, MessageHookContextExtension)

--- a/hooks/boot/02-message-helpers.rb
+++ b/hooks/boot/02-message-helpers.rb
@@ -20,9 +20,9 @@ module MessageHookContextExtension
 
   def certs_generate_command_message
     say <<MSG
-* To install an additional Foreman proxy on separate machine continue by running:
+  * To install an additional Foreman proxy on separate machine continue by running:
 
-    foreman-proxy-certs-generate --foreman-proxy-fqdn "<%= color('$FOREMAN_PROXY', :info) %>" --certs-tar "<%= color('/root/$FOREMAN_PROXY-certs.tar', :info) %>"
+      foreman-proxy-certs-generate --foreman-proxy-fqdn "<%= color('$FOREMAN_PROXY', :info) %>" --certs-tar "<%= color('/root/$FOREMAN_PROXY-certs.tar', :info) %>"
 MSG
   end
 

--- a/hooks/post/10-post_install_message.rb
+++ b/hooks/post/10-post_install_message.rb
@@ -2,25 +2,25 @@
 if [0, 2].include? @kafo.exit_code
   # Foreman UI?
   if module_enabled? 'foreman'
-    Kafo::MessageHelpers.server_success_message(@kafo)
-    Kafo::MessageHelpers.new_install_message(@kafo) if new_install?
+    server_success_message(@kafo)
+    new_install_message(@kafo) if new_install?
   end
 
   if module_enabled?('katello')
-    Kafo::MessageHelpers.certs_generate_command_message
+    certs_generate_command_message
   end
 
   if module_enabled?('katello_devel')
-    Kafo::MessageHelpers.dev_server_success_message(@kafo)
-    Kafo::MessageHelpers.dev_new_install_message(@kafo) if new_install?
+    dev_server_success_message(@kafo)
+    dev_new_install_message(@kafo) if new_install?
   end
 
   # Proxy?
   if module_enabled? 'foreman_proxy'
-    Kafo::MessageHelpers.proxy_success_message(@kafo)
+    proxy_success_message(@kafo)
   end
 else
-  Kafo::MessageHelpers.failure_message
+  failure_message
 end
 
-Kafo::MessageHelpers.log_message(@kafo)
+log_message(@kafo)


### PR DESCRIPTION
This fixes issue seen in nightly from Rubocop changes.