### PR TITLE
Drop redundant initial defaults

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -15,8 +15,6 @@ foreman:
   client_ssl_ca: /etc/foreman/proxy_ca.pem
   client_ssl_cert: /etc/foreman/client_cert.pem
   client_ssl_key: /etc/foreman/client_key.pem
-  initial_location: Default Location
-  initial_organization: Default Organization
   server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
   server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
   server_ssl_chain: /etc/pki/katello/certs/katello-server-ca.crt


### PR DESCRIPTION
These defaults are the same as what Foreman generates, so there is no need to specify these.

It should be noted that puppet-foreman has no default, but the Foreman seeds generate this default. That means anything that reads these values can no longer determine these.

Right now this is a draft because I'm not sure if anything reads this. However, it is a difference between Katello and Foreman. We want to get rid of those.