### PR TITLE
Add a --list-plugins hook

### DIFF
--- a/hooks/boot/05-plugins.rb
+++ b/hooks/boot/05-plugins.rb
@@ -1,0 +1,1 @@
+app_option('--list-plugins', :flag, "List all available plugins")

--- a/hooks/pre_validations/05-plugins.rb
+++ b/hooks/pre_validations/05-plugins.rb
@@ -1,0 +1,87 @@
+if app_value(:list_plugins)
+
+  class Plugin
+    include Comparable
+
+    attr_reader :group, :plugin, :provider, :module
+
+    # We expect a mymod::plugin::myplugin structure but also allow
+    # mymod::plugin::myplugin::provider
+    def initialize(mod)
+      parts = mod.identifier.split('::')
+
+      raise ArgumentError, "#{mod.identifier} is not a plugin" unless parts.length >= 3
+
+      type = ['plugin', 'cli', 'compute'].detect { |type| parts.include?(type) }
+      raise ArgumentError, "#{mod.identifier} is not a plugin" unless type
+
+      index = parts.index(type)
+      if type == 'plugin'
+        @group = parts.slice(0, index).join(' ')
+      else
+        @group = parts.slice(0, index + 1).join(' ')
+      end
+      @plugin, @provider = parts.slice(index + 1, parts.length)
+
+      @module = mod
+    end
+
+    def name
+      provider || plugin
+    end
+
+    def to_s
+      mod.identifier
+    end
+
+    def inspect
+      "<Plugin:#{mod.identifier}>"
+    end
+
+    def <=>(other)
+      if group != other.group
+        group <=> other.group
+      elsif plugin != other.plugin
+        plugin <=> other.plugin
+      elsif provider
+        if other.provider
+          provider <=> other.provider
+        else
+          1
+        end
+      elsif other.provider
+        -1
+      else
+        0
+      end
+    end
+  end
+
+  groups = Hash.new { |h, k| h[k] = [] }
+
+  kafo.modules.each do |mod|
+    begin
+      plugin = Plugin.new(mod)
+      groups[plugin.group] << plugin
+    rescue ArgumentError
+    end
+  end
+
+  if groups.any?
+    groups.each do |group, plugins|
+      say "* #{group.tr('_', ' ').capitalize}"
+      plugins.sort.each do |plugin|
+        enabled = plugin.module.enabled? ? 'enabled' : 'disabled'
+        indenting = plugin.provider ? '    ' : '  '
+
+        # TODO: assumes there is a plugin but breaks with
+        # foreman_proxy::plugin::dns::powerdns because dns is built in
+        say "#{indenting}* #{plugin.name} (#{enabled})"
+      end
+    end
+  else
+    say "No plugins available in #{scenario_data.name}"
+  end
+
+  exit(0)
+end


### PR DESCRIPTION
This adds an installer option --list-plugins hook. It is implemented in pre_validations because that allows showing whether they are enabled or not. This does mean that the verbose output is always shown prior to it.

Example output
```console
$ RUBYOPT=-W0 be ./bin/foreman-installer --scenario foreman --list-plugins --skip-checks-i-know-better
2020-11-10 12:18:12 [NOTICE] [pre_migrations] Executing hooks in group pre_migrations
2020-11-10 12:18:12 [NOTICE] [pre_migrations] All hooks in group pre_migrations finished
2020-11-10 12:18:12 [NOTICE] [boot] Executing hooks in group boot
2020-11-10 12:18:12 [ERROR ] [root] Command foreman-maintain packages -h not found
2020-11-10 12:18:12 [NOTICE] [boot] All hooks in group boot finished
2020-11-10 12:18:12 [NOTICE] [init] Executing hooks in group init
2020-11-10 12:18:12 [NOTICE] [init] All hooks in group init finished
2020-11-10 12:18:12 [NOTICE] [root] Loading default values from puppet modules...
2020-11-10 12:18:15 [NOTICE] [root] ... finished
2020-11-10 12:18:15 [NOTICE] [pre_values] Executing hooks in group pre_values
2020-11-10 12:18:15 [NOTICE] [pre_values] All hooks in group pre_values finished
2020-11-10 12:18:15 [NOTICE] [pre_validations] Executing hooks in group pre_validations
* Foreman cli
  * ansible (disabled)
  * azure (disabled)
  * discovery (disabled)
  * kubevirt (disabled)
  * openscap (disabled)
  * remote_execution (disabled)
  * tasks (disabled)
  * templates (disabled)
* Foreman
  * ansible (disabled)
  * azure (disabled)
  * bootdisk (disabled)
  * chef (disabled)
  * column_view (disabled)
  * default_hostgroup (disabled)
  * dhcp_browser (disabled)
  * digitalocean (disabled)
  * discovery (disabled)
  * expire_hosts (disabled)
  * hooks (disabled)
  * host_extra_validator (disabled)
  * kubevirt (disabled)
  * leapp (disabled)
  * memcache (disabled)
  * monitoring (disabled)
  * omaha (disabled)
  * openscap (disabled)
  * ovirt_provision (disabled)
  * puppetdb (disabled)
  * remote_execution (disabled)
    * cockpit (disabled)
  * salt (disabled)
  * setup (disabled)
  * snapshot_management (disabled)
  * statistics (disabled)
  * tasks (disabled)
  * templates (disabled)
* Foreman compute
  * ec2 (disabled)
  * gce (disabled)
  * libvirt (disabled)
  * openstack (disabled)
  * ovirt (disabled)
  * vmware (disabled)
* Foreman proxy
  * ansible (disabled)
  * chef (disabled)
    * infoblox (disabled)
    * remote_isc (disabled)
  * discovery (disabled)
    * infoblox (disabled)
    * powerdns (disabled)
  * dynflow (disabled)
  * monitoring (disabled)
  * omaha (disabled)
  * openscap (disabled)
  * pulp (disabled)
    * ssh (disabled)
  * salt (disabled)
```

There is still a TODO which can mostly be seen in the Foreman proxy part, hence currently a draft.