### PR TITLE
Fixes #29894 - Only write the success file on success

### DIFF
--- a/hooks/post/99-post_install_message.rb
+++ b/hooks/post/99-post_install_message.rb
@@ -20,9 +20,10 @@ if [0, 2].include? @kafo.exit_code
   if module_enabled? 'foreman_proxy'
     proxy_success_message(@kafo)
   end
+
+  File.write(success_file, '') if !app_value(:noop) && new_install?
 else
   failure_message
 end
 
-File.write(success_file, '') if !app_value(:noop) && new_install?
 log_message(@kafo)


### PR DESCRIPTION
540638cd3bc295a0f857f87b89863af5db8558b9 introduced a success file, but it's written regardless of success. When the first run fails, the user doesn't see initial credentials on the second (successful) run.