### PR TITLE
Refs #29069 - Install pulpcore-selinux if needed

### DIFF
--- a/hooks/pre/31_install_scl_packages.rb
+++ b/hooks/pre/31_install_scl_packages.rb
@@ -3,5 +3,6 @@ if el7?
   packages = []
   packages << 'rh-postgresql12-postgresql-server' if local_postgresql?
   packages << 'rh-redis5-redis' if local_redis?
+  packages << 'pulpcore-selinux' if pulpcore_enabled?
   ensure_packages(packages, 'installed')
 end


### PR DESCRIPTION
To work around PUP-2169, the selinux contexts need to be present before the main Puppet run. Because pulpcore-selinux depends on python3-pulpcore, the foreman-installer-katello package can't depend on it.