### PR TITLE
Fixes #32532: Ensure a valid tuning option is supplied

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'kafo', '~> 6.0'
+gem 'kafo', '~> 6.4'
 gem 'librarian-puppet'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 6.0'
 gem 'facter', '>= 3.0', '!= 4.0.52'

--- a/hooks/boot/13-tuning.rb
+++ b/hooks/boot/13-tuning.rb
@@ -9,5 +9,11 @@ if has_custom_fact?('tuning')
     'INSTALLATION_SIZE',
     "Tune for an installation size. Choices: #{TUNING_SIZES.join(', ')}",
     :default => get_custom_fact(TUNING_FACT)
-  )
+  ) do |value|
+    unless TUNING_SIZES.include?(value)
+      signal_usage_error("Invalid option supplied for --tuning. Please choose from one of: #{TUNING_SIZES.join(', ')}")
+    end
+
+    value
+  end
 end

--- a/hooks/pre_commit/13-tuning.rb
+++ b/hooks/pre_commit/13-tuning.rb
@@ -9,7 +9,6 @@ if app_option?(:tuning)
   }.freeze
   TUNING_FACT = 'tuning'.freeze
 
-  EXIT_INVALID_TUNING = 101
   EXIT_INSUFFICIENT_CPU_CORES = 102
   EXIT_INSUFFICIENT_MEMORY = 103
 
@@ -20,14 +19,8 @@ if app_option?(:tuning)
     new_tuning = current_tuning
   end
 
-  required = TUNING_SIZES[new_tuning]
-  if required.nil?
-    say "<%= color('Invalid tuning profile', :bad) %>"
-    say "'#{new_tuning}' is not one of #{TUNING_SIZES.keys.join(', ')}"
-    exit EXIT_INVALID_TUNING
-  end
-
   unless app_value(:disable_system_checks)
+    required = TUNING_SIZES[new_tuning]
     required_cores = required[:cpu_cores]
     required_memory = required[:memory]
 


### PR DESCRIPTION
Adds a validator to the tuning option to ensure that what is supplied
on the command line is in fact one of the valid options.

Requires: https://github.com/theforeman/kafo/pull/332

This has advantages over the current method which does not validate until the pre_commit stage thus running *more* of the installer than is necessary and provides a more Clamp native way to ensure input is valid.

Before:
```
# foreman-installer --disable-system-checks --tuning GIGANTIC
2021-05-05 20:52:05 [NOTICE] [root] Loading installer configuration. This will take some time.
2021-05-05 20:52:08 [NOTICE] [root] Running installer with log based terminal output at level NOTICE.
2021-05-05 20:52:08 [NOTICE] [root] Use -l to set the terminal output log level to ERROR, WARN, NOTICE, INFO, or DEBUG. See --full-help for definitions.
Invalid tuning profile
'GIGANTIC' is not one of default, medium, large, extra-large, extra-extra-large
```

After:
```
# foreman-installer --disable-system-checks --tuning GIGANTIC
Invalid option supplied for --tuning. Please choose from one of: default, medium, large, extra-large, extra-extra-large
See: 'foreman-installer --help'
```

This additionally solves the problem where if a user passed in `--tuning --medium` the default value for tuning would be selected *and* no error would be thrown for supplying the invalid `--medium`. Kafo strips out values passed to options that start with `-` (https://github.com/theforeman/kafo/blob/master/lib/kafo/kafo_configure.rb#L415).