### PR TITLE
Fixes #31909 - Enable pki-core DNF module on EL8

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -93,6 +93,10 @@ module HookContextExtension
     facts[:os][:release][:major] == '7' && facts[:os][:family] == 'RedHat'
   end
 
+  def el8?
+    facts[:os][:release][:major] == '8' && facts[:os][:family] == 'RedHat'
+  end
+
   def log_and_say(level, message, do_say = true, do_log = true)
     style = case level
             when :error

--- a/hooks/pre/32-install_selinux_packages.rb
+++ b/hooks/pre/32-install_selinux_packages.rb
@@ -12,5 +12,10 @@ if facts.dig(:os, :selinux, :enabled)
   packages << 'candlepin-selinux' if katello_enabled?
   packages << 'pulpcore-selinux' if pulpcore_enabled?
 
+  if katello_enabled? && el8?
+    # candlepin-selinux pulls in candlepin which requires pki-core
+    execute!('dnf module enable pki-core --assumeyes', false, true)
+  end
+
   ensure_packages(packages, 'installed')
 end


### PR DESCRIPTION
On EL8 the pki-core module is needed by candlepin. candlepin-selinux pulls in candlepin. This means that in the installer the SELinux workaround hook needs to enable the module.