### PR TITLE
Use forgeapi-cdn.puppet.com as forge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+# rdoc 6.4 pulls in psych 4 and Puppet is incompatible with that.
+# We don't want to list psych since that updates the bundled version
+gem 'rdoc', '< 6.4'
+
 gem 'kafo', '~> 6.4'
 gem 'librarian-puppet', '>= 3.0'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 7.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,4 +1,4 @@
-forge 'https://forgeapi.puppetlabs.com/'
+forge 'https://forgeapi-cdn.puppet.com/'
 
 # Dependencies
 # For Puppet 7 support


### PR DESCRIPTION
These days puppet.com is the preferred domain. forgeapi-cdn has the benefit that it supports IPv6.