### PR TITLE
Refs #28915 - Only run upgrade if the installer ran

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -1,3 +1,3 @@
-if foreman_server?
+if !app_value(:noop) && [0, 2].include?(@kafo.exit_code) && foreman_server?
   execute('foreman-rake upgrade:run')
 end


### PR DESCRIPTION
If the user passed in --noop, no upgrade should take place. When the install failed, there's also no point in running the upgrades.