### PR TITLE
Fixes #31490 - Remove digital ocean plugin

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -32,7 +32,6 @@ foreman::plugin::chef: false
 foreman::plugin::column_view: false
 foreman::plugin::default_hostgroup: false
 foreman::plugin::dhcp_browser: false
-foreman::plugin::digitalocean: false
 foreman::plugin::discovery: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::hooks: false

--- a/config/foreman.migrations/20201207225700_remove_digitalocean-plugin.rb
+++ b/config/foreman.migrations/20201207225700_remove_digitalocean-plugin.rb
@@ -1,0 +1,3 @@
+if answers.key?('foreman::plugin::digitalocean')
+  answers.delete('foreman::plugin::digitalocean')
+end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -48,7 +48,6 @@ foreman::plugin::bootdisk: false
 foreman::plugin::chef: false
 foreman::plugin::column_view: false
 foreman::plugin::default_hostgroup: false
-foreman::plugin::digitalocean: false
 foreman::plugin::discovery: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::hooks: false

--- a/config/katello.migrations/201207230019-remove-digitalocean-plugin.rb
+++ b/config/katello.migrations/201207230019-remove-digitalocean-plugin.rb
@@ -1,0 +1,3 @@
+if answers.key?('foreman::plugin::digitalocean')
+  answers.delete('foreman::plugin::digitalocean')
+end

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -11,7 +11,6 @@ foreman::compute::ovirt: false
 foreman::compute::vmware: false
 foreman::plugin::azure: false
 foreman::plugin::column_view: false
-foreman::plugin::digitalocean: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-before.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-before.yaml
@@ -11,7 +11,6 @@ foreman::compute::ovirt: false
 foreman::compute::rackspace: false
 foreman::compute::vmware: false
 foreman::plugin::azure: false
-foreman::plugin::digitalocean: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -11,7 +11,6 @@ foreman::compute::ovirt: false
 foreman::compute::vmware: false
 foreman::plugin::azure: false
 foreman::plugin::column_view: false
-foreman::plugin::digitalocean: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-before.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-before.yaml
@@ -11,7 +11,6 @@ foreman::compute::ovirt: false
 foreman::compute::rackspace: false
 foreman::compute::vmware: false
 foreman::plugin::azure: false
-foreman::plugin::digitalocean: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -11,7 +11,6 @@ foreman::compute::ovirt: false
 foreman::compute::vmware: false
 foreman::plugin::azure: false
 foreman::plugin::column_view: false
-foreman::plugin::digitalocean: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false


### PR DESCRIPTION
This plugin has not been maintained for a while now and causes
issues on installation. This commit removes the option from the
installer and can be easily reverted if the plugin is updated.