### PR TITLE
Fixes #20889 - Use event mpm module with Apache

### DIFF
--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -1,6 +1,7 @@
 ---
 apache::default_vhost: false
 apache::default_mods: false
+apache::mpm_module: 'event'
 
 dhcp::config_comment: |
   READ: This file was written the foreman-installer and not by the Foreman

--- a/config/foreman.hiera/family/RedHat-7.yaml
+++ b/config/foreman.hiera/family/RedHat-7.yaml
@@ -1,4 +1,10 @@
 ---
+# EL7 uses an older version of httpd where the event MPM suffers from issues such as
+# https://bz.apache.org/bugzilla/show_bug.cgi?id=53555. The fixes were deemed not
+# suitable for a backport due to a large version gap. Since the event MPM is not
+# recommended for EL7, we continue to use the prefork MPM here.
+apache::mpm_module: 'prefork'
+
 redis::globals::scl: rh-redis5
 
 postgresql::globals::version: '12'

--- a/config/foreman.hiera/tuning/common.yaml
+++ b/config/foreman.hiera/tuning/common.yaml
@@ -1,4 +1,9 @@
 ---
+apache::mod::event::startservers: 2
+apache::mod::event::minsparethreads: 16
+apache::mod::event::maxsparethreads: 32
+apache::mod::event::threadsperchild: 16
+
 lookup_options:
   postgresql::server::config_entries:
     merge: hash

--- a/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
@@ -1,4 +1,8 @@
 ---
+apache::mod::event::serverlimit: 64
+apache::mod::event::maxrequestworkers: 1024
+apache::mod::event::maxrequestsperchild: 4000
+
 apache::mod::prefork::serverlimit: 1024
 apache::mod::prefork::maxclients: 1024
 apache::mod::prefork::maxrequestsperchild: 4000

--- a/config/foreman.hiera/tuning/sizes/extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-large.yaml
@@ -1,4 +1,8 @@
 ---
+apache::mod::event::serverlimit: 64
+apache::mod::event::maxrequestworkers: 1024
+apache::mod::event::maxrequestsperchild: 4000
+
 apache::mod::prefork::serverlimit: 1024
 apache::mod::prefork::maxclients: 1024
 apache::mod::prefork::maxrequestsperchild: 4000

--- a/config/foreman.hiera/tuning/sizes/large.yaml
+++ b/config/foreman.hiera/tuning/sizes/large.yaml
@@ -1,4 +1,8 @@
 ---
+apache::mod::event::serverlimit: 64
+apache::mod::event::maxrequestworkers: 1024
+apache::mod::event::maxrequestsperchild: 4000
+
 apache::mod::prefork::serverlimit: 1024
 apache::mod::prefork::maxclients: 1024
 apache::mod::prefork::maxrequestsperchild: 4000

--- a/config/foreman.hiera/tuning/sizes/medium.yaml
+++ b/config/foreman.hiera/tuning/sizes/medium.yaml
@@ -1,4 +1,8 @@
 ---
+apache::mod::event::serverlimit: 64
+apache::mod::event::maxrequestworkers: 1024
+apache::mod::event::maxrequestsperchild: 4000
+
 apache::mod::prefork::serverlimit: 1024
 apache::mod::prefork::maxclients: 1024
 apache::mod::prefork::maxrequestsperchild: 4000


### PR DESCRIPTION
Some considerations:

1. There are issues with the older httpd on EL7 that make mpm_event perform worse than it should

2. This required updates to tuning profiles, and interestingly the prefork values were the same across all tuning sizes. Those apache directives have been updated here with more modern equivalents for mpm_event but these values haven't yet been thoroughly benchmarked