### PR TITLE
Fixes #31834: Ensure PostgreSQL 12 is enabled on EL8

### DIFF
--- a/hooks/pre/40-el8_modules.rb
+++ b/hooks/pre/40-el8_modules.rb
@@ -1,0 +1,7 @@
+if (module_enabled?('katello') || module_enabled?('foreman_proxy_content')) && el8?
+  ensure_dnf_module('pki-core', 'present')
+
+  if local_postgresql?
+    ensure_dnf_module('postgresql', '12')
+  end
+end


### PR DESCRIPTION
I was not sure if I should try to code up the steps to upgrade Foreman EL8 existing databases or leave that to the docs. The steps are effectively:

```
# ensure enough disk space on /var/lib/pgsql for twice the size of /var/lib/pgsql/data

systemctl stop postgresql foreman dynflow\*
mv /var/lib/pgsql/data /var/lib/pgsql/data-old
sed -i "s/\/var\/lib\/pgsql\/data/\/var\/lib\/pgsql\/data-old/g" data-old/postgresql.conf

dnf -y module remove postgresql-server
dnf -y module reset postgresql
dnf -y module enable postgresql:12
dnf -y install postgresql-server postgresql-upgrade

sudo -u postgres pg_upgrade --old-bindir /usr/lib64/pgsql/postgresql-10/bin --new-bindir /bin --old-datadir /var/lib/pgsql/data-old/ --new-datadir /var/lib/pgsql/data
```
