### PR TITLE
Fixes #32186 - Install pulp-selinux when pulp2 is enabled

### DIFF
--- a/hooks/pre/32-install_selinux_packages.rb
+++ b/hooks/pre/32-install_selinux_packages.rb
@@ -12,6 +12,7 @@ if facts.dig(:os, :selinux, :enabled)
   packages << 'candlepin-selinux' if katello_enabled?
   packages << 'pulpcore-selinux' if pulpcore_enabled?
   packages << 'crane-selinux' if pulp_enabled?
+  packages << 'pulp-selinux' if pulp_enabled?
 
   ensure_packages(packages, 'installed')
 end


### PR DESCRIPTION
/var/lib/pulp was getting its selinux context from selinux-pulpcore (var_lib_t) but it should be `httpd_sys_rw_content_t` when pulp2 is installed