### PR TITLE
Fixes #29437 - Drop PuppetDB module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,7 +2,6 @@ forge 'https://forgeapi.puppetlabs.com/'
 
 # Dependencies
 mod 'puppetlabs/postgresql',         '>= 5.6.0'
-mod 'puppetlabs/puppetdb'
 mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'
 mod 'theforeman/git',                :git => 'https://github.com/theforeman/puppet-git'


### PR DESCRIPTION
The intent was to make it possible to install PuppetDB but there’s no documentation, it’s tricky to set up and we don’t verify it (it may actually be broken). Adding to that, its maintainers are largely unresponsive. Adding support for new distribution versions and other module versions is very painful.