### PR TITLE
Fixes #31548 - Use the correct pulpcore legacy dir

### DIFF
--- a/hooks/post/34-pulpcore_directory_layout.rb
+++ b/hooks/post/34-pulpcore_directory_layout.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-LEGACY_DIR = Pathname.new('/var/lib/pulp/artifact')
+LEGACY_DIR = Pathname.new('/var/lib/pulp/docroot')
 
 if LEGACY_DIR.symlink?
   logger.debug("Removing legacy symlink #{LEGACY_DIR}")

--- a/hooks/pre/34-pulpcore_directory_layout.rb
+++ b/hooks/pre/34-pulpcore_directory_layout.rb
@@ -1,14 +1,12 @@
 require 'pathname'
 
 PULP_ROOT = Pathname.new('/var/lib/pulp')
-LEGACY_DIR = PULP_ROOT / 'artifact'
-NEW_MEDIA_ROOT = PULP_ROOT / 'media'
-DESTINATION = NEW_MEDIA_ROOT / LEGACY_DIR.basename
+LEGACY_DIR = PULP_ROOT / 'docroot'
+DESTINATION = PULP_ROOT / 'media'
 
 if LEGACY_DIR.directory? && !LEGACY_DIR.symlink?
   logger.debug("Migrating #{LEGACY_DIR} to #{DESTINATION}")
   unless app_value(:noop)
-    NEW_MEDIA_ROOT.mkpath
     LEGACY_DIR.rename(DESTINATION)
     LEGACY_DIR.make_symlink(DESTINATION)
   end

--- a/hooks/pre_validations/34-pulpcore_directory_layout.rb
+++ b/hooks/pre_validations/34-pulpcore_directory_layout.rb
@@ -1,8 +1,8 @@
 require 'pathname'
 
 PULP_ROOT = Pathname.new('/var/lib/pulp')
-LEGACY_DIR = PULP_ROOT / 'artifact'
-DESTINATION = PULP_ROOT / 'media' / LEGACY_DIR.basename
+LEGACY_DIR = PULP_ROOT / 'docroot'
+DESTINATION = PULP_ROOT / 'media'
 
 if LEGACY_DIR.directory? && !LEGACY_DIR.symlink? && DESTINATION.directory?
   message = <<~MESSAGE


### PR DESCRIPTION
In our previous layout we used /var/lib/pulp/docroot as media directory while upstream used /var/lib/pulp/artifact.

**Note** I haven't tested this yet.