### PR TITLE
Drop devlog check that was only valid for Pulp 2

### DIFF
--- a/katello/hooks/pre/19-devlog.rb
+++ b/katello/hooks/pre/19-devlog.rb
@@ -1,9 +1,0 @@
-# check to see if /dev/log directory exists
-
-if app_value(:disable_system_checks)
-  logger.warn 'Skipping system checks.'
-  # if dir_present is true then give warning to user and exit otherwise move on with install
-elsif File.exist?('/dev/log') == false
-  $stderr.puts 'This system is missing the /dev/log socket and will not install correctly, please fix this and then run the installer again.'
-  kafo.class.exit(1)
-end


### PR DESCRIPTION
See https://projects.theforeman.org/issues/16778 for reason it was
added originally.