### PR TITLE
Reflect changes for Puppetserver 7 support

### DIFF
--- a/config/foreman-proxy-content.migrations/210726184347-clear-puppet-server-ssl-chain-filepath.rb
+++ b/config/foreman-proxy-content.migrations/210726184347-clear-puppet-server-ssl-chain-filepath.rb
@@ -1,0 +1,5 @@
+# server_ssl_chain_filepath changed its default to undef, clear old default
+# https://github.com/theforeman/puppet-puppet/commit/818bf005b2a1b0f48896c5c9db9afbcf59aadb1c
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_ssl_chain_filepath'] == '/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem'
+  answers['puppet'].delete('server_ssl_chain_filepath')
+end

--- a/config/foreman.migrations/20210726184347_clear_puppet_server_ssl_chain_filepath.rb
+++ b/config/foreman.migrations/20210726184347_clear_puppet_server_ssl_chain_filepath.rb
@@ -1,0 +1,5 @@
+# server_ssl_chain_filepath changed its default to undef, clear old default
+# https://github.com/theforeman/puppet-puppet/commit/818bf005b2a1b0f48896c5c9db9afbcf59aadb1c
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_ssl_chain_filepath'] == '/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem'
+  answers['puppet'].delete('server_ssl_chain_filepath')
+end

--- a/config/katello.migrations/210726184347-clear-puppet-server-ssl-chain-filepath.rb
+++ b/config/katello.migrations/210726184347-clear-puppet-server-ssl-chain-filepath.rb
@@ -1,0 +1,5 @@
+# server_ssl_chain_filepath changed its default to undef, clear old default
+# https://github.com/theforeman/puppet-puppet/commit/818bf005b2a1b0f48896c5c9db9afbcf59aadb1c
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_ssl_chain_filepath'] == '/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem'
+  answers['puppet'].delete('server_ssl_chain_filepath')
+end

--- a/hooks/pre/31-puppet_server_migrate_ca.rb
+++ b/hooks/pre/31-puppet_server_migrate_ca.rb
@@ -1,0 +1,16 @@
+# In Puppetserver 7 the ca directory has moved from
+# /etc/puppetlabs/puppet/ssl/ca to /etc/puppetlabs/puppetserver/ca
+# There is a command (puppetserver ca migrate) to migrate, but this requires
+# the server to be stopped. The Puppet module can execute the migration, but
+# can't stop the service.
+stdout_stderr, _status = execute_command('puppetserver --version', false, true)
+stdout_stderr&.match(/puppetserver version: (?<version>\d+)\.\d+\.\d+/) do |match|
+  old_ca_dir = '/etc/puppetlabs/puppet/ssl/ca'
+  if m[:version] == '7' && File.directory?(old_ca_dir) && !File.symlink?(old_ca_dir)
+    if app_value(:noop)
+      logger.debug 'Would stop puppetserver.service to migrate CA directory'
+    else
+      stop_services(['puppetserver.service'])
+    end
+  end
+end


### PR DESCRIPTION
This adds a migration to clear --puppet-server-ssl-chain-filepath if it's the old default. It also stops the puppetserver service if needed to migrate the CA directory.