### PR TITLE
Fixes #32011 - Fix logger typo in reset data hook

### DIFF
--- a/hooks/pre/10-reset_data.rb
+++ b/hooks/pre/10-reset_data.rb
@@ -77,7 +77,7 @@ end
 
 def clear_pulpcore_content(content_dir)
   if File.directory?(content_dir)
-    logging.debug "Removing Pulpcore content from '#{content_dir}'"
+    logger.debug "Removing Pulpcore content from '#{content_dir}'"
     FileUtils.rm_rf(content_dir)
     logger.info "Pulpcore content successfully removed from '#{content_dir}'"
   else


### PR DESCRIPTION
I've been using the `--reset-data` feature to ensure the server is in a clean slate before recording ansible role fixtures.

After I upgraded my server to Katello 3.18, I noticed this issue.