### PR TITLE
Refs #34239: Require voxpupuli/puppet-mosquitto

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -24,3 +24,6 @@ mod 'theforeman/puppet',             :git => 'https://github.com/theforeman/pupp
 mod 'katello/foreman_proxy_content', :git => 'https://github.com/theforeman/puppet-foreman_proxy_content'
 mod 'katello/certs',                 :git => 'https://github.com/theforeman/puppet-certs'
 mod 'katello/katello',               :git => 'https://github.com/theforeman/puppet-katello'
+
+# REX dependencies
+mod 'voxpupuli/mosquitto',           :git => 'https://github.com/voxpupuli/puppet-mosquitto'


### PR DESCRIPTION
This is needed to support REX pull transport via MQTT as puppet-mosquitto
is a soft dependency of puppet-foreman_proxy.