### PR TITLE
Fixes #34875: Prevent certs regeneration on every installer run

### DIFF
--- a/hooks/pre_exit/20-certs_regenerate.rb
+++ b/hooks/pre_exit/20-certs_regenerate.rb
@@ -1,0 +1,6 @@
+if module_enabled?('certs') && param('certs', 'regenerate').value == true
+  answers = kafo.config.answers
+  answers['certs']['regenerate'] = false
+
+  kafo.config.store(answers)
+end


### PR DESCRIPTION
Given answers are stored, if a user supplies --certs-regenerate then
every installer run thereafter will regenerate certificates. Ensure this
value is reset after installation run.