### PR TITLE
Fixes #28903 - Stop installer when package install fails

### DIFF
--- a/hooks/pre/30-el7_upgrade_postgresql.rb
+++ b/hooks/pre/30-el7_upgrade_postgresql.rb
@@ -2,17 +2,17 @@ def postgresql_12_upgrade
   execute('foreman-maintain service start --only=postgresql')
   (_name, _owner, _enconding, collate, ctype, _privileges) = `runuser postgres -c 'psql -lt | grep -E "^\s+postgres"'`.chomp.split('|').map(&:strip)
   execute('foreman-maintain service stop')
-  ensure_package('rh-postgresql12-postgresql-server', 'installed')
 
+  server_packages = ['rh-postgresql12-postgresql-server']
   if execute_command("rpm -q postgresql-contrib", false, false)
-    ensure_package('rh-postgresql12-postgresql-contrib', 'installed')
+    server_packages << 'rh-postgresql12-postgresql-contrib'
   end
+  ensure_packages(server_packages, 'installed')
 
   execute(%(scl enable rh-postgresql12 "PGSETUP_INITDB_OPTIONS='--lc-collate=#{collate} --lc-ctype=#{ctype} --locale=#{collate}' postgresql-setup --upgrade"))
-  ensure_package('postgresql-server', 'absent')
-  ensure_package('postgresql', 'absent')
+  ensure_packages(['postgresql', 'postgresql-server'], 'absent')
   execute('rm -f /etc/systemd/system/postgresql.service')
-  ensure_package('rh-postgresql12-syspaths', 'installed')
+  ensure_packages(['rh-postgresql12-syspaths'], 'installed')
 end
 
 if local_postgresql? && el7? && foreman_server? && needs_postgresql_scl_upgrade?

--- a/hooks/pre/30-install_redis_scl.rb
+++ b/hooks/pre/30-install_redis_scl.rb
@@ -1,4 +1,0 @@
-# Working around https://tickets.puppetlabs.com/browse/PUP-2169
-if el7? && local_redis?
-  ensure_package('rh-redis5-redis', 'installed')
-end

--- a/hooks/pre/31-el7_install_postgresql.rb
+++ b/hooks/pre/31-el7_install_postgresql.rb
@@ -1,4 +1,0 @@
-# Working around https://tickets.puppetlabs.com/browse/PUP-2169
-if local_postgresql? && el7?
-  ensure_package('rh-postgresql12-postgresql-server', 'installed')
-end

--- a/hooks/pre/31_install_scl_packages.rb
+++ b/hooks/pre/31_install_scl_packages.rb
@@ -1,0 +1,7 @@
+# Working around https://tickets.puppetlabs.com/browse/PUP-2169
+if el7?
+  packages = []
+  packages << 'rh-postgresql12-postgresql-server' if local_postgresql?
+  packages << 'rh-redis5-redis' if local_redis?
+  ensure_packages(packages, 'installed')
+end

--- a/spec/hook_context_spec.rb
+++ b/spec/hook_context_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+require 'kafo/hook_context'
+require_relative '../hooks/boot/01-kafo-hook-extensions'
+
+describe 'HookContextExtension' do
+  let(:kafo) { instance_double('KafoConfigure') }
+  let(:logger) { instance_double('Logger') }
+  let(:context) { Kafo::HookContext.new(kafo) }
+
+  before do
+    allow(context).to receive(:logger).and_return(logger)
+  end
+
+  context 'ensure_packages' do
+    let(:state) { 'installed' }
+    subject { context.ensure_packages(packages, state) }
+
+    context 'no packages' do
+      let(:packages) { [] }
+
+      it 'returns without performing any action' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'with packages' do
+      let(:stdout) { '  StdOut    ' }
+      let(:stderr) { ' StdErr  ' }
+      let(:status) { instance_double('Process::Status', exitstatus: exitstatus) }
+      let(:exitstatus) { nil }
+
+      before do
+        allow(logger).to receive(:info)
+        allow(context).to receive(:apply_puppet_code).and_return([stdout, stderr, status])
+      end
+
+      context 'single package' do
+        let(:packages) { ['vim-enhanced'] }
+
+        [0, 2].each do |code|
+          context "exit code #{code}" do
+            let(:exitstatus) { code }
+
+            it 'calls Puppet successfully' do
+              is_expected.to be_nil
+
+              expect(logger).to have_received(:info).with('Ensuring vim-enhanced to package state installed')
+              expect(context).to have_received(:apply_puppet_code).with("package { ['vim-enhanced']: ensure => installed }")
+            end
+          end
+        end
+
+        context 'exit code 1' do
+          let(:exitstatus) { 1 }
+
+          before do
+            allow(context).to receive(:log_and_say)
+            allow(logger).to receive(:debug)
+            allow(context).to receive(:exit)
+          end
+
+          it 'calls Puppet, informs the user and exits' do
+            is_expected.to be_nil
+
+            expect(context).to have_received(:log_and_say).with(:error, 'Failed to ensure vim-enhanced is installed')
+            expect(context).to have_received(:log_and_say).with(:error, 'StdErr')
+            expect(logger).to have_received(:debug).with('StdOut')
+            expect(logger).to have_received(:debug).with('Exit status is 1')
+            expect(context).to have_received(:exit).with(1)
+          end
+        end
+      end
+
+      context 'multiple packages' do
+        let(:packages) { ['vim-enhanced', 'emacs'] }
+
+        before { allow(logger).to receive(:info) }
+
+        [0, 2].each do |code|
+          context "exit code #{code}" do
+            let(:exitstatus) { code }
+
+            it 'calls Puppet successfully' do
+              is_expected.to be_nil
+
+              expect(logger).to have_received(:info).with('Ensuring vim-enhanced, emacs to package state installed')
+              expect(context).to have_received(:apply_puppet_code).with("package { ['vim-enhanced', 'emacs']: ensure => installed }")
+            end
+          end
+        end
+
+        context 'exit code 1' do
+          let(:exitstatus) { 1 }
+
+          before do
+            allow(context).to receive(:log_and_say)
+            allow(logger).to receive(:debug)
+            allow(context).to receive(:exit)
+          end
+
+          it 'calls Puppet, informs the user and exits' do
+            is_expected.to be_nil
+
+            expect(context).to have_received(:log_and_say).with(:error, 'Failed to ensure vim-enhanced, emacs are installed')
+            expect(context).to have_received(:log_and_say).with(:error, 'StdErr')
+            expect(logger).to have_received(:debug).with('StdOut')
+            expect(logger).to have_received(:debug).with('Exit status is 1')
+            expect(context).to have_received(:exit).with(1)
+          end
+        end
+      end
+    end
+
+    context 'apply_puppet_code' do
+      subject { context.apply_puppet_code(code) }
+
+      before do
+        allow(Kafo::PuppetCommand).to receive(:search_puppet_path).with('puppet').and_return('/bin/puppet')
+        allow(Open3).to receive(:capture3).and_return('result')
+      end
+
+      after do
+        expect(Kafo::PuppetCommand).to have_received(:search_puppet_path)
+      end
+
+      context 'empty code' do
+        let(:code) { '' }
+
+        specify do
+          is_expected.to eq('result')
+          expect(Open3).to have_received(:capture3).with('echo "" | /bin/puppet apply --detailed-exitcodes')
+        end
+      end
+
+      context 'some code' do
+        let(:code) { "package { 'vim-enhanced': ensure => installed }" }
+
+        specify do
+          is_expected.to eq('result')
+          expect(Open3).to have_received(:capture3).with('echo "package { \'vim-enhanced\': ensure => installed }" | /bin/puppet apply --detailed-exitcodes')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The puppet resource command always exits with code 0, even when the package failed to install. This approach uses puppet apply with detailed exit codes to detect when it failed. It also unifies all PUP-2169 workarounds in a single file and execution.

This is a draft because it's untested.