### PR TITLE
Refs #32914: Add migrations for foreman_puppet plugin

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -43,7 +43,7 @@ foreman::plugin::monitoring: false
 foreman::plugin::omaha: false
 foreman::plugin::openscap: false
 foreman::plugin::ovirt_provision: false
-foreman::plugin::puppet: false
+foreman::plugin::puppet: true
 foreman::plugin::puppetdb: false
 foreman::plugin::remote_execution: false
 foreman::plugin::remote_execution::cockpit: false

--- a/config/foreman.migrations/20210708144320_add_foreman_puppet.rb
+++ b/config/foreman.migrations/20210708144320_add_foreman_puppet.rb
@@ -1,0 +1,3 @@
+unless answers.key?('foreman::plugin::puppet')
+  answers['foreman::plugin::puppet'] = true
+end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -53,7 +53,7 @@ foreman::plugin::leapp: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
 foreman::plugin::openscap: false
-foreman::plugin::puppet: false
+foreman::plugin::puppet: true
 foreman::plugin::puppetdb: false
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false

--- a/config/katello.migrations/210708144422-add-foreman-puppet.rb
+++ b/config/katello.migrations/210708144422-add-foreman-puppet.rb
@@ -1,0 +1,3 @@
+unless answers.key?('foreman::plugin::puppet')
+  answers['foreman::plugin::puppet'] = true
+end

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -18,6 +18,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
+foreman::plugin::puppet: true
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -18,6 +18,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
+foreman::plugin::puppet: true
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -18,6 +18,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
+foreman::plugin::puppet: true
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false


### PR DESCRIPTION
Currently, this is following existing behavior for new plugins. However, what is the expected behavior @ezr-ondrej  @ekohl ?  On upgrade, would we expect this plugin to be present and enabled?

Should these instead be written as:

```
unless answers.key?('foreman::plugin::puppet')
   answers['foreman::plugin::puppet'] = true
end
```