### PR TITLE
Refs #31385 - Clear out nil qpid ciphers

### DIFF
--- a/config/foreman-proxy-content.migrations/201217175955-stricter-ciphers.rb
+++ b/config/foreman-proxy-content.migrations/201217175955-stricter-ciphers.rb
@@ -1,0 +1,4 @@
+# Since #31385 the ciphers are now always set
+if answers['foreman_proxy_content'].is_a?(Hash) && answers['foreman_proxy_content']['qpid_router_ssl_ciphers'].nil?
+  answers['foreman_proxy_content'].delete('qpid_router_ssl_ciphers')
+end

--- a/config/katello.migrations/201217175955-stricter-ciphers.rb
+++ b/config/katello.migrations/201217175955-stricter-ciphers.rb
@@ -1,0 +1,4 @@
+# Since #31385 the ciphers are now always set
+if answers['foreman_proxy_content'].is_a?(Hash) && answers['foreman_proxy_content']['qpid_router_ssl_ciphers'].nil?
+  answers['foreman_proxy_content'].delete('qpid_router_ssl_ciphers')
+end


### PR DESCRIPTION
The parameter qpid_router_ssl_ciphers no longer accepts undef (nil) but now always sets the ciphers. This migration clears out the invalid value which will later copy the module default.