### PR TITLE
Add pulpcore data reset feature

### DIFF
--- a/katello/hooks/boot/11-clear_pulpcore_data_hook.rb
+++ b/katello/hooks/boot/11-clear_pulpcore_data_hook.rb
@@ -1,0 +1,7 @@
+# Add reset option
+app_option(
+  '--clear-pulpcore-content',
+  :flag,
+  'This option will clear all Pulpcore content from disk located in \'/var/lib/pulp/docroot/\'.',
+  :default => false
+)

--- a/katello/hooks/pre/11-clear_pulpcore_data_feature.rb
+++ b/katello/hooks/pre/11-clear_pulpcore_data_feature.rb
@@ -1,0 +1,12 @@
+# See bottom of the script for the command that kicks off the script
+
+def clear_pulpcore_content
+  if File.directory?('/var/lib/pulp/docroot')
+    FileUtils.rm_rf(Dir.glob("/var/lib/pulp/docroot/*"))
+    logger.info 'Pulpcore content successfully removed.'
+  else
+    logger.warn 'Pulpcore content directory not present at \'/var/lib/pulp/docroot\''
+  end
+end
+
+clear_pulpcore_content if app_value(:clear_pulpcore_content) && !app_value(:noop) && module_enabled?('foreman_proxy_content')


### PR DESCRIPTION
The `docroot` directory stores all of the pulpcore content as artifacts.  This should happen only after a pulp database reset, which seems to be the case.

Questions: 
Is the `app_value(:clear_pulpcore_content)` okay? I'm not sure where it comes from, perhaps as a command line argument?