### PR TITLE
Remove redundant defaults

### DIFF
--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -35,7 +35,6 @@ foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::shellhooks: false
 puppet:
   server: true
-  server_environments_owner: apache
   server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
   server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
   server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -90,12 +90,8 @@ foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::ssh: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false
-foreman_proxy_content:
-  proxy_pulp_yum_to_pulpcore: true
-  proxy_pulp_deb_to_pulpcore: true
-katello:
-  use_pulp_2_for_yum: false
-  use_pulp_2_for_deb: false
+foreman_proxy_content: true
+katello: true
 puppet:
   server: true
   server_environments_owner: apache

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -94,7 +94,6 @@ foreman_proxy_content: true
 katello: true
 puppet:
   server: true
-  server_environments_owner: apache
   server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
   server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
   server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/config/katello.migrations/200605154320-dont-use-pulpcore-rpm-on-upgrades.rb
+++ b/config/katello.migrations/200605154320-dont-use-pulpcore-rpm-on-upgrades.rb
@@ -6,4 +6,4 @@ def upgrade
   answers[KATELLO][USE_PULP_2_FOR_YUM] = true
 end
 
-upgrade if answers[KATELLO] && answers[KATELLO][USE_PULP_2_FOR_YUM].nil?
+upgrade if answers[KATELLO].is_a?(Hash) && answers[KATELLO][USE_PULP_2_FOR_YUM].nil?

--- a/config/katello.migrations/200611220455-dont-proxy-pulp-yum-to-pulpcore-on-upgrades.rb
+++ b/config/katello.migrations/200611220455-dont-proxy-pulp-yum-to-pulpcore-on-upgrades.rb
@@ -6,4 +6,4 @@ def upgrade
   answers[FPC][PROXY_YUM] = false
 end
 
-upgrade if answers[FPC] && answers[FPC][PROXY_YUM].nil?
+upgrade if answers[FPC].is_a?(Hash) && answers[FPC][PROXY_YUM].nil?


### PR DESCRIPTION
These 2 commits remove defaults that no longer need to be set. In one case because they were removed, in the other because they became irrelevant.