### PR TITLE
Fixes #32885: Remove puppet from foreman::user_groups if present

### DIFF
--- a/config/foreman.migrations/20210625142707_dynamic_puppet_in_foreman_groups.rb
+++ b/config/foreman.migrations/20210625142707_dynamic_puppet_in_foreman_groups.rb
@@ -1,0 +1,5 @@
+if answers['foreman'].is_a?(Hash)
+  if answers['foreman']['user_groups'] && answers['foreman']['user_groups'].include?('puppet')
+    answers['foreman']['user_groups'].delete('puppet')
+  end
+end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -22,7 +22,6 @@ foreman:
   server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
   server_ssl_crl: ""
   server_ssl_key: /etc/pki/katello/private/katello-apache.key
-  user_groups: []
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false

--- a/config/katello.migrations/190314163941-remove-foreman-user-groups.rb
+++ b/config/katello.migrations/190314163941-remove-foreman-user-groups.rb
@@ -1,5 +1,0 @@
-if answers['foreman'].is_a?(Hash)
-  answers['foreman']['user_groups'] = []
-elsif answers['foreman']
-  answers['foreman'] = { 'user_groups' => [] }
-end

--- a/config/katello.migrations/210625142712-dynamic-puppet-in-foreman-groups.rb
+++ b/config/katello.migrations/210625142712-dynamic-puppet-in-foreman-groups.rb
@@ -1,0 +1,5 @@
+if answers['foreman'].is_a?(Hash)
+  if answers['foreman']['user_groups'] && answers['foreman']['user_groups'].include?('puppet')
+    answers['foreman']['user_groups'].delete('puppet')
+  end
+end

--- a/spec/fixtures/cleanup-foreman-user-groups/foreman-answers-after.yaml
+++ b/spec/fixtures/cleanup-foreman-user-groups/foreman-answers-after.yaml
@@ -1,0 +1,2 @@
+foreman:
+  user_groups: []

--- a/spec/fixtures/cleanup-foreman-user-groups/foreman-answers-before.yaml
+++ b/spec/fixtures/cleanup-foreman-user-groups/foreman-answers-before.yaml
@@ -1,0 +1,2 @@
+foreman:
+  user_groups: ['puppet']

--- a/spec/fixtures/cleanup-foreman-user-groups/katello-answers-after.yaml
+++ b/spec/fixtures/cleanup-foreman-user-groups/katello-answers-after.yaml
@@ -1,0 +1,2 @@
+foreman:
+  user_groups: []

--- a/spec/fixtures/cleanup-foreman-user-groups/katello-answers-before.yaml
+++ b/spec/fixtures/cleanup-foreman-user-groups/katello-answers-before.yaml
@@ -1,0 +1,2 @@
+foreman:
+  user_groups: ['puppet']

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -122,4 +122,24 @@ describe 'migrations' do
       end
     end
   end
+
+  %w[foreman katello].each do |scenario_name|
+    context "foreman drop puppet from user_groups" do
+      let(:answers_after) { load_fixture_yaml('cleanup-foreman-user-groups', "#{scenario_name}-answers-after.yaml") }
+      let(:scenario) do
+        {
+          :answers    => load_fixture_yaml('cleanup-foreman-user-groups', "#{scenario_name}-answers-before.yaml"),
+          :config     => load_config_yaml("#{scenario_name}.yaml"),
+          :migrations => config_path("#{scenario_name}.migrations"),
+        }
+      end
+
+      let(:migrator) { Kafo::Migrations.new(scenario[:migrations]).run(scenario[:config], scenario[:answers]) }
+
+      it 'changes scenario answers' do
+        _, after = migrator
+        expect(after).to include answers_after
+      end
+    end
+  end
 end


### PR DESCRIPTION
The change https://github.com/theforeman/puppet-foreman/pull/938
introduced dynamically determining if the puppet group needed to
be added to the foreman user. This no longer needs to be set
explicitly on the foreman::user_groups parameter thus the migration
cleans it up if present.