### PR TITLE
Fixes #35138: Remove umask hook

### DIFF
--- a/katello/hooks/pre/16-set_umask.rb
+++ b/katello/hooks/pre/16-set_umask.rb
@@ -1,4 +1,0 @@
-if File.umask != 0o022
-  old = File.umask(0o022)
-  logger.info "Set umask to 0022 for installation, former umask was #{old.to_s(8).rjust(4, '0')}"
-end


### PR DESCRIPTION
Test run:

```console
# foreman-installer --scenario katello --disable-system-checks
2022-06-29 15:51:08 [NOTICE] [root] Loading installer configuration. This will take some time.
2022-06-29 15:51:11 [NOTICE] [root] Running installer with log based terminal output at level NOTICE.
2022-06-29 15:51:11 [NOTICE] [root] Use -l to set the terminal output log level to ERROR, WARN, NOTICE, INFO, or DEBUG. See --full-help for definitions.
2022-06-29 15:51:13 [WARN  ] [pre] Skipping system checks.
2022-06-29 15:55:02 [NOTICE] [configure] Starting system configuration.
2022-06-29 15:56:29 [NOTICE] [configure] 250 configuration steps out of 1374 steps complete.
2022-06-29 15:57:00 [NOTICE] [configure] 500 configuration steps out of 1376 steps complete.
2022-06-29 15:58:29 [NOTICE] [configure] 750 configuration steps out of 1382 steps complete.
2022-06-29 15:58:35 [NOTICE] [configure] 1000 configuration steps out of 1404 steps complete.
2022-06-29 16:00:33 [NOTICE] [configure] 1250 configuration steps out of 1404 steps complete.
2022-06-29 16:02:20 [NOTICE] [configure] System configuration has finished.
Executing: foreman-rake upgrade:run
=============================================
Upgrade Step 1/8: katello:correct_repositories. This may take a long while.
=============================================
Upgrade Step 2/8: katello:clean_backend_objects. This may take a long while.
0 orphaned consumer id(s) found in candlepin.
Candlepin orphaned consumers: []
=============================================
Upgrade Step 3/8: katello:upgrades:4.0:remove_ostree_puppet_content. =============================================
Upgrade Step 4/8: katello:upgrades:4.1:sync_noarch_content. =============================================
Upgrade Step 5/8: katello:upgrades:4.1:fix_invalid_pools. I, [2022-06-29T16:02:28.515514 #41857]  INFO -- : Corrected 0 invalid pools
I, [2022-06-29T16:02:28.515541 #41857]  INFO -- : Removed 0 orphaned pools
=============================================
Upgrade Step 6/8: katello:upgrades:4.1:reupdate_content_import_export_perms. =============================================
Upgrade Step 7/8: katello:upgrades:4.2:remove_checksum_values. =============================================
Upgrade Step 8/8: katello:upgrades:4.4:publish_import_cvvs.   Success!
  * Foreman is running at https://umask.wareagle.example.com
      Initial credentials are admin / hvHtoSHT2bmgtexi
  * To install an additional Foreman proxy on separate machine continue by running:

      foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" --certs-tar "/root/$FOREMAN_PROXY-certs.tar"
  * Foreman Proxy is running at https://umask.wareagle.example.com:9090

  The full log is at /var/log/foreman-installer/katello.log
# umask
0027
```