### PR TITLE
Refs #35353 - Drop xinetd support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,8 +1,6 @@
 forge 'https://forgeapi.puppet.com/'
 
 # Dependencies
-# For Puppet 7 support
-mod 'puppetlabs/xinetd',             :git => 'https://github.com/puppetlabs/puppetlabs-xinetd', :commit => 'e742608dccdf42236144acf9f05e483b47c576f1'
 mod 'puppetlabs/postgresql',         '>= 7.0.0'
 mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'


### PR DESCRIPTION
puppet-tftp has dropped the dependency on xinetd so no more specific version is needed.

Depends on https://github.com/theforeman/puppet-tftp/pull/136