### PR TITLE
Refs #35149 - Remove katello hook dirs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -114,10 +114,6 @@ SCENARIOS.each do |scenario|
       'parser_cache_path' => "#{DATADIR}/foreman-installer/parser_cache/#{scenario}.yaml",
     }
 
-    if ['foreman-proxy-content', 'katello'].include?(scenario)
-      scenario_config_replacements['hook_dirs'] = "['#{DATADIR}/foreman-installer/katello/hooks']"
-    end
-
     scenario_config_replacements.each do |setting, value|
       sh format('sed -i "s#\(.*%s:\).*#\1 %s#" %s', setting, value, t.name)
     end
@@ -296,10 +292,6 @@ task :install => :build do
   mkdir_p "#{DATADIR}/foreman-installer"
   cp_r Dir.glob('{checks,hooks,VERSION,README.md,LICENSE}'), "#{DATADIR}/foreman-installer"
   cp_r "#{BUILDDIR}/config", "#{DATADIR}/foreman-installer"
-
-  if BUILD_KATELLO
-    cp_r 'katello', "#{DATADIR}/foreman-installer"
-  end
 
   mkdir_p "#{SYSCONFDIR}/foreman-installer/scenarios.d"
   SCENARIOS.each do |scenario|

--- a/config/foreman-proxy-content.migrations/220804181233-drop-katello-hook-dirs.rb
+++ b/config/foreman-proxy-content.migrations/220804181233-drop-katello-hook-dirs.rb
@@ -1,0 +1,1 @@
+scenario.delete(:hook_dirs)

--- a/config/foreman-proxy-content.yaml
+++ b/config/foreman-proxy-content.yaml
@@ -11,7 +11,6 @@
 :answer_file: ./config/foreman-proxy-content-answers.yaml
 :installer_dir: .
 :module_dirs: ./_build/modules
-:hook_dirs: ['./katello/hooks']
 :parser_cache_path: ./_build/parser_cache/foreman-proxy-content.yaml
 :hiera_config: ./config/foreman-hiera.yaml
 

--- a/config/katello.migrations/220804181233-drop-katello-hook-dirs.rb
+++ b/config/katello.migrations/220804181233-drop-katello-hook-dirs.rb
@@ -1,0 +1,1 @@
+scenario.delete(:hook_dirs)

--- a/config/katello.yaml
+++ b/config/katello.yaml
@@ -11,7 +11,6 @@
 :answer_file: ./config/katello-answers.yaml
 :installer_dir: .
 :module_dirs: ./_build/modules
-:hook_dirs: ['./katello/hooks']
 :parser_cache_path: ./_build/parser_cache/katello.yaml
 :hiera_config: ./config/foreman-hiera.yaml
 :facts:

--- a/spec/fixtures/merged-installer/foreman-proxy-content-after.yaml
+++ b/spec/fixtures/merged-installer/foreman-proxy-content-after.yaml
@@ -12,8 +12,6 @@
 :installer_dir: /usr/share/foreman-installer
 :module_dirs:
 - /usr/share/foreman-installer/modules
-:hook_dirs:
-- /usr/share/foreman-installer/katello/hooks
 :colors: true
 :color_of_background: :dark
 :custom: {}

--- a/spec/fixtures/merged-installer/katello-after.yaml
+++ b/spec/fixtures/merged-installer/katello-after.yaml
@@ -12,8 +12,6 @@
 :installer_dir: /usr/share/foreman-installer
 :module_dirs:
 - /usr/share/foreman-installer/modules
-:hook_dirs:
-- /usr/share/foreman-installer/katello/hooks
 :colors: true
 :color_of_background: :dark
 :custom: {}

--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'semantic_puppet'
 
 describe 'Puppet module' do
-  VERSIONS = ['6.15.0', '7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
+  VERSIONS = ['6.23.0', '7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
 
   Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|
     context File.basename(File.dirname(filename)) do


### PR DESCRIPTION
In 10a30ba937f8e4c4cbbad889a05e3f5a8965eaf5 the top level directory katello was removed. This means the hook_dirs entry is no longer needed.  It also means the directory no longer needs to be copied during installation.