### PR TITLE
Remove mentions of Apache prefork settings

### DIFF
--- a/config/custom-hiera.yaml
+++ b/config/custom-hiera.yaml
@@ -16,15 +16,6 @@
 # changes before applying them, and test them in a non-production environment
 # first.
 #
-# Here are some examples of how you tune the Apache options if needed:
-#
-# apache::mod::prefork::startservers: 8
-# apache::mod::prefork::minspareservers: 5
-# apache::mod::prefork::maxspareservers: 20
-# apache::mod::prefork::serverlimit: 256
-# apache::mod::prefork::maxclients: 256
-# apache::mod::prefork::maxrequestsperchild: 4000
-#
 # Here are some examples of how you tune the PostgreSQL options if needed:
 #
 # postgresql::server::config_entries:

--- a/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
@@ -3,10 +3,6 @@ apache::mod::event::serverlimit: 64
 apache::mod::event::maxrequestworkers: 1024
 apache::mod::event::maxrequestsperchild: 4000
 
-apache::mod::prefork::serverlimit: 1024
-apache::mod::prefork::maxclients: 1024
-apache::mod::prefork::maxrequestsperchild: 4000
-
 candlepin::java_opts: "-Xms1024m -Xmx8192m"
 
 postgresql::server::config_entries:

--- a/config/foreman.hiera/tuning/sizes/extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-large.yaml
@@ -3,10 +3,6 @@ apache::mod::event::serverlimit: 64
 apache::mod::event::maxrequestworkers: 1024
 apache::mod::event::maxrequestsperchild: 4000
 
-apache::mod::prefork::serverlimit: 1024
-apache::mod::prefork::maxclients: 1024
-apache::mod::prefork::maxrequestsperchild: 4000
-
 candlepin::java_opts: "-Xms1024m -Xmx8192m"
 
 postgresql::server::config_entries:

--- a/config/foreman.hiera/tuning/sizes/large.yaml
+++ b/config/foreman.hiera/tuning/sizes/large.yaml
@@ -3,10 +3,6 @@ apache::mod::event::serverlimit: 64
 apache::mod::event::maxrequestworkers: 1024
 apache::mod::event::maxrequestsperchild: 4000
 
-apache::mod::prefork::serverlimit: 1024
-apache::mod::prefork::maxclients: 1024
-apache::mod::prefork::maxrequestsperchild: 4000
-
 postgresql::server::config_entries:
   max_connections: 1000
   shared_buffers: 8GB

--- a/config/foreman.hiera/tuning/sizes/medium.yaml
+++ b/config/foreman.hiera/tuning/sizes/medium.yaml
@@ -3,10 +3,6 @@ apache::mod::event::serverlimit: 64
 apache::mod::event::maxrequestworkers: 1024
 apache::mod::event::maxrequestsperchild: 4000
 
-apache::mod::prefork::serverlimit: 1024
-apache::mod::prefork::maxclients: 1024
-apache::mod::prefork::maxrequestsperchild: 4000
-
 postgresql::server::config_entries:
   max_connections: 1000
   shared_buffers: 4GB


### PR DESCRIPTION
There is no setup where prefork is used after EL7 support was dropped. While users can still manually switch the MPM module, we don't support this.

Fixes: 344905158ad04395a65a56564d460e0d4e9ad27c