### PR TITLE
Externalize answer defaults

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -9,7 +9,7 @@
 #
 # See params.pp in each class for what options are available
 ---
-foreman: {}
+foreman: true
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
@@ -57,7 +57,7 @@ foreman::plugin::statistics: false
 foreman::plugin::tasks: false
 foreman::plugin::templates: false
 foreman::plugin::webhooks: false
-foreman_proxy: {}
+foreman_proxy: true
 foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::chef: false
@@ -73,8 +73,4 @@ foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false
-puppet:
-  server: true
-  server_jvm_extra_args:
-    - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
-    - "-XX:ReservedCodeCacheSize=512m"
+puppet: true

--- a/config/foreman-hiera.yaml
+++ b/config/foreman-hiera.yaml
@@ -15,6 +15,7 @@ hierarchy:
   - name: "Built in"
     paths:
       - "scenario/%{facts.kafo.scenario.id}/family/%{facts.os.family}-%{facts.os.release.major}.yaml"
+      - "scenario/%{facts.kafo.scenario.id}/defaults.yaml"
       - "family/%{facts.os.family}-%{facts.os.release.major}.yaml"
       - "family/%{facts.os.family}.yaml"
       - "security.yaml"

--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -9,21 +9,9 @@
 #
 # See params.pp in each class for what options are available
 ---
-certs:
-  generate: false
-foreman_proxy_content:
-  pulpcore_mirror: true
-foreman_proxy:
-  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
-  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
-  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
-  http: true
-  manage_puppet_group: false
-  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
-  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
-  ssl_key: /etc/foreman-proxy/ssl_key.pem
-  ssl_port: '9090'
-  templates: true
+certs: true
+foreman_proxy_content: true
+foreman_proxy: true
 foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::dhcp::infoblox: false
@@ -33,11 +21,4 @@ foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::shellhooks: false
-puppet:
-  server: true
-  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
-  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
-  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
-  server_jvm_extra_args:
-    - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
-    - "-XX:ReservedCodeCacheSize=512m"
+puppet: true

--- a/config/foreman-proxy-content.migrations/180111142132-foreman_proxy_autosignfile.rb
+++ b/config/foreman-proxy-content.migrations/180111142132-foreman_proxy_autosignfile.rb
@@ -1,4 +1,4 @@
-if answers['foreman_proxy']
+if answers['foreman_proxy'].is_a?(Hash)
   answers['foreman_proxy']['use_autosignfile'] = true
   if answers['foreman_proxy'].key?('puppetdir')
     puppetdir = answers['foreman_proxy']['puppetdir']

--- a/config/foreman-proxy-content.migrations/180702133937-set-puppet-integration-answer.rb
+++ b/config/foreman-proxy-content.migrations/180702133937-set-puppet-integration-answer.rb
@@ -1,4 +1,4 @@
 if answers['foreman_proxy_content'].is_a?(Hash)
-  enabled = answers['puppet'].is_a?(Hash) && answers['puppet']['server'] != false && answers['puppet']['server_foreman'] != false
+  enabled = answers['puppet'] == true || (answers['puppet'].is_a?(Hash) && answers['puppet']['server'] != false && answers['puppet']['server_foreman'] != false)
   answers['foreman_proxy_content']['puppet'] = false unless enabled
 end

--- a/config/foreman-proxy-content.migrations/180813131441-unmanage-puppet-group.rb
+++ b/config/foreman-proxy-content.migrations/180813131441-unmanage-puppet-group.rb
@@ -1,5 +1,0 @@
-if answers['foreman_proxy'].is_a?(Hash)
-  answers['foreman_proxy']['manage_puppet_group'] = false
-elsif answers['foreman_proxy'] == true
-  answers['foreman_proxy'] = { 'manage_puppet_group' => false }
-end

--- a/config/foreman-proxy-content.migrations/190111180118-delete-removed-settings.rb
+++ b/config/foreman-proxy-content.migrations/190111180118-delete-removed-settings.rb
@@ -19,6 +19,6 @@ CLEAR.each do |mod, parameters|
   end
 end
 
-if (mod_answers = answers['foreman_proxy'])
+if (mod_answers = answers['foreman_proxy']) && mod_answers.is_a?(Hash)
   mod_answers['dhcp_gateway'] = nil if mod_answers['dhcp_gateway'] == '192.168.100.1'
 end

--- a/config/foreman-proxy-content.migrations/190111180118-delete-removed-settings.rb
+++ b/config/foreman-proxy-content.migrations/190111180118-delete-removed-settings.rb
@@ -1,44 +1,3 @@
-DELETED = {
-  'foreman' => [
-    'custom_repo',
-    'dynflow_in_core',
-    'email_conf',
-    'email_config_method',
-    'email_source',
-    'puppet_home',
-    'puppet_ssldir',
-  ],
-  'foreman_proxy' => [
-    'custom_repo',
-    'puppetca_modular',
-    'realm_split_config_files',
-    'use_autosignfile',
-  ],
-  'foreman_proxy::plugin::dhcp::infoblox' => [
-    'use_ranges',
-  ],
-  'puppet' => [
-    'agent_template',
-    'main_template',
-    'server_app_root',
-    'server_ca_proxy',
-    'server_directory_environments',
-    'server_dynamic_environments',
-    'server_environments',
-    'server_http_allow',
-    'server_httpd_service',
-    'server_implementation',
-    'server_main_template',
-    'server_passenger',
-    'server_passenger_min_instances',
-    'server_passenger_pre_start',
-    'server_passenger_ruby',
-    'server_rack_arguments',
-    'server_service_fallback',
-    'server_template',
-  ],
-}.freeze
-
 CLEAR = {
   'foreman' => [
     'authentication',
@@ -50,15 +9,6 @@ CLEAR = {
     'repo',
   ],
 }.freeze
-
-DELETED.each do |mod, parameters|
-  mod_answers = answers[mod]
-  next unless mod_answers.is_a?(Hash)
-
-  parameters.each do |parameter|
-    mod_answers.delete(parameter)
-  end
-end
 
 CLEAR.each do |mod, parameters|
   mod_answers = answers[mod]

--- a/config/foreman-proxy-content.migrations/200616155948-disable-pulp-3-proxying.rb
+++ b/config/foreman-proxy-content.migrations/200616155948-disable-pulp-3-proxying.rb
@@ -8,6 +8,6 @@ def upgrade
   answers[FOREMAN_PROXY_CONTENT][PROXY_ISOS] = false
 end
 
-if answers[FOREMAN_PROXY_CONTENT] == true || answers[FOREMAN_PROXY_CONTENT].is_a?(Hash)
+if answers[FOREMAN_PROXY_CONTENT].is_a?(Hash)
   upgrade
 end

--- a/config/foreman-proxy-content.migrations/210112194603-enable-pulp3-content-proxy.rb
+++ b/config/foreman-proxy-content.migrations/210112194603-enable-pulp3-content-proxy.rb
@@ -1,8 +1,6 @@
 answers.delete('foreman_proxy::plugin::pulp')
 
 if answers['foreman_proxy_content'].is_a?(Hash)
-  answers['foreman_proxy_content']['pulpcore_mirror'] = true
-
   # Prior migrations add these so we need to ensure they are deleted
   # config/katello.migrations/200611220455-dont-proxy-pulp-yum-to-pulpcore-on-upgrades.rb
   # config/katello.migrations/200123161606-enable-pulpcore.rb

--- a/config/foreman-proxy-content.migrations/210407174237-add-puppet-reserved-code-cache.rb
+++ b/config/foreman-proxy-content.migrations/210407174237-add-puppet-reserved-code-cache.rb
@@ -12,8 +12,5 @@ if answers['puppet'].is_a?(Hash)
         answers['puppet']['server_jvm_extra_args'] += " #{reserved_code_cache_arg}"
       end
     end
-  else
-    # The logger is silently added by the module if it's undef
-    answers['puppet']['server_jvm_extra_args'] = ['-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger', reserved_code_cache_arg]
   end
 end

--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -19,3 +19,9 @@ katello::globals::enable_file: "%{alias('foreman_proxy_content::enable_file')}"
 katello::globals::enable_docker: "%{alias('foreman_proxy_content::enable_docker')}"
 katello::globals::enable_deb: "%{alias('foreman_proxy_content::enable_deb')}"
 katello::globals::enable_ansible_collection: "%{alias('foreman_proxy_content::enable_ansible')}"
+
+puppet::server: true
+# The logger must be there. The ReservedCodeCacheSize helps with memory issues
+puppet::server_jvm_extra_args:
+  - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+  - "-XX:ReservedCodeCacheSize=512m"

--- a/config/foreman.hiera/scenario/foreman-proxy-content/defaults.yaml
+++ b/config/foreman.hiera/scenario/foreman-proxy-content/defaults.yaml
@@ -1,0 +1,18 @@
+certs::generate: false
+
+foreman_proxy_content::pulpcore_mirror: true
+
+foreman_proxy::foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+foreman_proxy::foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+foreman_proxy::foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::http: true
+foreman_proxy::manage_puppet_group: false
+foreman_proxy::ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+foreman_proxy::ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+foreman_proxy::ssl_key: /etc/foreman-proxy/ssl_key.pem
+foreman_proxy::ssl_port: 9090
+foreman_proxy::templates: true
+
+puppet::server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+puppet::server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+puppet::server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/config/foreman.hiera/scenario/katello/defaults.yaml
+++ b/config/foreman.hiera/scenario/katello/defaults.yaml
@@ -1,0 +1,25 @@
+certs::group: foreman
+
+foreman::client_ssl_ca: /etc/foreman/proxy_ca.pem
+foreman::client_ssl_cert: /etc/foreman/client_cert.pem
+foreman::client_ssl_key: /etc/foreman/client_key.pem
+foreman::initial_location: Default Location
+foreman::initial_organization: Default Organization
+foreman::server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
+foreman::server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+foreman::server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
+foreman::server_ssl_crl: ""
+foreman::server_ssl_key: /etc/pki/katello/private/katello-apache.key
+
+foreman_proxy::foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+foreman_proxy::foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+foreman_proxy::foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+foreman_proxy::manage_puppet_group: false
+foreman_proxy::ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+foreman_proxy::ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+foreman_proxy::ssl_key: /etc/foreman-proxy/ssl_key.pem
+foreman_proxy::ssl_port: 9090
+
+puppet::server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+puppet::server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+puppet::server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/config/foreman.migrations/20160405122117_passenger_ruby.rb
+++ b/config/foreman.migrations/20160405122117_passenger_ruby.rb
@@ -1,2 +1,2 @@
 # Redetermine the value of passenger_ruby, as it changed on Debian in puppet-foreman f9329b6
-answers['foreman'].delete('passenger_ruby') if answers['foreman']
+answers['foreman'].delete('passenger_ruby') if answers['foreman'].is_a?(Hash)

--- a/config/foreman.migrations/20160420224417_puppet_autosign.rb
+++ b/config/foreman.migrations/20160420224417_puppet_autosign.rb
@@ -1,7 +1,7 @@
 # Redetermine the value of autosign, as it changed from string/boolean to path/boolean
 # in puppet-puppet a2325f1 and was deleted from puppet-foreman_proxy 9f3c9aa
-if answers['puppet']
+if answers['puppet'].is_a?(Hash)
   current_autosign = answers['puppet']['autosign']
   answers['puppet'].delete('autosign') unless !!current_autosign == current_autosign # rubocop:disable Style/DoubleNegation
 end
-answers['foreman_proxy'].delete('autosign_location') if answers['foreman_proxy']
+answers['foreman_proxy'].delete('autosign_location') if answers['foreman_proxy'].is_a?(Hash)

--- a/config/foreman.migrations/20160518125928_foreman_proxy_puppetrun_rename.rb
+++ b/config/foreman.migrations/20160518125928_foreman_proxy_puppetrun_rename.rb
@@ -1,4 +1,6 @@
 # Rename foreman_proxy puppetrun parameters to puppet
 # https://github.com/theforeman/puppet-foreman_proxy/commit/c26cac15
-answers['foreman_proxy']['puppet'] = answers['foreman_proxy'].delete('puppetrun') if answers['foreman_proxy'] && answers['foreman_proxy'].has_key?('puppetrun')
-answers['foreman_proxy']['puppet_listen_on'] = answers['foreman_proxy'].delete('puppetrun_listen_on') if answers['foreman_proxy'] && answers['foreman_proxy'].has_key?('puppetrun_listen_on')
+if answers['foreman_proxy'].is_a?(Hash)
+  answers['foreman_proxy']['puppet'] = answers['foreman_proxy'].delete('puppetrun') if answers['foreman_proxy'].has_key?('puppetrun')
+  answers['foreman_proxy']['puppet_listen_on'] = answers['foreman_proxy'].delete('puppetrun_listen_on') if answers['foreman_proxy'].has_key?('puppetrun_listen_on')
+end

--- a/config/foreman.migrations/20160607133050_foreman_proxy_puppetssh_rename.rb
+++ b/config/foreman.migrations/20160607133050_foreman_proxy_puppetssh_rename.rb
@@ -1,3 +1,3 @@
 # Rename foreman_proxy provider "puppetssh" to "ssh"
 # http://projects.theforeman.org/issues/15323
-answers['foreman_proxy']['puppetrun_provider'] = 'ssh' if answers['foreman_proxy'] && answers['foreman_proxy']['puppetrun_provider'] == 'puppetssh'
+answers['foreman_proxy']['puppetrun_provider'] = 'ssh' if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['puppetrun_provider'] == 'puppetssh'

--- a/config/foreman.migrations/20160722161820_environment_to_rails_env.rb
+++ b/config/foreman.migrations/20160722161820_environment_to_rails_env.rb
@@ -1,3 +1,3 @@
 # rename foreman environment parameter to rails_env
 # https://github.com/theforeman/puppet-foreman_proxy/commit/d239f0b
-answers['foreman']['rails_env'] = answers['foreman'].delete('environment') if answers['foreman'] && answers['foreman'].has_key?('environment')
+answers['foreman']['rails_env'] = answers['foreman'].delete('environment') if answers['foreman'].is_a?(Hash) && answers['foreman'].has_key?('environment')

--- a/config/foreman.migrations/20160831180000_foreman_proxy_tftp_grub2.rb
+++ b/config/foreman.migrations/20160831180000_foreman_proxy_tftp_grub2.rb
@@ -1,4 +1,4 @@
-if answers['foreman_proxy']
+if answers['foreman_proxy'].is_a?(Hash)
   root = answers['foreman_proxy']['tftp_root']
   if answers['foreman_proxy']['tftp_dirs']
     dirs = answers['foreman_proxy']['tftp_dirs']

--- a/config/foreman.migrations/20160906121542_puppetserver_whitelist.rb
+++ b/config/foreman.migrations/20160906121542_puppetserver_whitelist.rb
@@ -1,6 +1,6 @@
 # Redetermine the value of API whitelists, as it changed
 # in puppet-puppet f9b4e87cd855d7d5d0bbf3a1831b5daf22cdb413
-if answers['puppet']
+if answers['puppet'].is_a?(Hash)
   answers['puppet'].delete('server_admin_api_whitelist')
   answers['puppet'].delete('server_ca_client_whitelist')
 end

--- a/config/foreman.migrations/20161125153500_foreman_email_config_method.rb
+++ b/config/foreman.migrations/20161125153500_foreman_email_config_method.rb
@@ -1,1 +1,1 @@
-answers['foreman']['email_config_method'] = 'database' if answers['foreman']
+answers['foreman']['email_config_method'] = 'database' if answers['foreman'].is_a?(Hash)

--- a/config/foreman.migrations/20170118105627_foreman_proxy_dhcp_range_false.rb
+++ b/config/foreman.migrations/20170118105627_foreman_proxy_dhcp_range_false.rb
@@ -1,2 +1,2 @@
 # false is no longer a valid value, the param should be undef/nil to be disabled
-answers['foreman_proxy']['dhcp_range'] = nil if answers['foreman_proxy'] && answers['foreman_proxy']['dhcp_range'] == false
+answers['foreman_proxy']['dhcp_range'] = nil if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['dhcp_range'] == false

--- a/config/foreman.migrations/20170213123300_foreman_proxy_realm_split_configs.rb
+++ b/config/foreman.migrations/20170213123300_foreman_proxy_realm_split_configs.rb
@@ -1,1 +1,1 @@
-answers['foreman_proxy']['realm_split_config_files'] = true if answers['foreman_proxy']
+answers['foreman_proxy']['realm_split_config_files'] = true if answers['foreman_proxy'].is_a?(Hash)

--- a/config/foreman.migrations/20170405155121_foreman_proxy_bind_host_array.rb
+++ b/config/foreman.migrations/20170405155121_foreman_proxy_bind_host_array.rb
@@ -1,3 +1,3 @@
-if answers['foreman_proxy'] && answers['foreman_proxy']['bind_host'].is_a?(String)
+if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['bind_host'].is_a?(String)
   answers['foreman_proxy']['bind_host'] = [answers['foreman_proxy']['bind_host']]
 end

--- a/config/foreman.migrations/20170530141108_foreman_proxy_autosignfile.rb
+++ b/config/foreman.migrations/20170530141108_foreman_proxy_autosignfile.rb
@@ -1,4 +1,4 @@
-if answers['foreman_proxy'] && !answers['foreman_proxy'].has_key?('use_autosignfile')
+if answers['foreman_proxy'].is_a?(Hash) && !answers['foreman_proxy'].has_key?('use_autosignfile')
   answers['foreman_proxy']['use_autosignfile'] = true
   if answers['foreman_proxy'].has_key?('puppetdir')
     puppetdir = answers['foreman_proxy']['puppetdir']

--- a/config/foreman.migrations/20170708010605_puppet_profiler_metrics.rb
+++ b/config/foreman.migrations/20170708010605_puppet_profiler_metrics.rb
@@ -1,6 +1,6 @@
 # server_puppetserver_metrics also controls if the Ruby profiler gets enabled
 # in puppet-puppet since 94ff77740a27d458ce1444db016645ab763cba42
-if answers['puppet'] && answers['puppet'].has_key?('server_enable_ruby_profiler')
+if answers['puppet'].is_a?(Hash) && answers['puppet'].has_key?('server_enable_ruby_profiler')
   if answers['puppet']['server_enable_ruby_profiler'] == true
     answers['puppet']['server_puppetserver_metrics'] = true
   end

--- a/config/foreman.migrations/20190111180118_delete_removed_settings.rb
+++ b/config/foreman.migrations/20190111180118_delete_removed_settings.rb
@@ -19,6 +19,6 @@ CLEAR.each do |mod, parameters|
   end
 end
 
-if (mod_answers = answers['foreman_proxy'])
+if (mod_answers = answers['foreman_proxy']) && mod_answers.is_a?(Hash)
   mod_answers['dhcp_gateway'] = nil if mod_answers['dhcp_gateway'] == '192.168.100.1'
 end

--- a/config/foreman.migrations/20190111180118_delete_removed_settings.rb
+++ b/config/foreman.migrations/20190111180118_delete_removed_settings.rb
@@ -1,44 +1,3 @@
-DELETED = {
-  'foreman' => [
-    'custom_repo',
-    'dynflow_in_core',
-    'email_conf',
-    'email_config_method',
-    'email_source',
-    'puppet_home',
-    'puppet_ssldir',
-  ],
-  'foreman_proxy' => [
-    'custom_repo',
-    'puppetca_modular',
-    'realm_split_config_files',
-    'use_autosignfile',
-  ],
-  'foreman_proxy::plugin::dhcp::infoblox' => [
-    'use_ranges',
-  ],
-  'puppet' => [
-    'agent_template',
-    'main_template',
-    'server_app_root',
-    'server_ca_proxy',
-    'server_directory_environments',
-    'server_dynamic_environments',
-    'server_environments',
-    'server_http_allow',
-    'server_httpd_service',
-    'server_implementation',
-    'server_main_template',
-    'server_passenger',
-    'server_passenger_min_instances',
-    'server_passenger_pre_start',
-    'server_passenger_ruby',
-    'server_rack_arguments',
-    'server_service_fallback',
-    'server_template',
-  ],
-}.freeze
-
 CLEAR = {
   'foreman' => [
     'authentication',
@@ -50,15 +9,6 @@ CLEAR = {
     'repo',
   ],
 }.freeze
-
-DELETED.each do |mod, parameters|
-  mod_answers = answers[mod]
-  next unless mod_answers.is_a?(Hash)
-
-  parameters.each do |parameter|
-    mod_answers.delete(parameter)
-  end
-end
 
 CLEAR.each do |mod, parameters|
   mod_answers = answers[mod]

--- a/config/foreman.migrations/20210407174237_add_puppet_reserved_code_cache.rb
+++ b/config/foreman.migrations/20210407174237_add_puppet_reserved_code_cache.rb
@@ -12,8 +12,5 @@ if answers['puppet'].is_a?(Hash)
         answers['puppet']['server_jvm_extra_args'] += " #{reserved_code_cache_arg}"
       end
     end
-  else
-    # The logger is silently added by the module if it's undef
-    answers['puppet']['server_jvm_extra_args'] = ['-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger', reserved_code_cache_arg]
   end
 end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -9,19 +9,8 @@
 #
 # See params.pp in each class for what options are available
 ---
-certs:
-  group: foreman
-foreman:
-  client_ssl_ca: /etc/foreman/proxy_ca.pem
-  client_ssl_cert: /etc/foreman/client_cert.pem
-  client_ssl_key: /etc/foreman/client_key.pem
-  initial_location: Default Location
-  initial_organization: Default Organization
-  server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
-  server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
-  server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt
-  server_ssl_crl: ""
-  server_ssl_key: /etc/pki/katello/private/katello-apache.key
+certs: true
+foreman: true
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
@@ -69,15 +58,7 @@ foreman::plugin::tasks: true
 foreman::plugin::templates: false
 foreman::plugin::virt_who_configure: false
 foreman::plugin::webhooks: false
-foreman_proxy:
-  foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
-  foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
-  foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
-  manage_puppet_group: false
-  ssl_ca: /etc/foreman-proxy/ssl_ca.pem
-  ssl_cert: /etc/foreman-proxy/ssl_cert.pem
-  ssl_key: /etc/foreman-proxy/ssl_key.pem
-  ssl_port: '9090'
+foreman_proxy: true
 foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::chef: false
@@ -92,11 +73,4 @@ foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false
 foreman_proxy_content: true
 katello: true
-puppet:
-  server: true
-  server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
-  server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
-  server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key
-  server_jvm_extra_args:
-    - "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
-    - "-XX:ReservedCodeCacheSize=512m"
+puppet: true

--- a/config/katello.migrations/180111142132-foreman_proxy_autosignfile.rb
+++ b/config/katello.migrations/180111142132-foreman_proxy_autosignfile.rb
@@ -1,4 +1,4 @@
-if answers['foreman_proxy']
+if answers['foreman_proxy'].is_a?(Hash)
   answers['foreman_proxy']['use_autosignfile'] = true
   if answers['foreman_proxy'].key?('puppetdir')
     puppetdir = answers['foreman_proxy']['puppetdir']

--- a/config/katello.migrations/180813131441-unmanage-puppet-group.rb
+++ b/config/katello.migrations/180813131441-unmanage-puppet-group.rb
@@ -1,5 +1,0 @@
-if answers['foreman_proxy'].is_a?(Hash)
-  answers['foreman_proxy']['manage_puppet_group'] = false
-elsif answers['foreman_proxy'] == true
-  answers['foreman_proxy'] = { 'manage_puppet_group' => false }
-end

--- a/config/katello.migrations/190111180118-delete-removed-settings.rb
+++ b/config/katello.migrations/190111180118-delete-removed-settings.rb
@@ -19,6 +19,6 @@ CLEAR.each do |mod, parameters|
   end
 end
 
-if (mod_answers = answers['foreman_proxy'])
+if (mod_answers = answers['foreman_proxy']) && mod_answers.is_a?(Hash)
   mod_answers['dhcp_gateway'] = nil if mod_answers['dhcp_gateway'] == '192.168.100.1'
 end

--- a/config/katello.migrations/190111180118-delete-removed-settings.rb
+++ b/config/katello.migrations/190111180118-delete-removed-settings.rb
@@ -1,44 +1,3 @@
-DELETED = {
-  'foreman' => [
-    'custom_repo',
-    'dynflow_in_core',
-    'email_conf',
-    'email_config_method',
-    'email_source',
-    'puppet_home',
-    'puppet_ssldir',
-  ],
-  'foreman_proxy' => [
-    'custom_repo',
-    'puppetca_modular',
-    'realm_split_config_files',
-    'use_autosignfile',
-  ],
-  'foreman_proxy::plugin::dhcp::infoblox' => [
-    'use_ranges',
-  ],
-  'puppet' => [
-    'agent_template',
-    'main_template',
-    'server_app_root',
-    'server_ca_proxy',
-    'server_directory_environments',
-    'server_dynamic_environments',
-    'server_environments',
-    'server_http_allow',
-    'server_httpd_service',
-    'server_implementation',
-    'server_main_template',
-    'server_passenger',
-    'server_passenger_min_instances',
-    'server_passenger_pre_start',
-    'server_passenger_ruby',
-    'server_rack_arguments',
-    'server_service_fallback',
-    'server_template',
-  ],
-}.freeze
-
 CLEAR = {
   'foreman' => [
     'authentication',
@@ -50,15 +9,6 @@ CLEAR = {
     'repo',
   ],
 }.freeze
-
-DELETED.each do |mod, parameters|
-  mod_answers = answers[mod]
-  next unless mod_answers.is_a?(Hash)
-
-  parameters.each do |parameter|
-    mod_answers.delete(parameter)
-  end
-end
 
 CLEAR.each do |mod, parameters|
   mod_answers = answers[mod]

--- a/config/katello.migrations/210407174237-add-puppet-reserved-code-cache.rb
+++ b/config/katello.migrations/210407174237-add-puppet-reserved-code-cache.rb
@@ -12,8 +12,5 @@ if answers['puppet'].is_a?(Hash)
         answers['puppet']['server_jvm_extra_args'] += " #{reserved_code_cache_arg}"
       end
     end
-  else
-    # The logger is silently added by the module if it's undef
-    answers['puppet']['server_jvm_extra_args'] = ['-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger', reserved_code_cache_arg]
   end
 end

--- a/spec/fixtures/cleanup-foreman-user-groups/foreman-answers-after.yaml
+++ b/spec/fixtures/cleanup-foreman-user-groups/foreman-answers-after.yaml
@@ -1,2 +1,0 @@
-foreman:
-  user_groups: []

--- a/spec/fixtures/cleanup-foreman-user-groups/foreman-answers-before.yaml
+++ b/spec/fixtures/cleanup-foreman-user-groups/foreman-answers-before.yaml
@@ -1,2 +1,0 @@
-foreman:
-  user_groups: ['puppet']

--- a/spec/fixtures/cleanup-foreman-user-groups/katello-answers-after.yaml
+++ b/spec/fixtures/cleanup-foreman-user-groups/katello-answers-after.yaml
@@ -1,2 +1,0 @@
-foreman:
-  user_groups: []

--- a/spec/fixtures/cleanup-foreman-user-groups/katello-answers-before.yaml
+++ b/spec/fixtures/cleanup-foreman-user-groups/katello-answers-before.yaml
@@ -1,2 +1,0 @@
-foreman:
-  user_groups: ['puppet']

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -125,10 +125,9 @@ describe 'migrations' do
 
   %w[foreman katello].each do |scenario_name|
     context "foreman drop puppet from user_groups" do
-      let(:answers_after) { load_fixture_yaml('cleanup-foreman-user-groups', "#{scenario_name}-answers-after.yaml") }
       let(:scenario) do
         {
-          :answers    => load_fixture_yaml('cleanup-foreman-user-groups', "#{scenario_name}-answers-before.yaml"),
+          :answers    => {'foreman' => {'user_groups' => ['puppet']}},
           :config     => load_config_yaml("#{scenario_name}.yaml"),
           :migrations => config_path("#{scenario_name}.migrations"),
         }
@@ -138,7 +137,7 @@ describe 'migrations' do
 
       it 'changes scenario answers' do
         _, after = migrator
-        expect(after).to include answers_after
+        expect(after).to include({'foreman' => {'user_groups' => []}})
       end
     end
   end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -127,7 +127,7 @@ describe 'migrations' do
     context "foreman drop puppet from user_groups" do
       let(:scenario) do
         {
-          :answers    => {'foreman' => {'user_groups' => ['puppet']}},
+          :answers    => { 'foreman' => { 'user_groups' => ['puppet'] } },
           :config     => load_config_yaml("#{scenario_name}.yaml"),
           :migrations => config_path("#{scenario_name}.migrations"),
         }
@@ -137,7 +137,7 @@ describe 'migrations' do
 
       it 'changes scenario answers' do
         _, after = migrator
-        expect(after).to include({'foreman' => {'user_groups' => []}})
+        expect(after['foreman']['user_groups']).to eq([])
       end
     end
   end


### PR DESCRIPTION
This moves all non-default options into the Hiera layer. Since Kafo 3.0 this works and is supported. It also means --reset-$option loads the installer default rather than the Puppet default.

Tests need modifications so this is still a draft. It's also untested but it's relevant to https://github.com/theforeman/foreman-installer/pull/717 and https://github.com/theforeman/kafo/pull/339.