### PR TITLE
Move default ssl-build directory to /var/lib/foreman-installer

### DIFF
--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -11,6 +11,7 @@
 ---
 certs:
   generate: false
+  ssl_build_dir: '/var/lib/foreman-installer/ssl-build'
 foreman_proxy_content:
   pulpcore_mirror: true
 foreman_proxy:

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -11,6 +11,7 @@
 ---
 certs:
   group: foreman
+  ssl_build_dir: '/var/lib/foreman-installer/ssl-build'
 foreman:
   client_ssl_ca: /etc/foreman/proxy_ca.pem
   client_ssl_cert: /etc/foreman/client_cert.pem

--- a/hooks/pre/35-move_ssl_build_dir.rb
+++ b/hooks/pre/35-move_ssl_build_dir.rb
@@ -1,0 +1,12 @@
+old_ssl_build_dir = '/root/ssl-build'
+new_ssl_build_dir = '/var/lib/foreman-installer/ssl-build'
+
+if module_enabled?('certs')
+  if param('certs', 'ssl_build_dir') == old_ssl_build_dir
+    if File.exist?(old_ssl_build_dir) && (!File.exist?(new_ssl_build_dir) || Dir.empty?(new_ssl_build_dir))
+      FileUtils.mv(old_ssl_build_dir, new_ssl_build_dir)
+    end
+
+    kafo.answers['certs']['ssl_build_dir'] = new_ssl_build_dir
+  end
+end


### PR DESCRIPTION
The idea is to move away from using `/root/ssl-build` which users often do not like, and has a tendency to get deleted accidentally to a more appropriate location in `/var/lib/foreman-installer`. This should be less prone to accidental removal and a better location for backup predictability, for a mounted volume and generally a better design. The tricky bit is what to do about existing `/root/ssl-build` directories. 


For upgrades, this attempts to move them as part of the boot hook if they are found to the new location. The alternative approach would be to change it for new installs only and leave it for upgrades. This, however, creates a split experience for our users base and makes debugging harder.