### PR TITLE
Fixes #33577 - Only enable Foreman Puppet plugin with Foreman

### DIFF
--- a/config/foreman.migrations/20210929144850_disable_puppet_plugins_if_undesired.rb
+++ b/config/foreman.migrations/20210929144850_disable_puppet_plugins_if_undesired.rb
@@ -1,0 +1,10 @@
+# This fixes up 20210803130619_add_hammer_puppet_plugin.rb in case foreman::cli
+# is disabled
+if answers['foreman::cli::puppet'] && !answers['foreman::cli']
+  answers['foreman::cli::puppet'] = false
+end
+# This fixes up 20210708144320_add_foreman_puppet.rb in case foreman is
+# disabled
+if answers['foreman::plugin::puppet'] && !answers['foreman']
+  answers['foreman::plugin::puppet'] = false
+end

--- a/config/katello.migrations/170331152302-add-cli.rb
+++ b/config/katello.migrations/170331152302-add-cli.rb
@@ -1,1 +1,3 @@
-answers['foreman::cli'] ||= true
+unless answers.key?('foreman::cli')
+  answers['foreman::cli'] = true
+end

--- a/config/katello.migrations/210929144850-disable-puppet-plugins-if-undesired.rb
+++ b/config/katello.migrations/210929144850-disable-puppet-plugins-if-undesired.rb
@@ -1,0 +1,10 @@
+# This fixes up 20210803130619-add-hammer-puppet-plugin.rb in case foreman::cli
+# is disabled
+if answers['foreman::cli::puppet'] && !answers['foreman::cli']
+  answers['foreman::cli::puppet'] = false
+end
+# This fixes up 210708144422-add-foreman-puppet.rb in case foreman is
+# disabled
+if answers['foreman::plugin::puppet'] && !answers['foreman']
+  answers['foreman::plugin::puppet'] = false
+end

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -21,7 +21,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
-foreman::plugin::puppet: true
+foreman::plugin::puppet: false
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -21,7 +21,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
-foreman::plugin::puppet: true
+foreman::plugin::puppet: false
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -21,7 +21,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
-foreman::plugin::puppet: true
+foreman::plugin::puppet: false
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -142,4 +142,38 @@ describe 'migrations' do
       end
     end
   end
+
+  context 'disable puppet if needed' do
+    %w[foreman katello].each do |scenario_name|
+      context "on #{scenario_name}" do
+        let(:answers) do
+          {
+            'foreman' => false,
+            'foreman::cli' => false,
+          }
+        end
+        let(:scenario_name) { scenario_name }
+        let(:config) { load_config_yaml("#{scenario_name}.yaml") }
+        let(:migrations) { config_path("#{scenario_name}.migrations") }
+        let(:migrator) { Kafo::Migrations.new(migrations).run(config, answers) }
+        subject(:migrated_answers) { migrator[1] }
+
+        it 'keeps foreman::cli disabled' do
+          expect(migrated_answers['foreman::cli']).to be false
+        end
+
+        it 'adds foreman::cli::puppet disabled' do
+          expect(migrated_answers['foreman::cli::puppet']).to be false
+        end
+
+        it 'keeps foreman disabled' do
+          expect(migrated_answers['foreman']).to be false
+        end
+
+        it 'adds foreman::plugin::puppet disabled' do
+          expect(migrated_answers['foreman::plugin::puppet']).to be false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
If the user passed in --no-enable-foreman then the Foreman plugin should not be enabled. The same is true for the CLI side of it.

The add-cli migration is changed to respect an already present option that is false in order to properly test this change.

(cherry picked from commit ce89a30b315e729a45101a8707fcf88f9e9a39c8)