### PR TITLE
Refs #29097 - Handle command not found

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -107,7 +107,13 @@ module HookContextExtension
   def execute_command(command, do_say, do_log)
     log_and_say(:debug, "Executing: #{command}", do_say, do_log)
 
-    stdout_stderr, status = Open3.capture2e(*Kafo::PuppetCommand.format_command(command))
+    begin
+      stdout_stderr, status = Open3.capture2e(*Kafo::PuppetCommand.format_command(command))
+    rescue Errno::ENOENT
+      log_and_say(:error, "Command #{command} not found", do_say, do_log)
+      return false
+    end
+
     stdout_stderr.lines.map(&:chomp).each do |line|
       log_and_say(:debug, line, do_say, do_log)
     end


### PR DESCRIPTION
44591b97fe11bcb8c55af88309166aab0fa4ac2c started to execute this command using execute_command() which uses open3 under the hood. When a command doesn't exist, Errno::ENOENT is raised; unlike system() which returns false. This catches it and handles the output.

This surfaced on Debian with the Puppet hook:

    /usr/lib/ruby/2.5.0/open3.rb:199:in `spawn': No such file or directory - rpm (Errno::ENOENT)
            from /usr/lib/ruby/2.5.0/open3.rb:199:in `popen_run'
            from /usr/lib/ruby/2.5.0/open3.rb:190:in `popen2e'
            from /usr/lib/ruby/2.5.0/open3.rb:349:in `capture2e'
            from /usr/share/foreman-installer/hooks/boot/01-kafo-hook-extensions.rb:110:in `execute_command'
            from /usr/share/foreman-installer/hooks/pre/31-puppet_agent_oauth.rb:2:in `block (4 levels) in load'

I'm not quite sure why we didn't see this before. Perhaps the recent refactoring here introduced this.