### PR TITLE
Reflect the new minimum Puppet version 6.15.0 in tests

### DIFF
--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'semantic_puppet'
 
 describe 'Puppet module' do
-  VERSIONS = ['6.1.0', '7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
+  VERSIONS = ['6.15.0', '7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
 
   Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|
     context File.basename(File.dirname(filename)) do


### PR DESCRIPTION
puppet-foreman_proxy now requires a Puppet 6.15.0 feature.