### PR TITLE
Fixes #31234: Create new certificate bundle everytime

### DIFF
--- a/katello_certs/config/foreman-proxy-certs-answers.yaml
+++ b/katello_certs/config/foreman-proxy-certs-answers.yaml
@@ -1,5 +1,6 @@
 certs:
   generate: true
+  regenerate: true
   deploy: false
   group: foreman
 foreman_proxy_certs: true


### PR DESCRIPTION
The first time a certificate bundle is created for a foreman proxy
any updates a user wishes to make are not reflected in the bundle
unless the user deletes it on disk or explicitly passes --certs-regenerate.
Given the foreman-proxy-certs-generate command is intended for
users to generate bundles for a foreman-proxy, this bundle should
be generated, with updates, anytime a user runs the command. This
enables that change by setting regenerate to true as the default.