### PR TITLE
Fixes #35440 - Drop host reports plugin

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -14,7 +14,6 @@ foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
 foreman::cli::discovery: false
-foreman::cli::host_reports: false
 foreman::cli::kubevirt: false
 foreman::cli::openscap: false
 foreman::cli::puppet: true
@@ -42,7 +41,6 @@ foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::hooks: false
 foreman::plugin::host_extra_validator: false
-foreman::plugin::host_reports: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
@@ -75,7 +73,6 @@ foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::dns::powerdns: false
 foreman_proxy::plugin::dynflow: false
-foreman_proxy::plugin::reports: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::omaha: false
 foreman_proxy::plugin::openscap: false

--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -34,7 +34,6 @@ foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
-foreman_proxy::plugin::reports: false
 foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::script: false
 foreman_proxy::plugin::salt: false

--- a/config/foreman-proxy-content.migrations/220826141649-drop-host-reports-plugin.rb
+++ b/config/foreman-proxy-content.migrations/220826141649-drop-host-reports-plugin.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-foreman/commit/f8f7e906e0707febc68dfff768a86e561ce0581d
+answers.delete('foreman::cli::host_reports')
+answers.delete('foreman::plugin::host_reports')
+# https://github.com/theforeman/puppet-foreman_proxy/commit/8d3c7fd63999bade3fe12835316f01f0d9285503
+answers.delete('foreman_proxy::plugin::reports')

--- a/config/foreman.migrations/20220826141649_drop_host_reports_plugin.rb
+++ b/config/foreman.migrations/20220826141649_drop_host_reports_plugin.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-foreman/commit/f8f7e906e0707febc68dfff768a86e561ce0581d
+answers.delete('foreman::cli::host_reports')
+answers.delete('foreman::plugin::host_reports')
+# https://github.com/theforeman/puppet-foreman_proxy/commit/8d3c7fd63999bade3fe12835316f01f0d9285503
+answers.delete('foreman_proxy::plugin::reports')

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -26,7 +26,6 @@ foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
 foreman::cli::discovery: false
-foreman::cli::host_reports: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
 foreman::cli::openscap: false
@@ -55,7 +54,6 @@ foreman::plugin::dlm: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::hooks: false
-foreman::plugin::host_reports: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
@@ -98,7 +96,6 @@ foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::monitoring: false
-foreman_proxy::plugin::reports: false
 foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::script: false
 foreman_proxy::plugin::salt: false

--- a/config/katello.migrations/220826141649-drop-host-reports-plugin.rb
+++ b/config/katello.migrations/220826141649-drop-host-reports-plugin.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-foreman/commit/f8f7e906e0707febc68dfff768a86e561ce0581d
+answers.delete('foreman::cli::host_reports')
+answers.delete('foreman::plugin::host_reports')
+# https://github.com/theforeman/puppet-foreman_proxy/commit/8d3c7fd63999bade3fe12835316f01f0d9285503
+answers.delete('foreman_proxy::plugin::reports')

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -1,7 +1,6 @@
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
-foreman::cli::host_reports: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
 foreman::cli::puppet: true
@@ -21,7 +20,6 @@ foreman::plugin::dlm: false
 foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
-foreman::plugin::host_reports: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
@@ -44,7 +42,6 @@ foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::chef: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
-foreman_proxy::plugin::reports: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -1,7 +1,6 @@
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
-foreman::cli::host_reports: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
 foreman::cli::puppet: true
@@ -21,7 +20,6 @@ foreman::plugin::dlm: false
 foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
-foreman::plugin::host_reports: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
@@ -44,7 +42,6 @@ foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::chef: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
-foreman_proxy::plugin::reports: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -1,7 +1,6 @@
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
-foreman::cli::host_reports: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false
 foreman::cli::puppet: true
@@ -21,7 +20,6 @@ foreman::plugin::dlm: false
 foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
-foreman::plugin::host_reports: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false
@@ -44,7 +42,6 @@ foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::chef: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
-foreman_proxy::plugin::reports: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false


### PR DESCRIPTION
This plugin is discontinued and has been removed from the repositories since it was broken.