### PR TITLE
Drop max_keepalive_requests and websockets_ssl_* answers

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -17,15 +17,12 @@ foreman:
   client_ssl_key: /etc/foreman/client_key.pem
   initial_location: Default Location
   initial_organization: Default Organization
-  max_keepalive_requests: 10000
   server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
   server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
   server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
   server_ssl_crl: ""
   server_ssl_key: /etc/pki/katello/private/katello-apache.key
   user_groups: []
-  websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
-  websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false


### PR DESCRIPTION
max_keepalive_requests was removed a while back[1] so this does nothing. The websocket SSL cert and key are also copied from the server[2]. There is no migration for this since keeping the values is still valid.

[1]: https://github.com/theforeman/puppet-foreman/commit/26158236419362b9fac0bc6b3f667410e8392cc9
[2]: https://github.com/theforeman/puppet-foreman/commit/2dc5e7d802e2a11e35bd1e34d28cce05195040ce