### PR TITLE
Fixes #29941 - Check modules are enabled

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -49,8 +49,16 @@ module HookContextExtension
     module_enabled?('katello_devel')
   end
 
+  def local_foreman_db?
+    foreman_server? && param_value('foreman', 'db_manage')
+  end
+
+  def local_candlepin_db?
+    module_enabled?('katello') && param_value('katello', 'candlepin_manage_db')
+  end
+
   def local_postgresql?
-    param_value('foreman', 'db_manage') || param_value('katello', 'candlepin_manage_db') || devel_scenario?
+    local_foreman_db? || local_candlepin_db? || devel_scenario?
   end
 
   def local_redis?
@@ -58,7 +66,7 @@ module HookContextExtension
   end
 
   def pulpcore_enabled?
-    param_value('foreman_proxy_plugin_pulp', 'pulpcore_enabled')
+    module_enabled?('foreman_proxy_plugin_pulp') && param_value('foreman_proxy_plugin_pulp', 'pulpcore_enabled')
   end
 
   def needs_postgresql_scl_upgrade?

--- a/katello/hooks/pre_commit/05-puppet_certs_exist.rb
+++ b/katello/hooks/pre_commit/05-puppet_certs_exist.rb
@@ -1,4 +1,4 @@
-puppet_ca_enabled = param_value('foreman_proxy', 'puppetca')
+puppet_ca_enabled = module_enabled?('foreman_proxy') && param_value('foreman_proxy', 'puppetca')
 server_crl_path = param_value('foreman', 'server_ssl_crl')
 cert_dir = param_value('foreman_proxy', 'ssldir')
 key_path = param_value('foreman_proxy', 'puppet_ssl_key')


### PR DESCRIPTION
param_value() can return an answer for a disabled module. The result is that PostgreSQL is being installed on a Foreman Proxy when it's not needed.