### PR TITLE
Fixes #32002: Use runuser for executing reset commands

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -122,7 +122,7 @@ module HookContextExtension
     end
 
     unless status
-      log_and_say("#{command} failed! Check the output for error!", do_say, do_log)
+      log_and_say(:error, "#{command} failed! Check the output for error!", do_say, do_log)
       exit 1
     end
   end

--- a/hooks/pre/10-reset_data.rb
+++ b/hooks/pre/10-reset_data.rb
@@ -41,18 +41,18 @@ def load_db_config(db)
 end
 
 def empty_db_in_postgresql(db)
-  logger.info "Dropping #{db} database!"
+  logger.notice "Dropping #{db} database!"
 
   config = load_db_config(db)
   if remote_host?(config[:host])
     empty_database!(config)
   else
-    execute!("sudo -u postgres dropdb #{config[:database]}")
+    execute!("runuser -l postgres -c 'dropdb #{config[:database]}'", false, true)
   end
 end
 
 def reset_candlepin
-  execute!('rm -f /var/lib/candlepin/.puppet-candlepin-cpdb*')
+  execute!('rm -f /var/lib/candlepin/.puppet-candlepin-cpdb*', false, true)
   empty_db_in_postgresql('candlepin')
 end
 
@@ -72,14 +72,14 @@ def empty_database!(config)
         where schemaname = 'public';
       ))
   delete_statements = `#{generate_delete_statements}`
-  execute!(pg_sql_statement(config, delete_statements)) if delete_statements
+  execute!(pg_sql_statement(config, delete_statements), false, true) if delete_statements
 end
 
 def clear_pulpcore_content(content_dir)
   if File.directory?(content_dir)
-    logger.debug "Removing Pulpcore content from '#{content_dir}'"
+    logger.notice "Removing Pulpcore content from '#{content_dir}'"
     FileUtils.rm_rf(content_dir)
-    logger.info "Pulpcore content successfully removed from '#{content_dir}'"
+    logger.notice "Pulpcore content successfully removed from '#{content_dir}'"
   else
     logger.warn "Pulpcore content directory not present at '#{content_dir}'"
   end


### PR DESCRIPTION
Hides nonsense errors such as when a user cannot change directories
when running the reset-data command. Additionally, converts reset-data
execution into log output only.