### PR TITLE
Fixes #32323 - Correct PostgreSQL service name on EL7

### DIFF
--- a/config/foreman.hiera/family/RedHat-7.yaml
+++ b/config/foreman.hiera/family/RedHat-7.yaml
@@ -5,7 +5,7 @@ postgresql::globals::version: '12'
 postgresql::globals::client_package_name: rh-postgresql12-postgresql-syspaths
 postgresql::globals::server_package_name: rh-postgresql12-postgresql-server-syspaths
 postgresql::globals::contrib_package_name: rh-postgresql12-postgresql-contrib-syspaths
-postgresql::globals::service_name: postgresql
+postgresql::globals::service_name: rh-postgresql12-postgresql
 postgresql::globals::datadir: /var/opt/rh/rh-postgresql12/lib/pgsql/data
 postgresql::globals::confdir: /var/opt/rh/rh-postgresql12/lib/pgsql/data
 postgresql::globals::bindir: /usr/bin

--- a/hooks/pre/29-el7_clean_systemd_pg.rb
+++ b/hooks/pre/29-el7_clean_systemd_pg.rb
@@ -1,0 +1,4 @@
+# On EL7 the SCL override should be used instead
+if !app_value(:noop) && el7?
+  FileUtils.rm_f('/etc/systemd/system/postgresql.service.d/postgresql.conf')
+end


### PR DESCRIPTION
While we do install the -server-syspaths package (which allows using the non-SCL name), due to implementation details the systemd override files must be created on the original name. Otherwise they do not have any effect and only generate warnings.

See https://bugzilla.redhat.com/show_bug.cgi?id=1964394#c3 for a detailed analysis.