### PR TITLE
Fixes #31022 - Use an isolated Puppet environment

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -1,4 +1,5 @@
 require 'English'
+require 'fileutils'
 require 'open3'
 
 module HookContextExtension
@@ -32,8 +33,13 @@ module HookContextExtension
   end
 
   def apply_puppet_code(code)
-    bin_path = Kafo::PuppetCommand.search_puppet_path('puppet')
-    Open3.capture3(*Kafo::PuppetCommand.format_command("echo \"#{code}\" | #{bin_path} apply --detailed-exitcodes"))
+    execution_env = Kafo::ExecutionEnvironment.new
+    puppetconf = execution_env.configure_puppet
+    options = ['--detailed-exitcodes']
+    command = PuppetCommand.new(code, options, puppetconf).command
+    Open3.capture3(*Kafo::PuppetCommand.format_command(command))
+  ensure
+    FileUtils.rm_rf(execution_env.directory)
   end
 
   def fail_and_exit(message, code = 1)


### PR DESCRIPTION
When there's splay=true in /etc/puppetlabs/puppet/puppet.conf, puppet apply waits a random period (up to 30 minutes). Kafo deals with this by using --config=/tmp/.../puppet.conf which is generated in the ExecutionEnvironment. The boot hook apply_puppet_code does not use this which causes the host's puppet.conf to take effect. This can lead to much longer installer times where it just sleeps.

This patch reuses Kafo::ExecutionEnvironment for an isolated environment.

I have not tested this patch yet, but it's based on https://community.theforeman.org/t/puppet-with-splay-true/20777 as a report.