### PR TITLE
Fixes #29243: Create new install file

### DIFF
--- a/hooks/post/99-post_install_message.rb
+++ b/hooks/post/99-post_install_message.rb
@@ -24,4 +24,5 @@ else
   failure_message
 end
 
+File.write(success_file, '') if !app_value(:noop) && new_install?
 log_message(@kafo)


### PR DESCRIPTION
Fixes regression where new install messages are being printed
all the time rather than only on new installs.