### PR TITLE
Add Foreman DHCP browser plugin to Katello

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -49,6 +49,7 @@ foreman::plugin::bootdisk: false
 foreman::plugin::chef: false
 foreman::plugin::column_view: false
 foreman::plugin::default_hostgroup: false
+foreman::plugin::dhcp_browser: false
 foreman::plugin::discovery: false
 foreman::plugin::dlm: false
 foreman::plugin::expire_hosts: false

--- a/config/katello.migrations/20220602151000_foreman_dhcp_browser.rb
+++ b/config/katello.migrations/20220602151000_foreman_dhcp_browser.rb
@@ -1,0 +1,1 @@
+answers['foreman::plugin::dhcp_browser'] ||= false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -18,6 +18,7 @@ foreman::plugin::acd: false
 foreman::plugin::azure: false
 foreman::plugin::column_view: false
 foreman::plugin::dlm: false
+foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::host_reports: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -18,6 +18,7 @@ foreman::plugin::acd: false
 foreman::plugin::azure: false
 foreman::plugin::column_view: false
 foreman::plugin::dlm: false
+foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::host_reports: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -18,6 +18,7 @@ foreman::plugin::acd: false
 foreman::plugin::azure: false
 foreman::plugin::column_view: false
 foreman::plugin::dlm: false
+foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::host_reports: false


### PR DESCRIPTION
It is already included for Foreman, but missing in Katello.