### PR TITLE
Fixes #32180: Unset system proxy and SSL environment variables for th…

### DIFF
--- a/checks/env_variables.rb
+++ b/checks/env_variables.rb
@@ -1,9 +1,0 @@
-#!/usr/bin/env ruby
-
-variables = %w[http_proxy https_proxy ssl_cert_file
-               HTTP_PROXY HTTPS_PROXY SSL_CERT_FILE]
-
-if variables.map { |variable| ENV[variable] }.compact.any?
-  $stderr.puts "Please unset the following environment variables before running the installer: #{variables.join(', ')}"
-  exit 1
-end

--- a/hooks/boot/05-environment.rb
+++ b/hooks/boot/05-environment.rb
@@ -1,0 +1,5 @@
+%w[http_proxy https_proxy ssl_cert_file HTTP_PROXY HTTPS_PROXY SSL_CERT_FILE].each do |variable|
+  if ::ENV.delete(variable)
+    logger.warn "Unsetting environment variable '#{variable}' for the duration of the install."
+  end
+end


### PR DESCRIPTION
…e duration of the install

Moves from checking for http proxy and SSL environment variables and
failing if they are present to a model of unsetting them during
the duration of the install run. This does not change them on
the system itself.