### PR TITLE
Refs #33214: Reset puma min threads to default from puppet module

### DIFF
--- a/config/foreman.migrations/20210809133823_reset_puma_min_threads.rb
+++ b/config/foreman.migrations/20210809133823_reset_puma_min_threads.rb
@@ -1,0 +1,6 @@
+if answers['foreman'].is_a?(Hash)
+  if answers['foreman']['foreman_service_puma_threads_min'] == 0 ||
+     answers['foreman']['foreman_service_puma_threads_min'] == answers['foreman']['foreman_service_puma_threads_max']
+    answers['foreman'].delete('foreman_service_puma_threads_min')
+  end
+end

--- a/config/katello.migrations/210809133829-reset-puma-min-threads.rb
+++ b/config/katello.migrations/210809133829-reset-puma-min-threads.rb
@@ -1,0 +1,6 @@
+if answers['foreman'].is_a?(Hash)
+  if answers['foreman']['foreman_service_puma_threads_min'] == 0 ||
+     answers['foreman']['foreman_service_puma_threads_min'] == answers['foreman']['foreman_service_puma_threads_max']
+    answers['foreman'].delete('foreman_service_puma_threads_min')
+  end
+end


### PR DESCRIPTION
If the default value for foreman_service_puma_threads_min is found,
which is zero, this deletes that value from the answers file. This
allows the new default to be populated from the puppet module. The
new default is to set min threads equal to max threads. If the minimum
is anything other than zero than we can assume the user has customized
the value.