### PR TITLE
Assert distribution support

### DIFF
--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -2,6 +2,12 @@ require 'json'
 require 'semantic_puppet'
 
 SUPPORTED_PUPPET_VERSIONS = ['7.9.0', '8.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
+SUPPORTED_DISTROS = {
+  'CentOS' => ['8', '9'],
+  'Debian' => ['11'],
+  'RedHat' => ['8', '9'],
+  'Ubuntu' => ['20.04'],
+}
 
 describe 'Puppet module' do
   Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|
@@ -14,10 +20,33 @@ describe 'Puppet module' do
         version_requirement ||= '>= 0'
         SemanticPuppet::VersionRange.parse(version_requirement)
       end
+      let(:operatingsystem_support) { metadata['operatingsystem_support'] }
 
       SUPPORTED_PUPPET_VERSIONS.each do |puppet_version|
         it "supports Puppet #{puppet_version}" do
           expect(puppet_requirement).to include(puppet_version)
+        end
+      end
+
+      SUPPORTED_DISTROS.each do |distro, versions|
+        versions.each do |version|
+          it "should support #{distro} #{version}" do
+            if operatingsystem_support.nil?
+              skip "No OS support listed"
+            end
+
+            distro_versions = operatingsystem_support.find { |os| os['operatingsystem'] == distro }
+
+            if distro_versions.nil?
+              skip "Distribution #{distro} is not supported"
+            end
+
+            unless distro_versions.key?('operatingsystemrelease')
+              skip "No specific distribution versions listed"
+            end
+
+            expect(distro_versions['operatingsystemrelease']).to include(version)
+          end
         end
       end
     end


### PR DESCRIPTION
This takes the approach that if a distribution is supported, it should support certain versions that Foreman supports.

Currently this fails because not all modules mark the distributions as supported. This is an effort to ensure a platform is supported when we add it. Below is a list of current failures:

* [x] Puppet module puppetdb should support Debian 10 - module removed
* [x] Puppet module augeasproviders_core should support CentOS 7 / Debian 10 - https://github.com/hercules-team/augeasproviders_core/pull/21
* [x] Puppet module augeasproviders_sysctl should support Debian 10 - https://github.com/hercules-team/augeasproviders_sysctl/pull/39
* [x] Puppet module extlib should support Debian 10 - https://github.com/voxpupuli/puppet-extlib/pull/154
* [x] Puppet module foreman_proxy should support CentOS 8 - https://github.com/theforeman/puppet-foreman_proxy/pull/582
* [x] Puppet module inifile should support Debian 10 - can't use 4.x due to puppetdb
* [x] Puppet module mongodb should support CentOS 8 / Debian 10 - WONTFIX, irrelevant
* [x] Puppet module pulp should support CentOS 8 - WONTFIX, irrelevant
* [x] Puppet module puppet should support CentOS 8 - https://github.com/theforeman/puppet-puppet/pull/742
* [x] Puppet module qpid should support CentOS 8 - WONTFIX, irrelevant
* [x] Puppet module redis should support Debian 10 - https://github.com/voxpupuli/puppet-redis/pull/338
* [x] Puppet module squid should support CentOS 8 / Debian 10 / Ubuntu 18.04 - in git master but irrelevant
* [x] Puppet module translate should support CentOS 7 / Ubuntu 18.04 - https://github.com/puppetlabs/puppetlabs-translate/pull/70
* [x] Puppet module trusted_ca should support Debian 10 - https://github.com/voxpupuli/puppet-trusted_ca/pull/21