### PR TITLE
Do not pass --assumeyes to f-maintain packages is-locked

### DIFF
--- a/hooks/pre_commit/09-version_locking.rb
+++ b/hooks/pre_commit/09-version_locking.rb
@@ -1,5 +1,5 @@
 def packages_locked?
-  foreman_maintain('packages is-locked --assumeyes')
+  foreman_maintain('packages is-locked')
 end
 
 def unlock_packages


### PR DESCRIPTION
This doesn't make sense and in the latest foreman-maintain 0.8.3 it's [no longer accepted](https://github.com/theforeman/foreman_maintain/commit/374e3d10e4dd434ed6ccfbbc28136e31c3fdde3c).