### PR TITLE
Mark some options from hooks as advanced

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'kafo', '~> 5.1'
+gem 'kafo', '~> 6.0'
 gem 'librarian-puppet'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 6.0'
 gem 'facter', '>= 3.0'

--- a/hooks/boot/10-reset_data.rb
+++ b/hooks/boot/10-reset_data.rb
@@ -5,5 +5,6 @@ app_option(
   "You will lose all data!\nUnfortunately, we " +
   "can't detect a failure, so you should verify success " +
   "manually.\nDropping can fail when the DB is in use.",
-  :default => false
+  :default => false,
+  :advanced => true
 )

--- a/hooks/boot/11-detailed_exitcodes.rb
+++ b/hooks/boot/11-detailed_exitcodes.rb
@@ -2,5 +2,6 @@ app_option(
   '--detailed-exitcodes', :flag,
   "Provide transaction information via exit codes, see puppet-agent(8)\n" +
     "for full details.",
-  :default => false
+  :default => false,
+  :advanced => true
 )

--- a/hooks/boot/12-clear_pulp_content.rb
+++ b/hooks/boot/12-clear_pulp_content.rb
@@ -3,6 +3,7 @@ if pulp_present?
     '--clear-pulp-content',
     :flag,
     'This option will clear all Pulp 2 data.',
-    :default => false
+    :default => false,
+    :advanced => true
   )
 end

--- a/katello/hooks/boot/17-disable_system_checks.rb
+++ b/katello/hooks/boot/17-disable_system_checks.rb
@@ -3,5 +3,6 @@ app_option(
   '--disable-system-checks',
   :flag,
   "This option will skip the system checks for memory.",
-  :default => false
+  :default => false,
+  :advanced => true
 )

--- a/spec/hook_context_spec.rb
+++ b/spec/hook_context_spec.rb
@@ -5,7 +5,7 @@ require_relative '../hooks/boot/01-kafo-hook-extensions'
 describe 'HookContextExtension' do
   let(:kafo) { instance_double('KafoConfigure') }
   let(:logger) { instance_double('Logger') }
-  let(:context) { Kafo::HookContext.new(kafo) }
+  let(:context) { Kafo::HookContext.new(kafo, logger) }
 
   before do
     allow(context).to receive(:logger).and_return(logger)

--- a/spec/services_hook_extensions_spec.rb
+++ b/spec/services_hook_extensions_spec.rb
@@ -5,7 +5,7 @@ require_relative '../hooks/boot/04-services'
 describe 'ForemanMaintainHookContextExtension' do
   let(:kafo) { instance_double('KafoConfigure') }
   let(:logger) { instance_double('Logger') }
-  let(:context) { Kafo::HookContext.new(kafo) }
+  let(:context) { Kafo::HookContext.new(kafo, logger) }
 
   before do
     allow(context).to receive(:logger).and_return(logger)


### PR DESCRIPTION
This will cause the options marked as advanced to appear under
--full-help since they are intended for special case scenarios or
advanced use cases.

This requires a release of Kafo with https://github.com/theforeman/kafo/pull/280 to take affect