### PR TITLE
Fixes #30078 Add default_hostgroup plugin for the Katello scenario

### DIFF
--- a/config/foreman.migrations/20200602080100_add_default_hostgroup.rb
+++ b/config/foreman.migrations/20200602080100_add_default_hostgroup.rb
@@ -1,0 +1,1 @@
+answers['foreman::plugin::default_hostgroup'] ||= false

--- a/config/katello.migrations/20200602080100-add-default_hostgroup.rb
+++ b/config/katello.migrations/20200602080100-add-default_hostgroup.rb
@@ -1,0 +1,1 @@
+answers['foreman::plugin::default_hostgroup'] ||= false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -11,6 +11,7 @@ foreman::compute::ovirt: false
 foreman::compute::rackspace: false
 foreman::compute::vmware: false
 foreman::plugin::azure: false
+foreman::plugin::default_hostgroup: false
 foreman::plugin::digitalocean: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::kubevirt: false


### PR DESCRIPTION
Based on the recommendation provided in the support communication
https://community.theforeman.org/t/default-host-group-plugin-config-file-through-the-installer/18797/2