### PR TITLE
Refs #32175: Set foreman-tasks backup to true on upgrades

### DIFF
--- a/config/foreman.migrations/20210323145821_foreman_tasks-backup.rb
+++ b/config/foreman.migrations/20210323145821_foreman_tasks-backup.rb
@@ -1,0 +1,3 @@
+if answers['foreman::plugin::tasks'].is_a?(Hash) && !answers['foreman::plugin::tasks'].key?('backup')
+  answers['foreman::plugin::tasks']['backup'] = true
+end

--- a/config/katello.migrations/210323145816-foreman-tasks-backup.rb
+++ b/config/katello.migrations/210323145816-foreman-tasks-backup.rb
@@ -1,0 +1,3 @@
+if answers['foreman::plugin::tasks'].is_a?(Hash) && !answers['foreman::plugin::tasks'].key?('backup')
+  answers['foreman::plugin::tasks']['backup'] = true
+end


### PR DESCRIPTION
For new installations, the intent is to default to task cleanup
to not store backups of the tasks deleted. Since the previous
behavior is to store backups on cleanup, when upgrading users
should retain the same behavior and intentionally disable backups
to prevent unexpected behavior changes.