### PR TITLE
Fixes #33312 - Set Puma tuning values

### DIFF
--- a/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
@@ -11,3 +11,7 @@ postgresql::server::config_entries:
   work_mem: 8MB
   effective_cache_size: 32GB
   autovacuum_vacuum_cost_limit: 2000
+
+foreman::foreman_service_puma_workers: 72
+foreman::foreman_service_puma_threads_max: 5
+foreman::foreman_service_puma_threads_min: 5

--- a/config/foreman.hiera/tuning/sizes/extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-large.yaml
@@ -11,3 +11,7 @@ postgresql::server::config_entries:
   work_mem: 8MB
   effective_cache_size: 32GB
   autovacuum_vacuum_cost_limit: 2000
+
+foreman::foreman_service_puma_workers: 48
+foreman::foreman_service_puma_threads_max: 5
+foreman::foreman_service_puma_threads_min: 5

--- a/config/foreman.hiera/tuning/sizes/large.yaml
+++ b/config/foreman.hiera/tuning/sizes/large.yaml
@@ -8,3 +8,7 @@ postgresql::server::config_entries:
   shared_buffers: 8GB
   effective_cache_size: 16GB
   autovacuum_vacuum_cost_limit: 2000
+
+foreman::foreman_service_puma_workers: 24
+foreman::foreman_service_puma_threads_max: 5
+foreman::foreman_service_puma_threads_min: 5

--- a/config/foreman.hiera/tuning/sizes/medium.yaml
+++ b/config/foreman.hiera/tuning/sizes/medium.yaml
@@ -8,3 +8,7 @@ postgresql::server::config_entries:
   shared_buffers: 4GB
   effective_cache_size: 16GB
   autovacuum_vacuum_cost_limit: 2000
+
+foreman::foreman_service_puma_workers: 6
+foreman::foreman_service_puma_threads_max: 5
+foreman::foreman_service_puma_threads_min: 5


### PR DESCRIPTION
This initially sets the Puma tuning values based on the same ideas
from https://github.com/theforeman/puppet-foreman/pull/986 statically
calculated for each of the CPU and memory values that exist for the
various profiles.