### PR TITLE
Fixes #31834 - Use PostgreSQL 12 on EL8

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,8 @@
 forge 'https://forgeapi.puppetlabs.com/'
 
 # Dependencies
-mod 'puppetlabs/postgresql',         '>= 6.10.1'
+# This uses a version with DNF module support but without dropping Puppet 5
+mod 'puppetlabs/postgresql',         :git => 'https://github.com/theforeman/puppetlabs-postgresql', :commit => '8d0efec9fb5a5df42ed64375c71a11d8b6f90b4c'
 mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'
 mod 'theforeman/git',                :git => 'https://github.com/theforeman/puppet-git'

--- a/config/foreman.hiera/family/RedHat-8.yaml
+++ b/config/foreman.hiera/family/RedHat-8.yaml
@@ -5,3 +5,6 @@ apache::mod::ssl::ssl_protocol:
   - 'ALL'
   - '-TLSv1'
   - '-TLSv1.1'
+
+postgresql::globals::manage_dnf_module: true
+postgresql::globals::version: "12"


### PR DESCRIPTION
This aligns Red Hat 7 and Red Hat 8 on PostgreSQL 12. It uses the branch manage_dnf_module.

It may break existing installations on PostgreSQL 10 since there is no upgrade path. Those users are recommended to set version to 10 in their custom-hiera.yaml.

This is an alternative to https://github.com/theforeman/foreman-installer/pull/646.