### PR TITLE
Handle server_puppetserver_metrics nil migration

### DIFF
--- a/config/foreman-proxy-content.migrations/210331121715-clear-puppetserver-nil-metrics.rb
+++ b/config/foreman-proxy-content.migrations/210331121715-clear-puppetserver-nil-metrics.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash)
+  answers['puppet'].delete('server_puppetserver_metrics') if answers['puppet']['server_puppetserver_metrics'].nil?
+end

--- a/config/foreman.migrations/20210331121715_clear_puppetserver-nil-metrics.rb
+++ b/config/foreman.migrations/20210331121715_clear_puppetserver-nil-metrics.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash)
+  answers['puppet'].delete('server_puppetserver_metrics') if answers['puppet']['server_puppetserver_metrics'].nil?
+end

--- a/config/katello.migrations/210331121715-clear-puppetserver-nil-metrics.rb
+++ b/config/katello.migrations/210331121715-clear-puppetserver-nil-metrics.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash)
+  answers['puppet'].delete('server_puppetserver_metrics') if answers['puppet']['server_puppetserver_metrics'].nil?
+end


### PR DESCRIPTION
In the Puppet module the parameter server_puppetserver_metrics was changed from Optional[Boolean] to Boolean. This breaks upgrades. The solution is to delete the entry if it's nil which causes Kafo to determine the new default automatically.

Needs https://github.com/theforeman/foreman-installer/pull/667 and other things to be green, but it should fix nightly.