### PR TITLE
Revert "Fixes #29282: Add migration to enable Puma"

### DIFF
--- a/config/foreman.migrations/20200305172758_enable_puma.rb
+++ b/config/foreman.migrations/20200305172758_enable_puma.rb
@@ -1,1 +1,0 @@
-answers['foreman']['passenger'] = false if answers['foreman'].is_a?(Hash) && answers['foreman']['passenger']

--- a/config/katello.migrations/200306192827-enable_puma.rb
+++ b/config/katello.migrations/200306192827-enable_puma.rb
@@ -1,1 +1,0 @@
-answers['foreman']['passenger'] = false if answers['foreman'].is_a?(Hash) && answers['foreman']['passenger']


### PR DESCRIPTION
This reverts commit 0b244f5623889585eb2b1a16a20ef659ebd2195f.

This currently doesn't work because systemctl start foreman returns immediately, even before the service is up. Essentially it's a race condition which for some reason this isn't an issue in installation.

There are two possible solutions to make this reliable: switch from the service type simple to notify. However, the puma-plugin-systemd is unmaintained and incompatible with the currently used puma version. The other solution is systemd socket activation where systemd immediately opens a socket that blocks until it's started up. This should work, but the SCL tooling is proving to complicate this.

To unblock the current nightly packages, a short term revert is in order while we work on the proper solution.