### PR TITLE
Use r10k with dependency solver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'kafo', '~> 6.4'
-gem 'librarian-puppet', '>= 3.0'
+gem 'r10k', github: 'binford2k/r10k', branch: 'resolver'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 7.0'
 gem 'facter', '>= 3.0', '!= 4.0.52'
 

--- a/Rakefile
+++ b/Rakefile
@@ -226,10 +226,14 @@ file "#{BUILDDIR}/foreman-installer.8" => "#{BUILDDIR}/foreman-installer.8.ascii
   end
 end
 
+file "Puppetfile.lock" => "Puppetfile" do
+  sh "r10k puppetfile resolve"
+end
+
 directory "#{BUILDDIR}/modules"
-file "#{BUILDDIR}/modules" => BUILDDIR do |_t|
+file "#{BUILDDIR}/modules" => [BUILDDIR, "Puppetfile.lock"] do |_t|
   if Dir["modules/*"].empty?
-    sh "librarian-puppet install --verbose --path #{BUILDDIR}/modules"
+    sh "r10k puppetfile install --verbose --path #{BUILDDIR}/modules"
   else
     cp_r "modules/", BUILDDIR
   end


### PR DESCRIPTION
This uses r10k's new dependency solver to replace librarian-puppet. librarian-puppet is mostly on life support, so it's interesting to look at possible replacements.

It pulls in https://github.com/puppetlabs/r10k/pull/1232 so this is still experimental.

The first thing I ran into is that I can't run it on Ruby 3 because it pins cri to a non-Ruby 3 compatible version. That's why I'm relying on CI to see if this even works.