### PR TITLE
Fixes #35157 - Enable Pulp's content caching on Katello

### DIFF
--- a/config/katello.migrations/220705101935-enable-pulp-content-cache.rb
+++ b/config/katello.migrations/220705101935-enable-pulp-content-cache.rb
@@ -1,0 +1,3 @@
+if answers['foreman_proxy_content'].is_a?(Hash) && answers['foreman_proxy_content'].key?('pulpcore_cache_enabled')
+  answers['foreman_proxy_content']['pulpcore_cache_enabled'] = true
+end


### PR DESCRIPTION
Like 4155c66f59ea42fe10d709434d6ab5dcdb66b572 but for the Katello scenario.

(cherry picked from commit b6305f7f8d7877ec9a38314a6eed521143bd27ff)