### PR TITLE
Refs #28903 - Swap the postgresql{,-server} removal

### DIFF
--- a/hooks/pre/30-el7_upgrade_postgresql.rb
+++ b/hooks/pre/30-el7_upgrade_postgresql.rb
@@ -10,7 +10,8 @@ def postgresql_12_upgrade
   ensure_packages(server_packages, 'installed')
 
   execute(%(scl enable rh-postgresql12 "PGSETUP_INITDB_OPTIONS='--lc-collate=#{collate} --lc-ctype=#{ctype} --locale=#{collate}' postgresql-setup --upgrade"))
-  ensure_packages(['postgresql', 'postgresql-server'], 'absent')
+  ensure_packages(['postgresql-server'], 'absent')
+  ensure_packages(['postgresql'], 'absent')
   execute('rm -f /etc/systemd/system/postgresql.service')
   ensure_packages(['rh-postgresql12-syspaths'], 'installed')
 end


### PR DESCRIPTION
postgresql can't be removed until postgresql-server is removed. 72d7c3f67fd4e1b131871c946d03808c9d26a124 swapped the order. This swaps the order around.