### PR TITLE
Fixes #30436 - add import-export paths to katello answers

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -91,8 +91,6 @@ foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
 foreman_proxy_content:
   proxy_pulp_yum_to_pulpcore: true
-  allowed_import_path: ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']
-  allowed_export_path: ['/var/lib/pulp/exports']
 katello:
   use_pulp_2_for_yum: false
 puppet:

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -91,6 +91,8 @@ foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
 foreman_proxy_content:
   proxy_pulp_yum_to_pulpcore: true
+  allowed_import_path: ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']
+  allowed_export_path: ['/var/lib/pulp/exports']
 katello:
   use_pulp_2_for_yum: false
 puppet:

--- a/config/katello.migrations/201117205851-add-import-export-params.rb
+++ b/config/katello.migrations/201117205851-add-import-export-params.rb
@@ -1,0 +1,8 @@
+if answers['pulpcore'].is_a?(Hash)
+  answers['pulpcore']['allowed_import_path'] = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']
+  answers['pulpcore']['allowed_export_path'] = ['/var/lib/pulp/exports']
+end
+if answers['foreman_proxy_content'].is_a?(Hash)
+  answers['foreman_proxy_content']['pulpcore']['allowed_import_path'] = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']
+  answers['foreman_proxy_content']['pulpcore']['allowed_export_path'] = ['/var/lib/pulp/exports']
+end

--- a/config/katello.migrations/201117205851-add-import-export-params.rb
+++ b/config/katello.migrations/201117205851-add-import-export-params.rb
@@ -1,7 +1,3 @@
-if answers['pulpcore'].is_a?(Hash)
-  answers['pulpcore']['allowed_import_path'] = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']
-  answers['pulpcore']['allowed_export_path'] = ['/var/lib/pulp/exports']
-end
 if answers['foreman_proxy_content'].is_a?(Hash)
   answers['foreman_proxy_content']['pulpcore']['allowed_import_path'] = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']
   answers['foreman_proxy_content']['pulpcore']['allowed_export_path'] = ['/var/lib/pulp/exports']

--- a/config/katello.migrations/201117205851-add-import-export-params.rb
+++ b/config/katello.migrations/201117205851-add-import-export-params.rb
@@ -1,4 +1,4 @@
 if answers['foreman_proxy_content'].is_a?(Hash)
-  answers['foreman_proxy_content']['pulpcore']['allowed_import_path'] = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']
-  answers['foreman_proxy_content']['pulpcore']['allowed_export_path'] = ['/var/lib/pulp/exports']
+  answers['foreman_proxy_content']['pulpcore_allowed_import_path'] = ['/var/lib/pulp/sync_imports', '/var/lib/pulp/imports']
+  answers['foreman_proxy_content']['pulpcore_allowed_export_path'] = ['/var/lib/pulp/exports']
 end


### PR DESCRIPTION
This is the third PR from https://github.com/theforeman/puppet-pulpcore/pull/147#pullrequestreview-529534099

* override the default $allowed_{import,export}_path parameters for the Katello scenario only
* define a migration for the Katello scenario that sets the proper values of the parameters for users who already installed

(thanks to @chris1984 for some guidance)
