### PR TITLE
Fix pulpcore assets directory permissions

### DIFF
--- a/hooks/pre/33-pulpcore_assets_permissions.rb
+++ b/hooks/pre/33-pulpcore_assets_permissions.rb
@@ -1,0 +1,11 @@
+# Prior to Katello 3.18 assets were built by root. Katello 3.18 runs it as pulp
+# and this corrects the permissions.
+unless app_value(:noop)
+  DIRECTORY = '/var/lib/pulp/assets'.freeze
+  USER = 'pulp'.freeze
+
+  if File.directory?(DIRECTORY) && File.stat(DIRECTORY).uid == 0
+    require 'fileutils'
+    FileUtils.chown_R(USER, USER, DIRECTORY)
+  end
+end

--- a/hooks/pre_commit/33-pulpcore_assets_permissions.rb
+++ b/hooks/pre_commit/33-pulpcore_assets_permissions.rb
@@ -1,0 +1,12 @@
+# hooks/pre/33-pulpcore_assets_permissions.rb needs user pulp
+DIRECTORY = '/var/lib/pulp/assets'.freeze
+USER = 'pulp'.freeze
+if File.directory?(DIRECTORY)
+  require 'etc'
+
+  begin
+    Etc.getpwnam(USER)
+  rescue ArgumentError
+    fail_and_exit("Detected incorrect permissions on #{DIRECTORY} but user #{USER} doesn't exist")
+  end
+end


### PR DESCRIPTION
Prior to Katello 3.18 assets were built by root. Katello 3.18 runs it as pulp and this corrects the permissions.

This goes together with https://github.com/theforeman/puppet-pulpcore/pull/121.