### PR TITLE
Fixes #34590 - Enable only minimum apache modules

### DIFF
--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -1,5 +1,7 @@
 ---
 apache::default_vhost: false
+apache::default_mods: false
+
 dhcp::config_comment: |
   READ: This file was written the foreman-installer and not by the Foreman
   application. Any updates to subnets in the Foreman database are not


### PR DESCRIPTION
The puppetlabs-apache puppet module used by the foreman-installer
installs Apache httpd with a set of default Apache modules, some of
which are not necessary for our use case. This commit reduces that set
of Apache modules down to a minimum, by overriding the
apache::default_mods parameter in the common tuning profile. The user
can enable additional modules if desired by overriding
apache::default_mods to an expanded list in custom-hiera.yaml.