### PR TITLE
Demonstrate Kafo multi-hook

### DIFF
--- a/hooks/multi/34-pulpcore_directory_layout.rb
+++ b/hooks/multi/34-pulpcore_directory_layout.rb
@@ -1,0 +1,30 @@
+require 'pathname'
+
+PULP_ROOT = Pathname.new('/tmp/pulp')
+LEGACY_DIR = PULP_ROOT / 'artifact'
+NEW_MEDIA_ROOT = PULP_ROOT / 'media'
+DESTINATION = NEW_MEDIA_ROOT / LEGACY_DIR.basename
+
+pre_validations do
+  if LEGACY_DIR.directory? && !LEGACY_DIR.symlink? && DESTINATION.directory?
+    fail_and_exit("Target #{DESTINATION} already exists. Unable to migrate Pulp media root.")
+  end
+end
+
+pre do
+  if LEGACY_DIR.directory? && !LEGACY_DIR.symlink?
+    logger.debug("Migrating #{LEGACY_DIR} to #{DESTINATION}")
+    unless app_value(:noop)
+      NEW_MEDIA_ROOT.mkpath
+      LEGACY_DIR.rename(DESTINATION)
+      LEGACY_DIR.make_symlink(DESTINATION)
+    end
+  end
+end
+
+post do
+  if LEGACY_DIR.symlink?
+    logger.debug("Removing legacy symlink #{LEGACY_DIR}")
+    LEGACY_DIR.unlink unless app_value(:noop)
+  end
+end


### PR DESCRIPTION
The Pulp media root is being changed from /var/lib/pulp to /var/lib/pulp/media. This migration moves the existing content in /var/lib/pulp/artifact.

Pulp only really uses $MEDIA_ROOT/artifact but various tools that can do consistency checks use the entire MEDIA_ROOT.

These hooks are implemented in 4 stages, 3 of which in hooks.

* pre_validations - Checks if a migration would be a problem
* pre - Moves the directory and creates a symlink
* Puppet - Updates the config and restarts services
* post - Cleans up the old symlink

It's an alternative to https://github.com/theforeman/foreman-installer/pull/583 to demonstrate [Kafo's new multi hook](https://github.com/theforeman/kafo/pull/288) approach to avoid duplicating constants.