### PR TITLE
Fixes #33109 - Date used by katello-certs-check should be formatted c…

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -95,10 +95,9 @@ function check-server-cert-encoding () {
 }
 
 function check-expiration () {
-    DATE=$(date -u +"%b %-d %R:%S %Y")
     CERT_EXP=$(openssl x509 -noout -enddate -in $CERT_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
     CA_EXP=$(openssl x509 -noout -enddate -in $CA_BUNDLE_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
-    DATE_TODAY=$(date -d"${DATE}" +%Y%m%d%H%M%S)
+    DATE_TODAY=$(date +%Y%m%d%H%M%S)
     CERT_DATE=$(date -d"${CERT_EXP}" +%Y%m%d%H%M%S)
     CA_DATE=$(date -d"${CA_EXP}" +%Y%m%d%H%M%S)
     printf "Checking expiration of certificate: "

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -97,7 +97,7 @@ function check-server-cert-encoding () {
 function check-expiration () {
     CERT_EXP=$(openssl x509 -noout -enddate -in $CERT_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
     CA_EXP=$(openssl x509 -noout -enddate -in $CA_BUNDLE_FILE | sed -e 's/notAfter=//' | awk '{$NF="";}1')
-    DATE_TODAY=$(date +%Y%m%d%H%M%S)
+    DATE_TODAY=$(date -u +%Y%m%d%H%M%S)
     CERT_DATE=$(date -d"${CERT_EXP}" +%Y%m%d%H%M%S)
     CA_DATE=$(date -d"${CA_EXP}" +%Y%m%d%H%M%S)
     printf "Checking expiration of certificate: "


### PR DESCRIPTION
…orrectly by program

2nd try at this, clean edit - somehow completely messed up my previous git and some sleep deprivation errors...

https://github.com/theforeman/foreman-installer/pull/728