### PR TITLE
Raise the expected minimum Puppet version to 5.5.20

### DIFF
--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'semantic_puppet'
 
 describe 'Puppet module' do
-  VERSIONS = ['5.5.10', '6.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
+  VERSIONS = ['5.5.20', '6.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
 
   Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|
     context File.basename(File.dirname(filename)) do


### PR DESCRIPTION
The Candlepin module expects at least Puppet 5.5.20 for DNF module support. This has been handled in packaging so it's safe to raise this.  Eventually we'll drop Puppet 5 since it's now EOL, but it's a larger effort that we're not ready for.