### PR TITLE
Drop EL8 modularity workaround

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -93,10 +93,6 @@ module HookContextExtension
     facts[:os][:release][:major] == '7' && facts[:os][:family] == 'RedHat'
   end
 
-  def el8?
-    facts[:os][:release][:major] == '8' && facts[:os][:family] == 'RedHat'
-  end
-
   def log_and_say(level, message, do_say = true, do_log = true)
     style = case level
             when :error

--- a/hooks/pre/32-install_selinux_packages.rb
+++ b/hooks/pre/32-install_selinux_packages.rb
@@ -12,10 +12,5 @@ if facts.dig(:os, :selinux, :enabled)
   packages << 'candlepin-selinux' if katello_enabled?
   packages << 'pulpcore-selinux' if pulpcore_enabled?
 
-  if katello_enabled? && el8?
-    # candlepin-selinux pulls in candlepin which requires pki-core
-    execute!('dnf module enable pki-core --assumeyes', false, true)
-  end
-
   ensure_packages(packages, 'installed')
 end


### PR DESCRIPTION
Since Foreman 3.3 there is proper modularity support which pulls in pki-core already. That means if the user enabled the katello module, this is redundant.