### PR TITLE
Refs #29602 - Remove dropped repository parameters

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -9,8 +9,7 @@
 #
 # See params.pp in each class for what options are available
 ---
-foreman:
-  configure_epel_repo: false
+foreman: {}
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -15,8 +15,6 @@ foreman:
   client_ssl_ca: /etc/foreman/proxy_ca.pem
   client_ssl_cert: /etc/foreman/client_cert.pem
   client_ssl_key: /etc/foreman/client_key.pem
-  configure_epel_repo: false
-  configure_scl_repo: false
   initial_location: Default Location
   initial_organization: Default Organization
   max_keepalive_requests: 10000


### PR DESCRIPTION
Since theforeman-foreman 15.0.0 these parameters no longer exist and by default no repository setup is done.