### PR TITLE
Refs #31051 - Remove Warning method from katello-certs-check

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -74,10 +74,6 @@ function success () {
     echo -e "\n${GREEN}[OK]${RESET}\n"
 }
 
-function warning () {
-    echo -e "\n${YELLOW}[WARNING]${RESET}\n"
-}
-
 function check-server-cert-encoding () {
     printf 'Checking server certificate encoding: '
     openssl x509 -inform pem -in $CERT_FILE -noout -text &> /dev/null


### PR DESCRIPTION
The last use of this method was removed in e53e71 ( #590 )