### PR TITLE
Fixes #31642 - Add container gateway support

### DIFF
--- a/config/foreman-proxy-content.migrations/210129165632-add-container-gateway.rb
+++ b/config/foreman-proxy-content.migrations/210129165632-add-container-gateway.rb
@@ -1,0 +1,1 @@
+answers['foreman_proxy::plugin::container_gateway'] ||= false


### PR DESCRIPTION
Adds a migration for the container_gateway plugin.

Related PRs:

https://github.com/theforeman/puppet-foreman_proxy/pull/643
https://github.com/theforeman/puppet-foreman_proxy_content/pull/319