### PR TITLE
Fixes #30802: Set proxy timeout to 15 minutes

### DIFF
--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -9,3 +9,7 @@ dhcp::config_comment: |
   foreman-installer. Use custom-hiera.yaml for multiple subnets.
 
 mongodb::server::set_parameter: "{diagnosticDataCollectionEnabled: false}"
+
+foreman::config::apache::proxy_params:
+  retry: '0'
+  timeout: '900'


### PR DESCRIPTION
This sets the Foreman HTTPs reverse proxy timeout to 15 minutes to
give a cushion for some requests (such as provisioning) that can
keep an open request for 10+ minutes. This sets a sane default and
users can then tune it to their own infrastructure needs.