### PR TITLE
Refs #33864 - Disable registration on upgrades

### DIFF
--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -24,6 +24,7 @@ foreman_proxy:
   ssl_cert: /etc/foreman-proxy/ssl_cert.pem
   ssl_key: /etc/foreman-proxy/ssl_key.pem
   ssl_port: '9090'
+  registration: true
   templates: true
   puppet: false
   puppetca: false

--- a/config/foreman-proxy-content.migrations/211108174119-disable-registration-without-templates.rb
+++ b/config/foreman-proxy-content.migrations/211108174119-disable-registration-without-templates.rb
@@ -1,0 +1,6 @@
+# In Foreman 3.1 the registration module requires templates where it previously
+# worked standalone.
+# https://github.com/theforeman/puppet-foreman_proxy/commit/6f64423e7ca25c8b58f8da4d371172c22eb9b0e3
+if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['registration'] && !answers['foreman_proxy']['templates']
+  answers['foreman_proxy']['registration'] = false
+end

--- a/config/foreman.migrations/20211108174119_disable_registration_without_templates.rb
+++ b/config/foreman.migrations/20211108174119_disable_registration_without_templates.rb
@@ -1,0 +1,6 @@
+# In Foreman 3.1 the registration module requires templates where it previously
+# worked standalone.
+# https://github.com/theforeman/puppet-foreman_proxy/commit/6f64423e7ca25c8b58f8da4d371172c22eb9b0e3
+if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['registration'] && !answers['foreman_proxy']['templates']
+  answers['foreman_proxy']['registration'] = false
+end

--- a/config/katello.migrations/211108174119-disable-registration-without-templates.rb
+++ b/config/katello.migrations/211108174119-disable-registration-without-templates.rb
@@ -1,0 +1,6 @@
+# In Foreman 3.1 the registration module requires templates where it previously
+# worked standalone.
+# https://github.com/theforeman/puppet-foreman_proxy/commit/6f64423e7ca25c8b58f8da4d371172c22eb9b0e3
+if answers['foreman_proxy'].is_a?(Hash) && answers['foreman_proxy']['registration'] && !answers['foreman_proxy']['templates']
+  answers['foreman_proxy']['registration'] = false
+end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -100,6 +100,44 @@ describe 'with all migrations' do
     end
   end
 
+  context 'the migration 20211108174119_disable_registration_without_templates' do
+    %w[foreman foreman-proxy-content katello].each do |scenario_name|
+      context "on #{scenario_name}" do
+        let(:scenario_name) { scenario_name }
+
+        context 'with registration, without templates' do
+          let(:answers) do
+            {
+              'foreman_proxy' => {
+                'registration' => true,
+                'templates' => false,
+              },
+            }
+          end
+
+          it 'disables registration' do
+            expect(migrated_answers['foreman_proxy']['registration']).to be false
+          end
+        end
+
+        context 'with registration, with templates' do
+          let(:answers) do
+            {
+              'foreman_proxy' => {
+                'registration' => true,
+                'templates' => true,
+              },
+            }
+          end
+
+          it 'keeps registration enabled' do
+            expect(migrated_answers['foreman_proxy']['registration']).to be true
+          end
+        end
+      end
+    end
+  end
+
   context 'the migration 181213211252-merged-installer' do
     let(:config) { load_fixture_yaml('merged-installer', "#{scenario_name}-before.yaml") }
 


### PR DESCRIPTION
In Foreman 3.1 the registration module requires templates where it previously worked standalone.

In a Foreman or Katello scenario the registration module doesn't make sense since the clients can connect directly to a Foreman, which makes the indirection redundant. The Smart Proxy may also not have plain HTTP enabled which then breaks things.

It is explicitly enabled by default in the foreman-proxy-content scenario because there templates is enabled by default, which makes it safe to enable registration.