### PR TITLE
Fixes #28839 - Reset pulpcore db with reset

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -41,7 +41,11 @@ module HookContextExtension
   end
 
   def local_redis?
-    (foreman_server? && !param_value('foreman', 'jobs_sidekiq_redis_url')) || param_value('foreman_proxy::plugin::pulp', 'pulpcore_enabled') || devel_scenario?
+    (foreman_server? && !param_value('foreman', 'jobs_sidekiq_redis_url')) || pulpcore_enabled? || devel_scenario?
+  end
+
+  def pulpcore_enabled?
+    param_value('foreman_proxy_plugin_pulp', 'pulpcore_enabled')
   end
 
   def needs_postgresql_scl_upgrade?


### PR DESCRIPTION
To test:
1. Spin up a nightly.
2. Run foreman-installer --foreman-proxy-plugin-pulp-pulpcore-enabled=true on the nightly box to enable pulpcore.
3. Pull in these changes. I did these changes directly on the installed foreman-installer files on the nightly under /usr/share/foreman-installer
4. Run foreman-installer --reset

You will need to be on the latest foreman-maintain.
