### PR TITLE
Add puppetserver_foreman module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,6 +6,7 @@ mod 'puppetlabs/postgresql',         :git => 'https://github.com/theforeman/pupp
 mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'
 mod 'theforeman/git',                :git => 'https://github.com/theforeman/puppet-git'
+mod 'theforeman/puppetserver_foreman', :git => 'https://github.com/theforeman/puppet-puppetserver_foreman'
 mod 'theforeman/tftp',               :git => 'https://github.com/theforeman/puppet-tftp'
 
 # Katello dependencies


### PR DESCRIPTION
theforeman/puppet [switched its dependency from theforeman/foreman to theforeman/puppetserver_foreman](https://github.com/theforeman/puppet-puppet/commit/c64b89694fb2a0815d1ade68d0cf98aa36524745) for specific Foreman integration. This makes it easier to iterate standalone.