### PR TITLE
Add Foreman SCC manager plugin

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -64,6 +64,7 @@ foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false
 foreman::plugin::salt: false
+foreman::plugin::scc_manager: false
 foreman::plugin::setup: false
 foreman::plugin::snapshot_management: false
 foreman::plugin::statistics: false

--- a/config/katello.migrations/20220602170000_foreman_scc_manager.rb
+++ b/config/katello.migrations/20220602170000_foreman_scc_manager.rb
@@ -1,0 +1,1 @@
+answers['foreman::plugin::scc_manager'] ||= false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -28,6 +28,7 @@ foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false
 foreman::plugin::salt: false
+foreman::plugin::scc_manager: false
 foreman::plugin::snapshot_management: false
 foreman::plugin::statistics: false
 foreman::plugin::virt_who_configure: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -28,6 +28,7 @@ foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false
 foreman::plugin::salt: false
+foreman::plugin::scc_manager: false
 foreman::plugin::snapshot_management: false
 foreman::plugin::statistics: false
 foreman::plugin::virt_who_configure: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -28,6 +28,7 @@ foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false
 foreman::plugin::rh_cloud: false
 foreman::plugin::salt: false
+foreman::plugin::scc_manager: false
 foreman::plugin::snapshot_management: false
 foreman::plugin::statistics: false
 foreman::plugin::virt_who_configure: false


### PR DESCRIPTION
Depends on https://github.com/theforeman/puppet-foreman/pull/1057 and it is Katello only as the plugin only works on it, not pure Foreman.