### PR TITLE
Fixes #33337 - Do not enable Puppet infrastructure by default for Katello scenarios

### DIFF
--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -13,6 +13,7 @@ certs:
   generate: false
 foreman_proxy_content:
   pulpcore_mirror: true
+  puppet: false
 foreman_proxy:
   foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
   foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
@@ -24,6 +25,8 @@ foreman_proxy:
   ssl_key: /etc/foreman-proxy/ssl_key.pem
   ssl_port: '9090'
   templates: true
+  puppet: false
+  puppetca: false
 foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::dhcp::infoblox: false
@@ -33,11 +36,4 @@ foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::shellhooks: false
-puppet:
-  server: true
-  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
-  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
-  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
-  server_jvm_extra_args:
-    - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
-    - "-XX:ReservedCodeCacheSize=512m"
+puppet: false

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -29,7 +29,7 @@ foreman::cli::discovery: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
 foreman::cli::openscap: false
-foreman::cli::puppet: true
+foreman::cli::puppet: false
 foreman::cli::remote_execution: true
 foreman::cli::tasks: false
 foreman::cli::templates: false
@@ -56,7 +56,7 @@ foreman::plugin::leapp: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
 foreman::plugin::openscap: false
-foreman::plugin::puppet: true
+foreman::plugin::puppet: false
 foreman::plugin::puppetdb: false
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
@@ -78,6 +78,8 @@ foreman_proxy:
   ssl_cert: /etc/foreman-proxy/ssl_cert.pem
   ssl_key: /etc/foreman-proxy/ssl_key.pem
   ssl_port: '9090'
+  puppet: false
+  puppetca: false
 foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::chef: false
@@ -92,11 +94,4 @@ foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false
 foreman_proxy_content: true
 katello: true
-puppet:
-  server: true
-  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
-  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
-  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
-  server_jvm_extra_args:
-    - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
-    - "-XX:ReservedCodeCacheSize=512m"
+puppet: false

--- a/katello_certs/hooks/boot/02-message-helpers.rb
+++ b/katello_certs/hooks/boot/02-message-helpers.rb
@@ -62,8 +62,7 @@ module KatelloCertsMessageHookContextExtension
                     --foreman-proxy-trusted-hosts                 "#{fqdn}"\\
                     --foreman-proxy-trusted-hosts                 "#{foreman_proxy_fqdn}"\\
                     --foreman-proxy-oauth-consumer-key            "#{foreman_oauth_key}"\\
-                    --foreman-proxy-oauth-consumer-secret         "#{foreman_oauth_secret}"\\
-                    --puppet-server-foreman-url                   "#{foreman_url}"
+                    --foreman-proxy-oauth-consumer-secret         "#{foreman_oauth_secret}"
 MSG
   end
 end


### PR DESCRIPTION
This simplifies Katello's initial deployment to have Puppet off by default and matches what Foreman 3.1 will aim for. New installations will not get Puppet and users will need to make that choice. Upgrades will remain in tact. Users who wish to turn puppet on will need to run:

```
foreman-installer --scenario katello --enable-foreman-plugin-puppet --foreman-proxy-puppet true --foreman-proxy-puppetca true --foreman-proxy-content-puppet true --enable-puppet --puppet-server true --puppet-server-environments-owner apache --puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt --puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt --puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
```

Upgrading users who wish to disable would run (though this needs to be tested):

```
foreman-installer --scenario katello --no-enable-foreman-plugin-puppet --foreman-proxy-puppet false --foreman-proxy-puppetca false --foreman-proxy-content-puppet false --no-enable-puppet
```

As I am not sure what disabling the plugin will od here as it would leave data. I will look to add some bats tests.