### PR TITLE
Fixes #35134: Introduce development tuning profile, update default

### DIFF
--- a/hooks/boot/13-tuning.rb
+++ b/hooks/boot/13-tuning.rb
@@ -1,7 +1,8 @@
 if has_custom_fact?('tuning')
-  # TODO: automatically get the tuning sizes - standard doesn't exist and only
-  # loads base. The rest maps to config/foreman.hiera/tuning/sizes/$size.yaml
-  TUNING_SIZES = ['default'] + ['medium', 'large', 'extra-large', 'extra-extra-large']
+  # Tuning sizes are based off of config/foreman.hiera/tuning/common.yaml
+  # Additional configuration and overrides of base configuration are mapped to
+  # config/foreman.hiera/tuning/sizes/$size.yaml
+  TUNING_SIZES = ['default', 'medium', 'large', 'extra-large', 'extra-extra-large', 'development'].freeze
   TUNING_FACT = 'tuning'.freeze
 
   app_option(

--- a/hooks/pre_commit/13-tuning.rb
+++ b/hooks/pre_commit/13-tuning.rb
@@ -1,7 +1,8 @@
 if app_option?(:tuning)
   # A mapping of tuning profile to the required CPU cores and memory in GB
   TUNING_SIZES = {
-    'default' => { cpu_cores: 1, memory: 8 },
+    'development' => { cpu_cores: 1, memory: 6 },
+    'default' => { cpu_cores: 4, memory: 20 },
     'medium' => { cpu_cores: 8, memory: 32 },
     'large' => { cpu_cores: 16, memory: 64 },
     'extra-large' => { cpu_cores: 32, memory: 128 },


### PR DESCRIPTION
Introduces a development tuning profile that exists to have the lowest
possible values for a development or custom CI environment. Additionally
this moves the default tuning to match the performance tuning guide values for
default.

See [Performance Tuning Guide](https://docs.theforeman.org/nightly/Performance_Tuning_Guide/index-foreman-el.html#Puma_Workers_and_Threads_Recommendation_performance-tuning) for table of values for CPUs and memory.

Additional follow up work I intend to persue:

 * Use development profile in development environments and CI in places such as Forklift
 * Removal of `--disable-system-checks` where we expect that the development profile covers a reasonable bare minimum
