### PR TITLE
Add module checkout scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ modules/*
 .bundle/
 Gemfile.lock
 config/foreman.migrations/.applied
+workdir/
 .vendor/
 spec/fixtures/katello-certs-check/certs/*.csr
 spec/fixtures/katello-certs-check/ca.key

--- a/bin/checkout-module
+++ b/bin/checkout-module
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configuration part
+
+# This is a git alias for a remote. To configure this, the following can be used:
+#
+# git config url."https://github.com/theforeman".insteadOf ghf:
+# git config url."git@github.com:theforeman/".pushInsteadOf ghf:
+#
+# This sets up fetching over HTTPS and pushing over SSH. Obviously this is just
+# one way. The value can also be modified to a different base URL.
+REPO_BASE_URL="ghf:"
+
+# Script
+
+MODULE="$1"
+BRANCH="${2:-master}"
+
+if [[ -z $MODULE ]] ; then
+	echo "Usage: $0 MODULE [BRANCH]"
+	exit 1
+fi
+
+SHORT_VERSION=$(cut -d. -f1,2 VERSION)
+
+WORKDIR="${PWD}/workdir"
+BARE_CHECKOUT="${WORKDIR}/bare/${MODULE}.git"
+FULL_CHECKOUT="${WORKDIR}/modules/${SHORT_VERSION}/${MODULE}"
+REPO_URL="${REPO_BASE_URL}${MODULE}"
+
+if [[ -d "$BARE_CHECKOUT" ]] ; then
+	git --git-dir "$BARE_CHECKOUT" fetch --quiet
+else
+	git clone --mirror --bare --quiet "$REPO_URL" "$BARE_CHECKOUT"
+fi
+
+# If the stable branch doesn't exist, master is used.
+# TODO: if master has moved on, it would be great if we can detect a branch is needed
+# This can be done by checking if there's a new major version in metadata.json
+if ! git --git-dir "$BARE_CHECKOUT" branch | grep --word-regexp "$BRANCH" --quiet ; then
+	echo "Branch ${BRANCH} does not exist for ${MODULE}; assuming master"
+	BRANCH="master"
+fi
+
+if [[ -d "$FULL_CHECKOUT" ]] ; then
+	( cd "$FULL_CHECKOUT" && git checkout "$BRANCH" )
+else
+	git --git-dir "$BARE_CHECKOUT" worktree add --track -B "$BRANCH" "$FULL_CHECKOUT" "$BRANCH"
+fi

--- a/bin/checkout-modules
+++ b/bin/checkout-modules
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+./bin/module-versions | while read LINE ; do
+	./bin/checkout-module $LINE
+done

--- a/bin/module-versions
+++ b/bin/module-versions
@@ -18,10 +18,10 @@ begin
     author, name = manifest.name.split('-')
     if ['theforeman', 'katello'].include?(author)
       branch = "#{manifest.version.to_s.split('.')[0..1].join('.')}-stable"
-      puts "puppet-#{name} #{manifest.version} #{branch}"
+      puts "puppet-#{name} #{branch} #{manifest.version}"
     end
   end
-rescue ArgumentError => e
-  puts e
+rescue ArgumentError => error
+  STDERR.puts error
   exit 1
 end


### PR DESCRIPTION
This is mainly intended for the stable branches. It allows checking out all modules based on Puppetfile.lock. This is done by having a directory called workdir. Within that there's a directory 'bare' which contains all the modules as bare checkouts. Then in the modules a directory is created for the MAJOR.MINOR version. Within that directory there's a checkout for each module owned by theforeman/Katello.

The output of module-versions is changed to make it easier in the checkout-module script.