### PR TITLE
Fixes #33191 - Debian puppet-agent-oauth reinstall support

### DIFF
--- a/hooks/pre/31-puppet_agent_oauth.rb
+++ b/hooks/pre/31-puppet_agent_oauth.rb
@@ -1,9 +1,33 @@
-unless app_value(:noop)
-  if File.exist?('/opt/puppetlabs/puppet/bin/ruby') && execute("rpm -q puppet-agent-oauth", false, false)
-    unless execute("/opt/puppetlabs/puppet/bin/ruby -e \"require 'oauth'\"", false, false)
-      success = execute("yum -y reinstall puppet-agent-oauth", false, true)
+def oauth_aio_gem_installed?
+  return false unless File.exist?('/opt/puppetlabs/puppet/bin/ruby')
 
-      logger.error("Failed to reinstall puppet-agent-oauth. Please check that the package is available from a repository.") unless success
-    end
+  case facts['os']['family']
+  when 'Debian'
+    execute("dpkg-query --show --showformat='${db:Status-Status}' puppet-agent-oauth | grep -q '^installed'", false, false)
+  when 'RedHat'
+    execute("rpm -q puppet-agent-oauth", false, false)
+  end
+end
+
+def oauth_aio_gem_works?
+  execute("/opt/puppetlabs/puppet/bin/ruby -e \"require 'oauth'\"", false, false)
+end
+
+def reinstall_oauth_aio_gem
+  case facts['os']['family']
+  when 'Debian'
+    execute("apt-get --reinstall install puppet-agent-oauth", false, true)
+  when 'RedHat'
+    execute("yum -y reinstall puppet-agent-oauth", false, true)
+  end
+end
+
+if oauth_aio_gem_installed? && !oauth_aio_gem_works?
+  if app_value(:noop)
+    logger.error('Detected broken puppet-agent-oauth; needs reinstall')
+  else
+    success = reinstall_oauth_aio_gem
+
+    logger.error("Failed to reinstall puppet-agent-oauth. Please check that the package is available from a repository.") unless success
   end
 end


### PR DESCRIPTION
This has been supported for a while on RPM-based distros. This adds it on Debian.

It also changes it to log an error on noop that it detected an incorrect situation.

Credits to @timdeluxe in https://github.com/theforeman/foreman-installer/pull/641 for the specific dpkg/apt commands. This PR takes a bit different implementation approach by also looking at facts. This should save some useless command executions on both platforms.