### PR TITLE
Refs #28928 - Remove checkpoint_segments from tuning

### DIFF
--- a/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
@@ -12,6 +12,5 @@ postgresql::server::config_entries:
   max_connections: 1000
   shared_buffers: 32GB
   work_mem: 8MB
-  checkpoint_segments: 32
   effective_cache_size: 32GB
   autovacuum_vacuum_cost_limit: 2000

--- a/config/foreman.hiera/tuning/sizes/extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-large.yaml
@@ -12,6 +12,5 @@ postgresql::server::config_entries:
   max_connections: 1000
   shared_buffers: 16GB
   work_mem: 8MB
-  checkpoint_segments: 32
   effective_cache_size: 32GB
   autovacuum_vacuum_cost_limit: 2000

--- a/config/foreman.hiera/tuning/sizes/large.yaml
+++ b/config/foreman.hiera/tuning/sizes/large.yaml
@@ -9,6 +9,5 @@ apache::mod::prefork::maxrequestsperchild: 4000
 postgresql::server::config_entries:
   max_connections: 1000
   shared_buffers: 8GB
-  checkpoint_segments: 32
   effective_cache_size: 16GB
   autovacuum_vacuum_cost_limit: 2000

--- a/config/foreman.hiera/tuning/sizes/medium.yaml
+++ b/config/foreman.hiera/tuning/sizes/medium.yaml
@@ -9,6 +9,5 @@ apache::mod::prefork::maxrequestsperchild: 4000
 postgresql::server::config_entries:
   max_connections: 1000
   shared_buffers: 4GB
-  checkpoint_segments: 32
   effective_cache_size: 16GB
   autovacuum_vacuum_cost_limit: 2000


### PR DESCRIPTION
The checkpoint_segments setting no longer exists since PostgreSQL 10 and the server fails to start up if it's present.

This is not a complete fix since it doesn't clean it up on existing installations which can break upgrades.