### PR TITLE
Fixes #28799: Allow calling puppet from inside SCL context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'kafo', '~> 4.0'
+gem 'kafo', '~> 4.1'
 gem 'librarian-puppet'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 6.0'
 if RUBY_VERSION < '2.1'

--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -33,7 +33,7 @@ module HookContextExtension
 
   def apply_puppet_code(code)
     bin_path = Kafo::PuppetCommand.search_puppet_path('puppet')
-    Open3.capture3("echo \"#{code}\" | #{bin_path} apply --detailed-exitcodes")
+    Open3.capture3(*Kafo::PuppetCommand.format_command("echo \"#{code}\" | #{bin_path} apply --detailed-exitcodes"))
   end
 
   def fail_and_exit(message, code = 1)

--- a/spec/hook_context_spec.rb
+++ b/spec/hook_context_spec.rb
@@ -120,7 +120,7 @@ describe 'HookContextExtension' do
       end
 
       after do
-        expect(Kafo::PuppetCommand).to have_received(:search_puppet_path)
+        expect(Kafo::PuppetCommand).to have_received(:search_puppet_path).twice
       end
 
       context 'empty code' do
@@ -128,7 +128,7 @@ describe 'HookContextExtension' do
 
         specify do
           is_expected.to eq('result')
-          expect(Open3).to have_received(:capture3).with('echo "" | /bin/puppet apply --detailed-exitcodes')
+          expect(Open3).to have_received(:capture3).with(anything, 'echo "" | /bin/puppet apply --detailed-exitcodes', anything)
         end
       end
 
@@ -137,7 +137,7 @@ describe 'HookContextExtension' do
 
         specify do
           is_expected.to eq('result')
-          expect(Open3).to have_received(:capture3).with('echo "package { \'vim-enhanced\': ensure => installed }" | /bin/puppet apply --detailed-exitcodes')
+          expect(Open3).to have_received(:capture3).with(anything, 'echo "package { \'vim-enhanced\': ensure => installed }" | /bin/puppet apply --detailed-exitcodes', anything)
         end
       end
     end


### PR DESCRIPTION
There are a series of changes needed to run the installer within an SCL Ruby context which would allow us to drop older Ruby support all together. This stems from a need to unset the environment and break out of SCL jail to run commands from the Puppet Ruby environment. The set of changes is listed here. There is of course packaging changes required as well that I will include once I have a PR up to show what is required to make this change.

 * https://github.com/theforeman/kafo/pull/250
 * https://github.com/theforeman/kafo_parsers/pull/37

The relevant EL7 packaging changes that would go with it:

 * https://github.com/theforeman/foreman-packaging/pull/4858