### PR TITLE
Refs #30423 - Migrate Pulp media directory

### DIFF
--- a/hooks/post/34-pulpcore_directory_layout.rb
+++ b/hooks/post/34-pulpcore_directory_layout.rb
@@ -1,0 +1,8 @@
+require 'pathname'
+
+LEGACY_DIR = Pathname.new('/var/lib/pulp/artifact')
+
+if LEGACY_DIR.symlink?
+  logger.debug("Removing legacy symlink #{LEGACY_DIR}")
+  LEGACY_DIR.unlink unless app_value(:noop)
+end

--- a/hooks/pre/34-pulpcore_directory_layout.rb
+++ b/hooks/pre/34-pulpcore_directory_layout.rb
@@ -1,0 +1,15 @@
+require 'pathname'
+
+PULP_ROOT = Pathname.new('/var/lib/pulp')
+LEGACY_DIR = PULP_ROOT / 'artifact'
+NEW_MEDIA_ROOT = PULP_ROOT / 'media'
+DESTINATION = NEW_MEDIA_ROOT / LEGACY_DIR.basename
+
+if LEGACY_DIR.directory? && !LEGACY_DIR.symlink?
+  logger.debug("Migrating #{LEGACY_DIR} to #{DESTINATION}")
+  unless app_value(:noop)
+    NEW_MEDIA_ROOT.mkpath
+    LEGACY_DIR.rename(DESTINATION)
+    LEGACY_DIR.make_symlink(DESTINATION)
+  end
+end

--- a/hooks/pre_validations/34-pulpcore_directory_layout.rb
+++ b/hooks/pre_validations/34-pulpcore_directory_layout.rb
@@ -1,0 +1,14 @@
+require 'pathname'
+
+PULP_ROOT = Pathname.new('/var/lib/pulp')
+LEGACY_DIR = PULP_ROOT / 'artifact'
+DESTINATION = PULP_ROOT / 'media' / LEGACY_DIR.basename
+
+if LEGACY_DIR.directory? && !LEGACY_DIR.symlink? && DESTINATION.directory?
+  message = <<~MESSAGE
+  Target #{DESTINATION} already exists. Unable to migrate Pulp media root from #{LEGACY_DIR}.
+
+  Ensure #{LEGACY_DIR} is not a directory or #{DESTINATION} does not exist.
+  MESSAGE
+  fail_and_exit(message)
+end


### PR DESCRIPTION
The Pulp media root is being changed from /var/lib/pulp to /var/lib/pulp/media. This migration moves the existing content in /var/lib/pulp/artifact.

Pulp only really uses $MEDIA_ROOT/artifact but various tools that can do consistency checks use the entire MEDIA_ROOT.

These hooks are implemented in 4 stages, 3 of which in hooks.

* pre_validations - Checks if a migration would be a problem
* pre - Moves the directory and creates a symlink
* [Puppet - Updates the config and restarts services](https://github.com/theforeman/puppet-pulpcore/pull/115)
* post - Cleans up the old symlink

This should only be merged after the [Puppet change](https://github.com/theforeman/puppet-pulpcore/pull/115).