### PR TITLE
Fixes #34440 - skip upgrade:run by run_rake_upgrade=false

### DIFF
--- a/hooks/post/30-upgrade.rb
+++ b/hooks/post/30-upgrade.rb
@@ -1,3 +1,8 @@
-if !app_value(:noop) && [0, 2].include?(@kafo.exit_code) && foreman_server?
+def run_rake_upgrade?
+  it = get_custom_config(:run_rake_upgrade)
+  it.nil? ? true : it
+end
+
+if !app_value(:noop) && [0, 2].include?(@kafo.exit_code) && foreman_server? && run_rake_upgrade?
   execute!('foreman-rake upgrade:run')
 end


### PR DESCRIPTION
this allows to override it in certain scenarios

(cherry picked from commit 889105c2ae968d413d88e785f449d99bd6916c0a)