### PR TITLE
Readd "Fixes #29282: Add migration to enable Puma"

### DIFF
--- a/config/foreman.migrations/20200305172758_enable_puma.rb
+++ b/config/foreman.migrations/20200305172758_enable_puma.rb
@@ -1,0 +1,1 @@
+answers['foreman']['passenger'] = false if answers['foreman'].is_a?(Hash) && answers['foreman']['passenger']

--- a/config/katello.migrations/200306192827-enable_puma.rb
+++ b/config/katello.migrations/200306192827-enable_puma.rb
@@ -1,0 +1,1 @@
+answers['foreman']['passenger'] = false if answers['foreman'].is_a?(Hash) && answers['foreman']['passenger']


### PR DESCRIPTION
The commit bd02fbd reverted commit 0b244f5.

https://github.com/theforeman/puppet-foreman/pull/814 fixed the race
condition of systemctl start foreman returning immediately before the
service was up.