### PR TITLE
Refs #29799 - Define clear mongo methods in module

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -147,26 +147,26 @@ module HookContextExtension
     end
     status.success?
   end
-end
 
-def remote_host?(hostname)
-  !['localhost', '127.0.0.1', `hostname`.strip].include?(hostname)
-end
+  def remote_host?(hostname)
+    !['localhost', '127.0.0.1', `hostname`.strip].include?(hostname)
+  end
 
-def load_mongo_config
-  seeds = param_value('katello', 'pulp_db_seeds')
-  seed = seeds.split(',').first
-  host, port = seed.split(':') if seed
-  {
-    host: host || 'localhost',
-    port: port || '27017',
-    database: param_value('katello', 'pulp_db_name') || 'pulp_database',
-    username: param_value('katello', 'pulp_db_username'),
-    password: param_value('katello', 'pulp_db_password'),
-    ssl: param_value('katello', 'pulp_db_ssl') || false,
-    ca_path: param_value('katello', 'pulp_db_ca_path'),
-    ssl_certfile: param_value('katello', 'pulp_db_ssl_certfile'),
-  }
+  def load_mongo_config
+    seeds = param_value('katello', 'pulp_db_seeds')
+    seed = seeds&.split(',')&.first
+    host, port = seed.split(':') if seed
+    {
+      host: host || 'localhost',
+      port: port || '27017',
+      database: param_value('katello', 'pulp_db_name') || 'pulp_database',
+      username: param_value('katello', 'pulp_db_username'),
+      password: param_value('katello', 'pulp_db_password'),
+      ssl: param_value('katello', 'pulp_db_ssl') || false,
+      ca_path: param_value('katello', 'pulp_db_ca_path'),
+      ssl_certfile: param_value('katello', 'pulp_db_ssl_certfile'),
+    }
+  end
 end
 
 Kafo::HookContext.send(:include, HookContextExtension)


### PR DESCRIPTION
3dcd45bef6f56a7af898eddf3283229f0e33d065 moved these methods to the common context but defined them outside of the module. This means they were not usable in the pre context. That leads some some infinite loop until the machine is out of memory.

It also handles the case when katello::pulp_db_seeds returns nil, which is always the case on a content proxy.