### PR TITLE
Refs #29803: if katello-certs-check fails the installer should exit

### DIFF
--- a/hooks/pre_commit/20-certs_update.rb
+++ b/hooks/pre_commit/20-certs_update.rb
@@ -14,6 +14,6 @@ if module_enabled?('certs')
   key_file  = param('certs', 'server_key').value
 
   unless app_value(:certs_skip_check) || [cert_file, ca_file, key_file].all? { |v| v.to_s.empty? }
-    execute_command(%(katello-certs-check -c "#{cert_file}" -k "#{key_file}" -b "#{ca_file}"))
+    execute(%(katello-certs-check -c "#{cert_file}" -k "#{key_file}" -b "#{ca_file}"))
   end
 end


### PR DESCRIPTION
This behavior got changed when the certs hook was moved to the
hooks/ directory and would now only log an error message while
continuing the installer execution to run.