### PR TITLE
Refs #30489 - enable dhcp acls by default 

### DIFF
--- a/config/foreman.migrations/20200909151007_manage_acls_on_debian.rb
+++ b/config/foreman.migrations/20200909151007_manage_acls_on_debian.rb
@@ -1,0 +1,3 @@
+if answers['foreman_proxy'].is_a?(Hash) && facts[:os][:family] == 'Debian'
+  answers['foreman_proxy']['dhcp_manage_acls'] ||= true if answers['foreman_proxy'].key?('dhcp_manage_acls')
+end


### PR DESCRIPTION
Both puppet-dhcp and puppet-foreman_proxy are ready to handle acls on both supported systems.
The best approach here is to leverage this to our favor instead of enforcing a user or mode on config files.

- [x] Needs https://github.com/theforeman/puppet-foreman_proxy/pull/614