### PR TITLE
reexec systemd after installing SELinux packages

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -15,6 +15,14 @@ module HookContextExtension
     !File.exist?(success_file)
   end
 
+  # @summary Use Puppet's package resource to ensure package state
+  # @param [Array[String]] packages
+  #   A list of package names
+  # @param [String] state
+  #   The package state to ensure. Can be installed, latest, absent or a
+  #   specific version number.
+  # @return [Boolean]
+  #   true if a change was made, false if not. Exits if there was an error
   def ensure_packages(packages, state = 'installed')
     return if packages.empty?
 
@@ -29,6 +37,8 @@ module HookContextExtension
       logger.debug("Exit status is #{status.exitstatus.inspect}")
       exit(1)
     end
+
+    status.exitstatus == 2
   end
 
   def apply_puppet_code(code)

--- a/hooks/pre/32-install_selinux_packages.rb
+++ b/hooks/pre/32-install_selinux_packages.rb
@@ -13,5 +13,10 @@ if facts.dig(:os, :selinux, :enabled)
   packages << 'pulpcore-selinux' if pulpcore_enabled?
   packages << 'crane-selinux' if pulp_enabled?
 
-  ensure_packages(packages, 'installed')
+  if ensure_packages(packages, 'installed')
+    # systemd 245+ reloads SELinux contexts on daemon-reload
+    # https://github.com/systemd/systemd/commit/a9dfac21ec850eb5dcaf1ae9ef729389e4c12802
+    # EL8 is 239, EL7 is 219
+    `systemctl daemon-reexec`
+  end
 end


### PR DESCRIPTION
Starting systemd 245 the daemon reloads SELinux contexts after a daemon-reload, but prior to that it needs to reexec. Both EL7 and EL8 are too old so this runs reexec. To limit the impact, it only does so if a package change was detected. This can fail if a metapackage (katello) already pulled in all packages but there's no reliable way to detect if a reexec is needed. Always running daemon-reexec can be unexpected.

This is untested and I'm not even sure if my logic is entirely correct.