### PR TITLE
Restore DNF module management for PG on EL8

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,6 +1,7 @@
 forge 'https://forgeapi.puppetlabs.com/'
 
-mod 'puppetlabs/postgresql',           '>= 6.10.1 < 7.0.0'
+# This uses a version with DNF module support but without dropping Puppet 5
+mod 'puppetlabs/postgresql',           :git => 'https://github.com/theforeman/puppetlabs-postgresql', :commit => '8d0efec9fb5a5df42ed64375c71a11d8b6f90b4c'
 mod 'theforeman/dhcp',                 '>= 6.2.0 < 6.3.0'
 mod 'theforeman/dns',                  '>= 8.2.0 < 8.3.0'
 mod 'theforeman/git',                  '>= 6.3.0 < 6.4.0'


### PR DESCRIPTION
In fdc20de529ebcaba1708bf9afa43a23e96a7858a the version of puppetlabs/postgresql was pinned to an unreleased version which does have DNF module management but doesn't drop Puppet 5. Then in 157bd6a7165e11c87e53aa5338b57e58018ed8ee it was pinned to >= 6.10.1 which is too old and lacks DNF module management. That means it ends up using the default PostgreSQL module which is version 10.

Fixes: 157bd6a7165e11c87e53aa5338b57e58018ed8ee