### PR TITLE
Refs #28928 - Remove checkpoint_segments option

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,7 @@
 forge 'https://forgeapi.puppetlabs.com/'
 
 # Dependencies
-mod 'puppetlabs/postgresql',         '>= 5.6.0'
+mod 'puppetlabs/postgresql',         '>= 6.8.0'
 mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'
 mod 'theforeman/git',                :git => 'https://github.com/theforeman/puppet-git'

--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -1,4 +1,8 @@
 ---
+lookup_options:
+  postgresql::server::config_entries:
+    merge: hash
+
 apache::default_vhost: false
 dhcp::config_comment: |
   READ: This file was written the foreman-installer and not by the Foreman
@@ -13,3 +17,8 @@ mongodb::server::set_parameter: "{diagnosticDataCollectionEnabled: false}"
 foreman::config::apache::proxy_params:
   retry: '0'
   timeout: '900'
+
+postgresql::server::config_entries:
+  # PostgreSQL 9.5 removed checkpoint_segments as a valid option. Foreman
+  # requires PostgreSQL 9.6 or newer.
+  checkpoint_segments: ~

--- a/config/foreman.hiera/tuning/common.yaml
+++ b/config/foreman.hiera/tuning/common.yaml
@@ -1,8 +1,4 @@
 ---
-lookup_options:
-  postgresql::server::config_entries:
-    merge: hash
-
 apache::mod::passenger::passenger_max_pool_size: 12
 apache::mod::passenger::passenger_max_instances_per_app: 6
 apache::mod::passenger::passenger_max_request_queue_size: 250

--- a/hooks/pre_validations/10-postgresql_checkpoint_segments.rb
+++ b/hooks/pre_validations/10-postgresql_checkpoint_segments.rb
@@ -1,5 +1,4 @@
 HIERA_FILE = '/etc/foreman-installer/custom-hiera.yaml'.freeze
-SCL_POSTGRESQL_CONF = '/var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf'.freeze
 
 custom_hiera = YAML.load_file(HIERA_FILE)
 
@@ -14,10 +13,6 @@ if custom_hiera &&
     Please remove this from the following locations and then re-run the installer:
       - #{HIERA_FILE}
   HEREDOC
-
-  if File.exist?(SCL_POSTGRESQL_CONF)
-    message += "    - #{SCL_POSTGRESQL_CONF}"
-  end
 
   if katello_present?
     message += <<~HEREDOC


### PR DESCRIPTION
puppetlabs-postgresql 6.8.0 introduces support to remove config entries. This makes upgrades more reliable.

Currently untested, hence a draft.