### PR TITLE
Use Kafo's migration DSL

### DIFF
--- a/config/foreman.migrations/20160405121109_foreman_ansible.rb
+++ b/config/foreman.migrations/20160405121109_foreman_ansible.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::ansible'] ||= false
+add_module('foreman::plugin::ansible')

--- a/config/foreman.migrations/20160405121739_foreman_memcache.rb
+++ b/config/foreman.migrations/20160405121739_foreman_memcache.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::memcache'] ||= false
+add_module('foreman::plugin::memcache')

--- a/config/foreman.migrations/20160405121855_foreman_cockpit.rb
+++ b/config/foreman.migrations/20160405121855_foreman_cockpit.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::cockpit'] ||= false
+add_module('foreman::plugin::cockpit')

--- a/config/foreman.migrations/20160405122117_passenger_ruby.rb
+++ b/config/foreman.migrations/20160405122117_passenger_ruby.rb
@@ -1,2 +1,2 @@
 # Redetermine the value of passenger_ruby, as it changed on Debian in puppet-foreman f9329b6
-answers['foreman'].delete('passenger_ruby') if answers['foreman']
+unset_answer('foreman', 'passenger_ruby')

--- a/config/foreman.migrations/20160405135043_foreman_proxy_discovery.rb
+++ b/config/foreman.migrations/20160405135043_foreman_proxy_discovery.rb
@@ -1,1 +1,1 @@
-answers['foreman_proxy::plugin::discovery'] ||= false
+add_module('foreman_proxy::plugin::discovery')

--- a/config/foreman.migrations/20160420224417_puppet_autosign.rb
+++ b/config/foreman.migrations/20160420224417_puppet_autosign.rb
@@ -1,7 +1,9 @@
 # Redetermine the value of autosign, as it changed from string/boolean to path/boolean
 # in puppet-puppet a2325f1 and was deleted from puppet-foreman_proxy 9f3c9aa
-if answers['puppet']
-  current_autosign = answers['puppet']['autosign']
-  answers['puppet'].delete('autosign') unless !!current_autosign == current_autosign # rubocop:disable Style/DoubleNegation
+migrate_module('puppet') do |mod|
+  current_autosign = mod['autosign']
+  unless current_autosign.is_a?(TrueClass) || current_autosign.is_a?(FalseClass)
+    mod.unset_answer('autosign')
+  end
 end
-answers['foreman_proxy'].delete('autosign_location') if answers['foreman_proxy']
+unset_answer('foreman_proxy', 'autosign_location')

--- a/config/foreman.migrations/20160518125928_foreman_proxy_puppetrun_rename.rb
+++ b/config/foreman.migrations/20160518125928_foreman_proxy_puppetrun_rename.rb
@@ -1,4 +1,6 @@
 # Rename foreman_proxy puppetrun parameters to puppet
 # https://github.com/theforeman/puppet-foreman_proxy/commit/c26cac15
-answers['foreman_proxy']['puppet'] = answers['foreman_proxy'].delete('puppetrun') if answers['foreman_proxy'] && answers['foreman_proxy'].has_key?('puppetrun')
-answers['foreman_proxy']['puppet_listen_on'] = answers['foreman_proxy'].delete('puppetrun_listen_on') if answers['foreman_proxy'] && answers['foreman_proxy'].has_key?('puppetrun_listen_on')
+migrate_module('foreman_proxy') do |mod|
+  mod.rename_parameter('puppetrun', 'puppet')
+  mod.rename_parameter('puppetrun_listen_on', 'puppet_listen_on')
+end

--- a/config/foreman.migrations/20160607133050_foreman_proxy_puppetssh_rename.rb
+++ b/config/foreman.migrations/20160607133050_foreman_proxy_puppetssh_rename.rb
@@ -1,3 +1,5 @@
 # Rename foreman_proxy provider "puppetssh" to "ssh"
 # http://projects.theforeman.org/issues/15323
-answers['foreman_proxy']['puppetrun_provider'] = 'ssh' if answers['foreman_proxy'] && answers['foreman_proxy']['puppetrun_provider'] == 'puppetssh'
+migrate_module('foreman_proxy') do |mod|
+  mod['puppetrun_provider'] = 'ssh' if mod['puppetrun_provider'] == 'puppetssh'
+end

--- a/config/foreman.migrations/20160614145332_foreman_expire_hosts.rb
+++ b/config/foreman.migrations/20160614145332_foreman_expire_hosts.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::expire_hosts'] ||= false
+add_module('foreman::plugin::expire_hosts')

--- a/config/foreman.migrations/20160615132930_foreman_azure.rb
+++ b/config/foreman.migrations/20160615132930_foreman_azure.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::azure'] ||= false
+add_module('foreman::plugin::azure')

--- a/config/foreman.migrations/20160705103630_readd_ovirt_provision.rb
+++ b/config/foreman.migrations/20160705103630_readd_ovirt_provision.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::ovirt_provision'] ||= false
+add_module('foreman::plugin::ovirt_provision')

--- a/config/foreman.migrations/20160708111111_foreman_host_extra_validator.rb
+++ b/config/foreman.migrations/20160708111111_foreman_host_extra_validator.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::host_extra_validator'] ||= false
+add_module('foreman::plugin::host_extra_validator')

--- a/config/foreman.migrations/20160722161820_environment_to_rails_env.rb
+++ b/config/foreman.migrations/20160722161820_environment_to_rails_env.rb
@@ -1,3 +1,5 @@
 # rename foreman environment parameter to rails_env
 # https://github.com/theforeman/puppet-foreman_proxy/commit/d239f0b
-answers['foreman']['rails_env'] = answers['foreman'].delete('environment') if answers['foreman'] && answers['foreman'].has_key?('environment')
+migrate_module('foreman') do |mod|
+  mod.rename_parameter('environment', 'rails_env')
+end

--- a/config/foreman.migrations/20160725151907_foreman_remote_execution.rb
+++ b/config/foreman.migrations/20160725151907_foreman_remote_execution.rb
@@ -1,2 +1,2 @@
-answers['foreman::plugin::remote_execution'] ||= false
-answers['foreman_proxy::plugin::remote_execution::ssh'] ||= false
+add_module('foreman::plugin::remote_execution')
+add_module('foreman_proxy::plugin::remote_execution::ssh')

--- a/config/foreman.migrations/20160831180000_foreman_proxy_tftp_grub2.rb
+++ b/config/foreman.migrations/20160831180000_foreman_proxy_tftp_grub2.rb
@@ -1,7 +1,6 @@
-if answers['foreman_proxy']
-  root = answers['foreman_proxy']['tftp_root']
-  if answers['foreman_proxy']['tftp_dirs']
-    dirs = answers['foreman_proxy']['tftp_dirs']
+migrate_module('foreman_proxy') do |mod|
+  root = mod['tftp_root']
+  if (dirs = mod['tftp_dirs'])
     dirs << "#{root}/grub"
     dirs << "#{root}/grub2"
     dirs.uniq!

--- a/config/foreman.migrations/20160906121542_puppetserver_whitelist.rb
+++ b/config/foreman.migrations/20160906121542_puppetserver_whitelist.rb
@@ -1,6 +1,6 @@
 # Redetermine the value of API whitelists, as it changed
 # in puppet-puppet f9b4e87cd855d7d5d0bbf3a1831b5daf22cdb413
-if answers['puppet']
-  answers['puppet'].delete('server_admin_api_whitelist')
-  answers['puppet'].delete('server_ca_client_whitelist')
+migrate_module('puppet') do |mod|
+  mod.delete('server_admin_api_whitelist')
+  mod.delete('server_ca_client_whitelist')
 end

--- a/config/foreman.migrations/20160919172842_infoblox.rb
+++ b/config/foreman.migrations/20160919172842_infoblox.rb
@@ -1,2 +1,2 @@
-answers['foreman_proxy::plugin::dns::infoblox'] ||= false
-answers['foreman_proxy::plugin::dhcp::infoblox'] ||= false
+add_module('foreman_proxy::plugin::dns::infoblox')
+add_module('foreman_proxy::plugin::dhcp::infoblox')

--- a/config/foreman.migrations/20160919173201_smart_proxy_ansible.rb
+++ b/config/foreman.migrations/20160919173201_smart_proxy_ansible.rb
@@ -1,1 +1,1 @@
-answers['foreman_proxy::plugin::ansible'] ||= false
+add_module('foreman_proxy::plugin::ansible')

--- a/config/foreman.migrations/20161122124500_hammer_cli_openscap.rb
+++ b/config/foreman.migrations/20161122124500_hammer_cli_openscap.rb
@@ -1,1 +1,1 @@
-answers['foreman::cli::openscap'] ||= false
+add_module('foreman::cli::openscap')

--- a/config/foreman.migrations/20161125153500_foreman_email_config_method.rb
+++ b/config/foreman.migrations/20161125153500_foreman_email_config_method.rb
@@ -1,1 +1,3 @@
-answers['foreman']['email_config_method'] = 'database' if answers['foreman']
+migrate_module('foreman') do |mod|
+  mod['email_config_method'] = 'database'
+end

--- a/config/foreman.migrations/20170111083507_foreman_monitoring.rb
+++ b/config/foreman.migrations/20170111083507_foreman_monitoring.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::monitoring'] ||= false
+add_module('foreman::plugin::monitoring')

--- a/config/foreman.migrations/20170111083525_foreman_omaha.rb
+++ b/config/foreman.migrations/20170111083525_foreman_omaha.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::omaha'] ||= false
+add_module('foreman::plugin::omaha')

--- a/config/foreman.migrations/20170111083555_smart_proxy_monitoring.rb
+++ b/config/foreman.migrations/20170111083555_smart_proxy_monitoring.rb
@@ -1,1 +1,1 @@
-answers['foreman_proxy::plugin::monitoring'] ||= false
+add_module('foreman_proxy::plugin::monitoring')

--- a/config/foreman.migrations/20170111083612_smart_proxy_omaha.rb
+++ b/config/foreman.migrations/20170111083612_smart_proxy_omaha.rb
@@ -1,1 +1,1 @@
-answers['foreman_proxy::plugin::omaha'] ||= false
+add_module('foreman_proxy::plugin::omaha')

--- a/config/foreman.migrations/20170118105627_foreman_proxy_dhcp_range_false.rb
+++ b/config/foreman.migrations/20170118105627_foreman_proxy_dhcp_range_false.rb
@@ -1,2 +1,2 @@
 # false is no longer a valid value, the param should be undef/nil to be disabled
-answers['foreman_proxy']['dhcp_range'] = nil if answers['foreman_proxy'] && answers['foreman_proxy']['dhcp_range'] == false
+unset_answer('foreman_proxy', 'dhcp_range') if get_answer('foreman_proxy', 'dhcp_range') == false

--- a/config/foreman.migrations/20170213123300_foreman_proxy_realm_split_configs.rb
+++ b/config/foreman.migrations/20170213123300_foreman_proxy_realm_split_configs.rb
@@ -1,1 +1,3 @@
-answers['foreman_proxy']['realm_split_config_files'] = true if answers['foreman_proxy']
+migrate_module('foreman_proxy') do |mod|
+  mod['realm_split_config_files'] = true
+end

--- a/config/foreman.migrations/20170331081217_foreman_proxy_dhcp_remote_isc.rb
+++ b/config/foreman.migrations/20170331081217_foreman_proxy_dhcp_remote_isc.rb
@@ -1,1 +1,1 @@
-answers['foreman_proxy::plugin::dhcp::remote_isc'] ||= false
+add_module('foreman_proxy::plugin::dhcp::remote_isc')

--- a/config/foreman.migrations/20170405155121_foreman_proxy_bind_host_array.rb
+++ b/config/foreman.migrations/20170405155121_foreman_proxy_bind_host_array.rb
@@ -1,3 +1,5 @@
-if answers['foreman_proxy'] && answers['foreman_proxy']['bind_host'].is_a?(String)
-  answers['foreman_proxy']['bind_host'] = [answers['foreman_proxy']['bind_host']]
+migrate_module('foreman_proxy') do |mod|
+  if mod['bind_host'].is_a?(String)
+    mod['bind_host'] = [mod['bind_host']]
+  end
 end

--- a/config/foreman.migrations/20180801104012_foreman_snapshot_management.rb
+++ b/config/foreman.migrations/20180801104012_foreman_snapshot_management.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::snapshot_management'] ||= false
+add_module('foreman::plugin::snapshot_management')

--- a/config/foreman.migrations/20180821005330_foreman_jobs_service.rb
+++ b/config/foreman.migrations/20180821005330_foreman_jobs_service.rb
@@ -1,3 +1,1 @@
-if answers['foreman'].is_a?(Hash) && answers['foreman'].key?('jobs_service') && answers['foreman']['jobs_service'].nil?
-  answers['foreman'].delete('jobs_service')
-end
+unset_answer('foreman', 'jobs_service') if get_answer('foreman', 'jobs_service').nil?

--- a/config/foreman.migrations/20180829115142_change_rex_ssh_dir.rb
+++ b/config/foreman.migrations/20180829115142_change_rex_ssh_dir.rb
@@ -1,8 +1,5 @@
-plugin_conf = answers['foreman_proxy::plugin::remote_execution::ssh']
-if plugin_conf
-  if plugin_conf.is_a?(Hash) && plugin_conf['ssh_identity_dir'] == '/usr/share/foreman-proxy/.ssh'
-    answers['foreman_proxy::plugin::remote_execution::ssh']['ssh_identity_dir'] = '/var/lib/foreman-proxy/ssh'
-  elsif !plugin_conf.is_a?(Hash)
-    answers['foreman_proxy::plugin::remote_execution::ssh'] = { 'ssh_identity_dir' => '/var/lib/foreman-proxy/ssh' }
+migrate_module('foreman_proxy::plugin::remote_execution::ssh'] do |mod|
+  if mod['ssh_identity_dir'] == '/usr/share/foreman-proxy/.ssh' || mod['ssh_identity_dir'].nil?
+    mod['ssh_identity_dir'] = '/var/lib/foreman-proxy/ssh'
   end
 end

--- a/config/foreman.migrations/20181015123542_migrate_seed_params.rb
+++ b/config/foreman.migrations/20181015123542_migrate_seed_params.rb
@@ -1,6 +1,5 @@
-mod = answers['foreman']
-if mod.is_a?(Hash)
+migrate_module('foreman') do |mod|
   ['admin_username', 'admin_password', 'admin_first_name', 'admin_last_name', 'admin_email'].each do |var|
-    mod["initial_#{var}"] = mod[var] unless mod[var].nil?
+    mod.rename_parameter(var, "initial_#{var}")
   end
 end

--- a/config/foreman.migrations/20181113150224-add-cli-plugins.rb
+++ b/config/foreman.migrations/20181113150224-add-cli-plugins.rb
@@ -1,4 +1,4 @@
-answers['foreman::cli::discovery'] ||= false
-answers['foreman::cli::remote_execution'] ||= false
-answers['foreman::cli::tasks'] ||= false
-answers['foreman::cli::templates'] ||= false
+add_module('foreman::cli::discovery')
+add_module('foreman::cli::remote_execution')
+add_module('foreman::cli::tasks')
+add_module('foreman::cli::templates')

--- a/config/foreman.migrations/20181114569402_add_ansible_cli.rb
+++ b/config/foreman.migrations/20181114569402_add_ansible_cli.rb
@@ -1,1 +1,1 @@
-answers['foreman::cli::ansible'] ||= false
+add_module('foreman::cli::ansible')

--- a/config/foreman.migrations/20190111180118_delete_removed_settings.rb
+++ b/config/foreman.migrations/20190111180118_delete_removed_settings.rb
@@ -1,74 +1,10 @@
-DELETED = {
-  'foreman' => [
-    'custom_repo',
-    'dynflow_in_core',
-    'email_conf',
-    'email_config_method',
-    'email_source',
-    'puppet_home',
-    'puppet_ssldir',
-  ],
-  'foreman_proxy' => [
-    'custom_repo',
-    'puppetca_modular',
-    'realm_split_config_files',
-    'use_autosignfile',
-  ],
-  'foreman_proxy::plugin::dhcp::infoblox' => [
-    'use_ranges',
-  ],
-  'puppet' => [
-    'agent_template',
-    'main_template',
-    'server_app_root',
-    'server_ca_proxy',
-    'server_directory_environments',
-    'server_dynamic_environments',
-    'server_environments',
-    'server_http_allow',
-    'server_httpd_service',
-    'server_implementation',
-    'server_main_template',
-    'server_passenger',
-    'server_passenger_min_instances',
-    'server_passenger_pre_start',
-    'server_passenger_ruby',
-    'server_rack_arguments',
-    'server_service_fallback',
-    'server_template',
-  ],
-}.freeze
-
-CLEAR = {
-  'foreman' => [
-    'authentication',
-    'locations_enabled',
-    'organizations_enabled',
-    'repo',
-  ],
-  'foreman_proxy' => [
-    'repo',
-  ],
-}.freeze
-
-DELETED.each do |mod, parameters|
-  mod_answers = answers[mod]
-  next unless mod_answers.is_a?(Hash)
-
-  parameters.each do |parameter|
-    mod_answers.delete(parameter)
+migrate_module('foreman') do |mod|
+  ['authentication', 'locations_enabled', 'organizations_enabled', 'repo'].each do |parameter|
+    mod.unset_answer(parameter)
   end
 end
 
-CLEAR.each do |mod, parameters|
-  mod_answers = answers[mod]
-  next unless mod_answers.is_a?(Hash)
-
-  parameters.each do |parameter|
-    mod_answers[parameter] = nil if mod_answers[parameter]
-  end
-end
-
-if (mod_answers = answers['foreman_proxy'])
-  mod_answers['dhcp_gateway'] = nil if mod_answers['dhcp_gateway'] == '192.168.100.1'
+migrate_module('foreman_proxy') do |mod|
+  mod.unset_answer('repo')
+  mod.unset_answer('dhcp_gateway') if mod['dhcp_gateway'] == '192.168.100.1'
 end

--- a/config/foreman.migrations/20190423154755_remove-docker-abrt-plugins.rb
+++ b/config/foreman.migrations/20190423154755_remove-docker-abrt-plugins.rb
@@ -1,3 +1,2 @@
-['foreman::plugin::docker', 'foreman_proxy::plugin::abrt'].each do |plugin|
-  answers.delete(plugin) if answers.include?(plugin)
-end
+delete_module('foreman::plugin::docker')
+delete_module('foreman_proxy::plugin::abrt')

--- a/config/foreman.migrations/20190502234130_foreman_kubevirt.rb
+++ b/config/foreman.migrations/20190502234130_foreman_kubevirt.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::kubevirt'] ||= false
+add_module('foreman::plugin::kubevirt')

--- a/config/foreman.migrations/20190520122507_hammer_cli_kubevirt.rb
+++ b/config/foreman.migrations/20190520122507_hammer_cli_kubevirt.rb
@@ -1,1 +1,1 @@
-answers['foreman::cli::kubevirt'] ||= false
+add_module('foreman::cli::kubevirt')

--- a/config/foreman.migrations/20190903120000_remove-cockpit-plugin.rb
+++ b/config/foreman.migrations/20190903120000_remove-cockpit-plugin.rb
@@ -1,3 +1,1 @@
-['foreman::plugin::cockpit'].each do |plugin|
-  answers.delete(plugin) if answers.include?(plugin)
-end
+delete_module('foreman::plugin::cockpit')

--- a/config/foreman.migrations/20191029130301_add_rex-cockpit.rb
+++ b/config/foreman.migrations/20191029130301_add_rex-cockpit.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::remote_execution::cockpit'] ||= false
+add_module('foreman::plugin::remote_execution::cockpit')

--- a/config/foreman.migrations/20191121124856_hammer_cli_azure.rb
+++ b/config/foreman.migrations/20191121124856_hammer_cli_azure.rb
@@ -1,1 +1,1 @@
-answers['foreman::cli::azure'] ||= false
+add_module('foreman::cli::azure')

--- a/config/foreman.migrations/20200113133837_reset_bind-host-foreman-proxy.rb
+++ b/config/foreman.migrations/20200113133837_reset_bind-host-foreman-proxy.rb
@@ -1,7 +1,5 @@
-if answers['foreman_proxy'].is_a?(Hash) &&
-   answers['foreman_proxy']['bind_host'].is_a?(Array) &&
-   answers['foreman_proxy']['bind_host'].include?('::') &&
-   facts[:os][:release][:major] == '7' &&
-   facts[:os][:family] == 'RedHat'
-  answers['foreman_proxy'].delete('bind_host')
+migrate_module('foreman_proxy') do |mod|
+  if mod['bind_host'].is_a?(Array) && mod['bind_host'].include?('::') && facts[:os][:release][:major] == '7' && facts[:os][:family] == 'RedHat'
+    mod.unset_answer('bind_host')
+  end
 end

--- a/config/foreman.migrations/20200305172758_enable_puma.rb
+++ b/config/foreman.migrations/20200305172758_enable_puma.rb
@@ -1,1 +1,3 @@
-answers['foreman']['passenger'] = false if answers['foreman'].is_a?(Hash) && answers['foreman']['passenger']
+migrate_module('foreman') do |mod|
+  mod['passenger'] = false if mod['passenger']
+end

--- a/config/foreman.migrations/20200504073814_add_foreman_leapp.rb
+++ b/config/foreman.migrations/20200504073814_add_foreman_leapp.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::leapp'] ||= false
+add_module('foreman::plugin::leapp')

--- a/config/foreman.migrations/20200803163936_add_statistics-plugin.rb
+++ b/config/foreman.migrations/20200803163936_add_statistics-plugin.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::statistics'] ||= false
+add_module('foreman::plugin::statistics')

--- a/config/foreman.migrations/20200803185054_add_column-view-plugin.rb
+++ b/config/foreman.migrations/20200803185054_add_column-view-plugin.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::column_view'] ||= false
+add_module('foreman::plugin::column_view')

--- a/config/foreman.migrations/20200805102253_change_logging_layout.rb
+++ b/config/foreman.migrations/20200805102253_change_logging_layout.rb
@@ -1,5 +1,4 @@
-mod = answers['foreman']
-layout_key = 'logging_layout'
-if mod.is_a?(Hash) && mod[layout_key] == 'pattern'
-  mod[layout_key] = 'multiline_request_pattern'
+migrate_module('foreman') do |mod|
+  layout_key = 'logging_layout'
+  mod[layout_key] = 'multiline_request_pattern' if mod[layout_key] == 'pattern'
 end

--- a/config/foreman.migrations/20200909151007_manage_acls_on_debian.rb
+++ b/config/foreman.migrations/20200909151007_manage_acls_on_debian.rb
@@ -1,3 +1,5 @@
-if answers['foreman_proxy'].is_a?(Hash) && facts[:os][:family] == 'Debian'
-  answers['foreman_proxy']['dhcp_manage_acls'] ||= true if answers['foreman_proxy'].key?('dhcp_manage_acls')
+migrate_module('foreman_proxy') do |mod|
+  if facts[:os][:family] == 'Debian'
+    mod['dhcp_manage_acls'] ||= true if mod.key?('dhcp_manage_acls')
+  end
 end

--- a/config/foreman.migrations/20201020000326_drop_rackspace.rb
+++ b/config/foreman.migrations/20201020000326_drop_rackspace.rb
@@ -1,3 +1,1 @@
-if answers.key?('foreman::compute::rackspace')
-  answers.delete('foreman::compute::rackspace')
-end
+remove_module('foreman::compute::rackspace')

--- a/config/foreman.migrations/20201207225700_remove_digitalocean-plugin.rb
+++ b/config/foreman.migrations/20201207225700_remove_digitalocean-plugin.rb
@@ -1,3 +1,1 @@
-if answers.key?('foreman::plugin::digitalocean')
-  answers.delete('foreman::plugin::digitalocean')
-end
+remove_module('foreman::plugin::digitalocean')

--- a/config/foreman.migrations/20201224125100_ansible_ssh_args.rb
+++ b/config/foreman.migrations/20201224125100_ansible_ssh_args.rb
@@ -1,4 +1,6 @@
 # migrate the default
-if answers['foreman_proxy::plugin::ansible'].is_a?(Hash) && answers['foreman_proxy::plugin::ansible']['ssh_args'] == '-o ProxyCommand=none'
-  answers['foreman_proxy::plugin::ansible']['ssh_args'] = '-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s'
+migrate_module('foreman_proxy::plugin::ansible') do |mod|
+  if mod['ssh_args'] == '-o ProxyCommand=none'
+    mod['ssh_args'] = '-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s'
+  end
 end

--- a/config/foreman.migrations/20210129165012_drop_foreman_proxy_plugin_pulp.rb
+++ b/config/foreman.migrations/20210129165012_drop_foreman_proxy_plugin_pulp.rb
@@ -1,1 +1,1 @@
-answers.delete('foreman_proxy::plugin::pulp')
+remove_module('foreman_proxy::plugin::pulp')

--- a/config/foreman.migrations/20210304102210_add_webhooks_plugin.rb
+++ b/config/foreman.migrations/20210304102210_add_webhooks_plugin.rb
@@ -1,1 +1,1 @@
-answers['foreman::plugin::webhooks'] ||= false
+add_module('foreman::plugin::webhooks')

--- a/config/foreman.migrations/20210304102446_add_proxy_shellhooks_plugin.rb
+++ b/config/foreman.migrations/20210304102446_add_proxy_shellhooks_plugin.rb
@@ -1,1 +1,1 @@
-answers['foreman_proxy::plugin::shellhooks'] ||= false
+add_module('foreman_proxy::plugin::shellhooks')

--- a/config/foreman.migrations/20210323145821_foreman_tasks-backup.rb
+++ b/config/foreman.migrations/20210323145821_foreman_tasks-backup.rb
@@ -1,3 +1,3 @@
-if answers['foreman::plugin::tasks'].is_a?(Hash) && !answers['foreman::plugin::tasks'].key?('backup')
-  answers['foreman::plugin::tasks']['backup'] = true
+migrate_module('foreman::plugin::tasks') do |mod|
+  mod['backup'] = true unless mod.key?('backup')
 end

--- a/config/foreman.migrations/20210331121715_clear_puppetserver-nil-metrics.rb
+++ b/config/foreman.migrations/20210331121715_clear_puppetserver-nil-metrics.rb
@@ -1,3 +1,1 @@
-if answers['puppet'].is_a?(Hash)
-  answers['puppet'].delete('server_puppetserver_metrics') if answers['puppet']['server_puppetserver_metrics'].nil?
-end
+unset_answer('puppet', 'server_puppetserver_metrics') if get_answer('puppet', 'server_puppetserver_metrics').nil?

--- a/config/foreman.migrations/20210625142707_dynamic_puppet_in_foreman_groups.rb
+++ b/config/foreman.migrations/20210625142707_dynamic_puppet_in_foreman_groups.rb
@@ -1,5 +1,5 @@
-if answers['foreman'].is_a?(Hash)
-  if answers['foreman']['user_groups'] && answers['foreman']['user_groups'].include?('puppet')
-    answers['foreman']['user_groups'].delete('puppet')
+migrate_module('foreman') do |mod|
+  if mod['user_groups'] && mod['user_groups'].include?('puppet')
+    mod['user_groups'].delete('puppet')
   end
 end

--- a/config/foreman.migrations/20210708144320_add_foreman_puppet.rb
+++ b/config/foreman.migrations/20210708144320_add_foreman_puppet.rb
@@ -1,3 +1,1 @@
-unless answers.key?('foreman::plugin::puppet')
-  answers['foreman::plugin::puppet'] = true
-end
+add_module('foreman::plugin::puppet', true)


### PR DESCRIPTION
This rewrites most Foreman migrations to a new migration DSL. The DSL decouples from the actual answer file structure and is more expressive.

Technically the DSL doesn't exist, but this at least makes sure that it's possible to express everything with the DSL I had in mind. As a reference to https://github.com/theforeman/kafo/pull/337.