### PR TITLE
Fixes #29296 - remove --upgrade

### DIFF
--- a/katello/hooks/boot/30-upgrade.rb
+++ b/katello/hooks/boot/30-upgrade.rb
@@ -1,6 +1,0 @@
-app_option(
-  '--upgrade',
-  :flag,
-  "Deprecated. The installer will ensure the right state in all cases now. This flag will be removed in a future release.",
-  :default => false
-)

--- a/katello/hooks/pre_validations/29-upgrade.rb
+++ b/katello/hooks/pre_validations/29-upgrade.rb
@@ -1,3 +1,0 @@
-if app_value(:upgrade)
-  log_and_say(:warn, 'The --upgrade option has been removed. The installer will ensure the system is in the right state. The use of --upgrade is no longer needed.')
-end


### PR DESCRIPTION
This option currently does nothing except print a notice that `--upgrade` is no longer needed. This PR will remove it entirely.