### PR TITLE
Fixes #35149: Drop --disable-system-checks installer option

### DIFF
--- a/hooks/pre_commit/13-tuning.rb
+++ b/hooks/pre_commit/13-tuning.rb
@@ -20,34 +20,30 @@ if app_option?(:tuning)
     new_tuning = current_tuning
   end
 
-  if app_value(:disable_system_checks)
-    logger.warn 'Skipping system checks.'
-  else
-    required = TUNING_SIZES[new_tuning]
-    required_cores = required[:cpu_cores]
-    required_memory = required[:memory]
+  required = TUNING_SIZES[new_tuning]
+  required_cores = required[:cpu_cores]
+  required_memory = required[:memory]
 
-    # Check if it's actually 90% of the required. If a crash kernel is enabled
-    # then the reported total memory is lower than in reality.
-    if facts[:memory][:system][:total_bytes] < (required_memory * 1024 * 1024 * 1024 * 0.9)
-      if app_value(:tuning)
-        say "<%= color('Insufficient memory for tuning size', :bad) %>"
-        say "Tuning profile '#{new_tuning}' requires at least #{required_memory} GB of memory and #{required_cores} CPU cores"
-      else
-        say "The #{scenario_id} scenario requires at least #{required_memory} GB of memory and #{required_cores} CPU cores"
-      end
-      exit EXIT_INSUFFICIENT_MEMORY
+  # Check if it's actually 90% of the required. If a crash kernel is enabled
+  # then the reported total memory is lower than in reality.
+  if facts[:memory][:system][:total_bytes] < (required_memory * 1024 * 1024 * 1024 * 0.9)
+    if app_value(:tuning)
+      say "<%= color('Insufficient memory for tuning size', :bad) %>"
+      say "Tuning profile '#{new_tuning}' requires at least #{required_memory} GB of memory and #{required_cores} CPU cores"
+    else
+      say "The #{scenario_id} scenario requires at least #{required_memory} GB of memory and #{required_cores} CPU cores"
     end
+    exit EXIT_INSUFFICIENT_MEMORY
+  end
 
-    if facts[:processors][:count] < required_cores
-      if app_value(:tuning)
-        say "<%= color('Insufficient CPU cores for tuning size', :bad) %>"
-        say "Tuning profile '#{new_tuning}' requires at least #{required_memory} GB of memory and #{required_cores} CPU cores"
-      else
-        say "The #{scenario_id} scenario requires at least #{required_memory} GB of memory and #{required_cores} CPU cores"
-      end
-      exit EXIT_INSUFFICIENT_CPU_CORES
+  if facts[:processors][:count] < required_cores
+    if app_value(:tuning)
+      say "<%= color('Insufficient CPU cores for tuning size', :bad) %>"
+      say "Tuning profile '#{new_tuning}' requires at least #{required_memory} GB of memory and #{required_cores} CPU cores"
+    else
+      say "The #{scenario_id} scenario requires at least #{required_memory} GB of memory and #{required_cores} CPU cores"
     end
+    exit EXIT_INSUFFICIENT_CPU_CORES
   end
 
   if current_tuning != new_tuning

--- a/katello/hooks/boot/17-disable_system_checks.rb
+++ b/katello/hooks/boot/17-disable_system_checks.rb
@@ -1,8 +1,0 @@
-# Add disable system checks option
-app_option(
-  '--disable-system-checks',
-  :flag,
-  "This option will skip the system checks for memory.",
-  :default => false,
-  :advanced => true
-)


### PR DESCRIPTION
Draft to start as it relies on:

 * https://github.com/theforeman/foreman-installer/pull/790
 * https://github.com/theforeman/foreman-installer/pull/788


I did not opt to keep the option around for a release with a warning because I felt like the option *implies* something is being disabled when used when in fact nothing is. There are a number of scripts that will need to be updated which is the downside. I was more worried about the false impression it would be sending and that forcing scripts to drop using this "workaround" is a good thing.