### PR TITLE
correct theforeman/foreman_proxy pin to pull 17.1.0

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -82,7 +82,7 @@ FORGE
       puppetlabs-concat (>= 1.0.0, < 7.0.0)
       puppetlabs-postgresql (>= 6.5.0, < 7.0.0)
       puppetlabs-stdlib (>= 4.25.0, < 7.0.0)
-    theforeman-foreman_proxy (17.0.0)
+    theforeman-foreman_proxy (17.1.0)
       puppet-extlib (>= 3.0.0, < 6.0.0)
       puppetlabs-stdlib (>= 4.19.0, < 7.0.0)
       richardc-datacat (>= 0.6.0, < 1.0.0)


### PR DESCRIPTION
the dependency was updated, but not the lockfile, resulting in Katello
failing to install with:

    Evaluation Error: Error while evaluating a Resource Statement,
    Could not find declared class foreman_proxy::plugin::container_gateway
    (file: /usr/share/foreman-installer/modules/foreman_proxy_content/manifests/init.pp, line: 245, column: 7)