### PR TITLE
Refs #28697 - Use systemctl instead of foreman-maintain

### DIFF
--- a/hooks/pre/30-el7_upgrade_postgresql.rb
+++ b/hooks/pre/30-el7_upgrade_postgresql.rb
@@ -1,5 +1,5 @@
 def postgresql_12_upgrade
-  execute('foreman-maintain service start --only=postgresql')
+  execute('systemctl start postgresql')
   (_name, _owner, _enconding, collate, ctype, _privileges) = `runuser postgres -c 'psql -lt | grep -E "^\s+postgres"'`.chomp.split('|').map(&:strip)
   execute('foreman-maintain service stop')
   ensure_package('rh-postgresql12-postgresql-server', 'installed')


### PR DESCRIPTION
The benefit of this is that systemctl is quiet where foreman-maintain is very noisy. It also avoids the overhead of Ruby just to start a service that's already known.