### PR TITLE
Drop EL8 pki-core modularity workaround

### DIFF
--- a/hooks/pre/32-install_selinux_packages.rb
+++ b/hooks/pre/32-install_selinux_packages.rb
@@ -12,10 +12,5 @@ if facts.dig(:os, :selinux, :enabled)
   packages << 'candlepin-selinux' if katello_enabled?
   packages << 'pulpcore-selinux' if pulpcore_enabled?
 
-  if katello_enabled? && el8?
-    # candlepin-selinux pulls in candlepin which requires pki-core
-    execute!('dnf module enable pki-core --assumeyes', false, true)
-  end
-
   ensure_packages(packages, 'installed')
 end


### PR DESCRIPTION
Now that there is a real katello module, this should no longer be needed.

Currently a draft since I'm not entirely sure about the implications.