### PR TITLE
Add hammer-cli-foreman-puppet

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -16,6 +16,7 @@ foreman::cli::azure: false
 foreman::cli::discovery: false
 foreman::cli::kubevirt: false
 foreman::cli::openscap: false
+foreman::cli::puppet: true
 foreman::cli::remote_execution: false
 foreman::cli::tasks: false
 foreman::cli::templates: false

--- a/config/foreman.migrations/20210803130619_add_hammer_puppet_plugin.rb
+++ b/config/foreman.migrations/20210803130619_add_hammer_puppet_plugin.rb
@@ -1,0 +1,3 @@
+unless answers.key?('foreman::cli::puppet')
+  answers['foreman::cli::puppet'] = true
+end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -29,6 +29,7 @@ foreman::cli::discovery: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
 foreman::cli::openscap: false
+foreman::cli::puppet: true
 foreman::cli::remote_execution: true
 foreman::cli::tasks: false
 foreman::cli::templates: false

--- a/config/katello.migrations/20210803130619-add-hammer-puppet-plugin.rb
+++ b/config/katello.migrations/20210803130619-add-hammer-puppet-plugin.rb
@@ -1,0 +1,3 @@
+unless answers.key?('foreman::cli::puppet')
+  answers['foreman::cli::puppet'] = true
+end

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -3,6 +3,7 @@ foreman::cli::ansible: false
 foreman::cli::azure: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
+foreman::cli::puppet: true
 foreman::cli::remote_execution: true
 foreman::cli::virt_who_configure: false
 foreman::compute::ec2: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -3,6 +3,7 @@ foreman::cli::ansible: false
 foreman::cli::azure: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
+foreman::cli::puppet: true
 foreman::cli::remote_execution: true
 foreman::cli::virt_who_configure: false
 foreman::compute::ec2: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -3,6 +3,7 @@ foreman::cli::ansible: false
 foreman::cli::azure: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
+foreman::cli::puppet: true
 foreman::cli::remote_execution: true
 foreman::cli::virt_who_configure: false
 foreman::compute::ec2: false


### PR DESCRIPTION
This will break Debian nightly until hammer-cli-foreman 3.0.0 is out and https://github.com/theforeman/foreman-packaging/pull/6975 is merged. For now I'd like to accept that and continue with RPMs where we do have nightly RPMs.