### PR TITLE
Refs #29797 - Move interactive part to pre_validations

### DIFF
--- a/hooks/pre/10-reset_data.rb
+++ b/hooks/pre/10-reset_data.rb
@@ -133,12 +133,4 @@ def empty_database!(config)
   execute(pg_sql_statement(config, delete_statements)) if delete_statements
 end
 
-if app_value(:reset_data) && !app_value(:noop)
-  response = ask('Are you sure you want to continue? This will drop the databases, reset all configurations that you have made and bring all application data back to a fresh install. [y/n]')
-  if response.downcase != 'y'
-    $stderr.puts '** cancelled **'
-    exit(1)
-  else
-    reset
-  end
-end
+reset if app_value(:reset_data) && !app_value(:noop)

--- a/hooks/pre_validations/01-reset_data.rb
+++ b/hooks/pre_validations/01-reset_data.rb
@@ -1,0 +1,7 @@
+if app_value(:reset_data) && !app_value(:noop)
+  response = ask('Are you sure you want to continue? This will drop the databases, reset all configurations that you have made and bring all application data back to a fresh install. [y/n]')
+  if response.downcase != 'y'
+    $stderr.puts '** cancelled **'
+    exit(1)
+  end
+end


### PR DESCRIPTION
In the pre phase everything has been committed to disk. It should never call exit based on user input. By moving the interactive part of pre_validations, the user is asked before any changes to the system are made.