### PR TITLE
Fixes #29425 - Configure default mongo cache size

### DIFF
--- a/config/foreman.hiera/tuning/common.yaml
+++ b/config/foreman.hiera/tuning/common.yaml
@@ -22,3 +22,6 @@ postgresql::server::config_entries:
   log_line_prefix: '%t '
   log_min_duration_statement: 1000
   log_rotation_size: 200000
+
+mongodb::server::config_data:
+  storage.wiredTiger.engineConfig.cacheSizeGB: "%{facts.kafo.scenario.custom.mongo_cache_size}"


### PR DESCRIPTION
Configuring default mongo cache size to 20% of total memory. See[1]
Otherwise mongo goes onto consume about 50% of total memory. See[2]

[1] https://access.redhat.com/solutions/4505561
[2] https://docs.mongodb.com/manual/core/wiredtiger/#memory-use