### PR TITLE
Fixes #31502 - Add salt-plugin to proxy-answers

### DIFF
--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -37,5 +37,6 @@ foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::reports: false
 foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::script: false
+foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false
 puppet: false

--- a/config/foreman-proxy-content.migrations/220707075153-add_salt_params_on_proxy.rb
+++ b/config/foreman-proxy-content.migrations/220707075153-add_salt_params_on_proxy.rb
@@ -1,0 +1,1 @@
+answers['foreman_proxy::plugin::salt'] ||= false


### PR DESCRIPTION
In order to have the commandline-parameters available in foreman-installer's foreman-proxy scenario.