### PR TITLE
Fixes #32269 - Set ReservedCodeCache for Puppetserver

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -70,3 +70,6 @@ foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false
 puppet:
   server: true
+  server_jvm_extra_args:
+    - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+    - "-XX:ReservedCodeCacheSize=512m"

--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -38,3 +38,6 @@ puppet:
   server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
   server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
   server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
+  server_jvm_extra_args:
+    - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+    - "-XX:ReservedCodeCacheSize=512m"

--- a/config/foreman-proxy-content.migrations/210407174237-add-puppet-reserved-code-cache.rb
+++ b/config/foreman-proxy-content.migrations/210407174237-add-puppet-reserved-code-cache.rb
@@ -1,0 +1,19 @@
+if answers['puppet'].is_a?(Hash)
+  reserved_code_cache_option = '-XX:ReservedCodeCacheSize'
+  reserved_code_cache_arg = "#{reserved_code_cache_option}=512m"
+  # Handle Optional[Variant[String,Array[String]]] $server_jvm_extra_args
+  if (answer = answers['puppet']['server_jvm_extra_args'])
+    if answer.is_a?(Array)
+      unless answer.any? { |arg| arg.include?(reserved_code_cache_option) }
+        answers['puppet']['server_jvm_extra_args'] << reserved_code_cache_arg
+      end
+    else
+      unless answer.include?(reserved_code_cache_option)
+        answers['puppet']['server_jvm_extra_args'] += " #{reserved_code_cache_arg}"
+      end
+    end
+  else
+    # The logger is silently added by the module if it's undef
+    answers['puppet']['server_jvm_extra_args'] = ['-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger', reserved_code_cache_arg]
+  end
+end

--- a/config/foreman.migrations/20210407174237_add_puppet_reserved_code_cache.rb
+++ b/config/foreman.migrations/20210407174237_add_puppet_reserved_code_cache.rb
@@ -1,0 +1,19 @@
+if answers['puppet'].is_a?(Hash)
+  reserved_code_cache_option = '-XX:ReservedCodeCacheSize'
+  reserved_code_cache_arg = "#{reserved_code_cache_option}=512m"
+  # Handle Optional[Variant[String,Array[String]]] $server_jvm_extra_args
+  if (answer = answers['puppet']['server_jvm_extra_args'])
+    if answer.is_a?(Array)
+      unless answer.any? { |arg| arg.include?(reserved_code_cache_option) }
+        answers['puppet']['server_jvm_extra_args'] << reserved_code_cache_arg
+      end
+    else
+      unless answer.include?(reserved_code_cache_option)
+        answers['puppet']['server_jvm_extra_args'] += " #{reserved_code_cache_arg}"
+      end
+    end
+  else
+    # The logger is silently added by the module if it's undef
+    answers['puppet']['server_jvm_extra_args'] = ['-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger', reserved_code_cache_arg]
+  end
+end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -100,3 +100,6 @@ puppet:
   server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
   server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
   server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
+  server_jvm_extra_args:
+    - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+    - "-XX:ReservedCodeCacheSize=512m"

--- a/config/katello.migrations/210407174237-add-puppet-reserved-code-cache.rb
+++ b/config/katello.migrations/210407174237-add-puppet-reserved-code-cache.rb
@@ -1,0 +1,19 @@
+if answers['puppet'].is_a?(Hash)
+  reserved_code_cache_option = '-XX:ReservedCodeCacheSize'
+  reserved_code_cache_arg = "#{reserved_code_cache_option}=512m"
+  # Handle Optional[Variant[String,Array[String]]] $server_jvm_extra_args
+  if (answer = answers['puppet']['server_jvm_extra_args'])
+    if answer.is_a?(Array)
+      unless answer.any? { |arg| arg.include?(reserved_code_cache_option) }
+        answers['puppet']['server_jvm_extra_args'] << reserved_code_cache_arg
+      end
+    else
+      unless answer.include?(reserved_code_cache_option)
+        answers['puppet']['server_jvm_extra_args'] += " #{reserved_code_cache_arg}"
+      end
+    end
+  else
+    # The logger is silently added by the module if it's undef
+    answers['puppet']['server_jvm_extra_args'] = ['-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger', reserved_code_cache_arg]
+  end
+end


### PR DESCRIPTION
Puppetserver 6 really benefits from an increased ReservedCodeCache. Puppet recommends this in their tuning guide[1] and various deployments have shown to greatly benefit from it. 512m appears to be a good default since it works well even on small installs without real downsides.

Currently a draft since it's untested.

[1]: https://puppet.com/docs/puppet/6.21/server/tuning_guide.html