### PR TITLE
Include theforeman/foreman_proxy 16.0.1

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -104,7 +104,7 @@ FORGE
       puppetlabs-concat (>= 1.0.0, < 7.0.0)
       puppetlabs-postgresql (>= 6.5.0, < 7.0.0)
       puppetlabs-stdlib (>= 4.25.0, < 7.0.0)
-    theforeman-foreman_proxy (16.0.0)
+    theforeman-foreman_proxy (16.0.1)
       puppet-extlib (>= 3.0.0, < 6.0.0)
       puppetlabs-stdlib (>= 4.19.0, < 7.0.0)
       richardc-datacat (>= 0.6.0, < 1.0.0)


### PR DESCRIPTION
This includes a fix for the ansible-runner repository.