### PR TITLE
Fixes #32401: Fix drop of --foreman-proxy-content-parent-fqdn parameter

### DIFF
--- a/KATELLO.md
+++ b/KATELLO.md
@@ -46,7 +46,6 @@ foreman-proxy-certs-generate --foreman-proxy-fqdn "myforeman-proxy-content.examp
 # Copy the ~/myforeman-proxy.example.com-certs.tar to the foreman-proxy system
 # register the system to Katello and run:
 foreman-installer --scenario                                "foreman-proxy-content"\
-                  --foreman-proxy-content-parent-fqdn       "master.example.com"\
                   --foreman-proxy-register-in-foreman       "true"\
                   --foreman-proxy-foreman-base-url          "https://master.example.com"\
                   --foreman-proxy-trusted-hosts             "master.example.com"\

--- a/katello_certs/hooks/boot/02-message-helpers.rb
+++ b/katello_certs/hooks/boot/02-message-helpers.rb
@@ -57,7 +57,6 @@ module KatelloCertsMessageHookContextExtension
   #{installer_command} \\
                     --scenario #{scenario_name} \\
                     --certs-tar-file                              "<%= color("#{certs_tar_file}", :info) %>"\\
-                    --foreman-proxy-content-parent-fqdn           "#{fqdn}"\\
                     --foreman-proxy-register-in-foreman           "true"\\
                     --foreman-proxy-foreman-base-url              "#{foreman_url}"\\
                     --foreman-proxy-trusted-hosts                 "#{fqdn}"\\


### PR DESCRIPTION
Will connect this to the Redmine filed by the user who reported the issue in Discourse (https://community.theforeman.org/t/unrecognized-option-foreman-proxy-content-parent-fqdn/23050)