### PR TITLE
Fixes #35453 - Remove trailing backslash from capsule-certs-generate …

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -279,7 +279,7 @@ elif [[ $EXIT_CODE == "0" ]]; then
                                    --certs-tar  "~/\$${PROXY_VAR}-certs.tar" \\
                                    --server-cert "$(readlink -f $CERT_FILE)" \\
                                    --server-key "$(readlink -f $KEY_FILE)" \\
-                                   --server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)" \\
+                                   --server-ca-cert "$(readlink -f $CA_BUNDLE_FILE)"
 
   To use them inside an EXISTING \$${PROXY_VAR}, run this command INSTEAD:
 


### PR DESCRIPTION
Due to the extra backslash in https://github.com/theforeman/foreman-installer/blob/develop/bin/katello-certs-check#L282 , the resulting capsule-certs-generate command for new capsules may not be getting executed in one shot when someone simply copy+paste and one can assume that the command is hung

The idea is simply to simply remove that backslash 

