### PR TITLE
Add a migration for foreman_proxy's httpboot

### DIFF
--- a/config/foreman-proxy-content.migrations/210802145222-reset-foreman-proxy-httpboot-undef.rb
+++ b/config/foreman-proxy-content.migrations/210802145222-reset-foreman-proxy-httpboot-undef.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-foreman_proxy/commit/e4b7763e45fecc5fbaa5d88cc066906d6caf7bf7
+# changed httpboot from Optional[Boolean] to Boolean
+if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['httpboot'].nil?
+  answers['foreman_proxy'].delete('httpboot')
+end

--- a/config/foreman.migrations/20210802145222_reset_foreman_proxy_httpboot_undef.rb
+++ b/config/foreman.migrations/20210802145222_reset_foreman_proxy_httpboot_undef.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-foreman_proxy/commit/e4b7763e45fecc5fbaa5d88cc066906d6caf7bf7
+# changed httpboot from Optional[Boolean] to Boolean
+if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['httpboot'].nil?
+  answers['foreman_proxy'].delete('httpboot')
+end

--- a/config/katello.migrations/210802145222-reset-foreman-proxy-httpboot-undef.rb
+++ b/config/katello.migrations/210802145222-reset-foreman-proxy-httpboot-undef.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-foreman_proxy/commit/e4b7763e45fecc5fbaa5d88cc066906d6caf7bf7
+# changed httpboot from Optional[Boolean] to Boolean
+if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['httpboot'].nil?
+  answers['foreman_proxy'].delete('httpboot')
+end


### PR DESCRIPTION
The httpboot option [changed](https://github.com/theforeman/puppet-foreman_proxy/commit/e4b7763e45fecc5fbaa5d88cc066906d6caf7bf7) from Optional[Boolean] to Boolean. That requires a migration if the value was undef.

Reported by @ares.