### PR TITLE
Fixes #32620: Unset NSS_DEFAULT_DB_TYPE during run

### DIFF
--- a/hooks/boot/05-environment.rb
+++ b/hooks/boot/05-environment.rb
@@ -1,4 +1,4 @@
-%w[http_proxy https_proxy ssl_cert_file HTTP_PROXY HTTPS_PROXY SSL_CERT_FILE].each do |variable|
+%w[http_proxy https_proxy ssl_cert_file HTTP_PROXY HTTPS_PROXY SSL_CERT_FILE NSS_DEFAULT_DB_TYPE].each do |variable|
   if ::ENV.delete(variable)
     logger.warn "Unsetting environment variable '#{variable}' for the duration of the install."
   end


### PR DESCRIPTION
When NSS_DEFAULT_DB_TYPE is set to, for example, sql then qpidd
will fail to start.