### PR TITLE
Fixes #31757 - Drop foreman proxy pulp plugin in foreman

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -64,7 +64,6 @@ foreman_proxy::plugin::dynflow: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::omaha: false
 foreman_proxy::plugin::openscap: false
-foreman_proxy::plugin::pulp: false
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
 puppet:

--- a/config/foreman.migrations/20210129165012_drop_foreman_proxy_plugin_pulp.rb
+++ b/config/foreman.migrations/20210129165012_drop_foreman_proxy_plugin_pulp.rb
@@ -1,0 +1,1 @@
+answers.delete('foreman_proxy::plugin::pulp')


### PR DESCRIPTION
In 01186b11dbc38ea45a570be758b681e1f5da7729 this was added, but it doesn't really make sense in the Foreman scenario. Only Katello can use it, but you need more things on the proxy which is only provided by the foreman-proxy-content scenario.