### PR TITLE
Don't use Facter 4.0.52

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'kafo', '~> 6.0'
 gem 'librarian-puppet'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 6.0'
-gem 'facter', '>= 3.0'
+gem 'facter', '>= 3.0', '!= 4.0.52'
 
 gem 'puppet-strings'
 gem 'rake'


### PR DESCRIPTION
This has broken the FQDN fact when FFI is unavailable. It's fixed in git but no release has been made yet and this allows us to build again.