### PR TITLE
Fixes #31022 - Use an isolated Puppet environment

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -31,9 +31,13 @@ module HookContextExtension
     end
   end
 
-  def apply_puppet_code(code)
-    bin_path = Kafo::PuppetCommand.search_puppet_path('puppet')
-    Open3.capture3(*Kafo::PuppetCommand.format_command("echo \"#{code}\" | #{bin_path} apply --detailed-exitcodes"))
+  def apply_puppet_code(code, use_noop=true)
+    puppet_execution_environment do |env|
+      options = ['--detailed-exitcodes']
+      settings = {noop: use_noop && app_value(:noop)}
+      command = env.build_command(code, options: options, settings: settings)
+      Open3.capture3(*command)
+    end
   end
 
   def fail_and_exit(message, code = 1)


### PR DESCRIPTION
When there's splay=true in /etc/puppetlabs/puppet/puppet.conf, puppet apply waits a random period (up to 30 minutes). Kafo deals with this by using --config=/tmp/.../puppet.conf which is generated in the ExecutionEnvironment. The boot hook apply_puppet_code does not use this which causes the host's puppet.conf to take effect. This can lead to much longer installer times where it just sleeps.

This patch uses the new puppet_execution_environment hook method to get a clean enviroment. It also respects noop from the app_value which it previously didn't.

Alternative to https://github.com/theforeman/foreman-installer/pull/584 but requires https://github.com/theforeman/kafo/pull/284.