### PR TITLE
Use a more expressive rspec test syntax

### DIFF
--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -17,7 +17,7 @@ describe 'Puppet module' do
 
       VERSIONS.each do |puppet_version|
         it "should support Puppet #{puppet_version}" do
-          expect(puppet_requirement.include?(puppet_version)).to be true
+          expect(puppet_requirement).to include(puppet_version)
         end
       end
     end


### PR DESCRIPTION
This results in a more readable failure:

    1) Puppet module mymodule should support Puppet 6.0.0
       Failure/Error: expect(puppet_requirement).to include(puppet_version)
         expected >=5.5.10 <6.0.0 to include 6.0.0
       # ./spec/puppet_version_spec.rb:28:in `block (5 levels) in <top (required)>'