### PR TITLE
Fixes #35524 - Use a patched puppetlabs-apache for SSO

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,5 +1,6 @@
 forge 'https://forgeapi.puppet.com/'
 
+mod 'puppetlabs/apache',             :git => 'https://github.com/theforeman/puppetlabs-apache', :branch => '7.0-stable'
 mod 'puppetlabs/xinetd',             :git => 'https://github.com/puppetlabs/puppetlabs-xinetd', :commit => 'e742608dccdf42236144acf9f05e483b47c576f1'
 mod 'puppetlabs/postgresql',           '>= 7.0.0'
 mod 'theforeman/dhcp',                 '>= 8.2.0 < 8.3.0'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -44,9 +44,6 @@ FORGE
       puppetlabs-stdlib (>= 4.13.1, < 9.0.0)
     puppet-trusted_ca (4.1.0)
       puppetlabs-stdlib (>= 4.13.0, < 9.0.0)
-    puppetlabs-apache (7.0.0)
-      puppetlabs-concat (>= 2.2.1, < 8.0.0)
-      puppetlabs-stdlib (>= 4.13.1, < 9.0.0)
     puppetlabs-apt (8.5.0)
       puppetlabs-stdlib (>= 4.16.0, < 9.0.0)
     puppetlabs-concat (7.2.0)
@@ -112,6 +109,15 @@ GIT
   specs:
     puppetlabs-xinetd (3.3.0)
 
+GIT
+  remote: https://github.com/theforeman/puppetlabs-apache
+  ref: 7.0-stable
+  sha: b65eeb3371c3c8a6d771c6384fb6f43bd3ce626e
+  specs:
+    puppetlabs-apache (7.0.0)
+      puppetlabs-concat (>= 2.2.1, < 8.0.0)
+      puppetlabs-stdlib (>= 4.13.1, < 9.0.0)
+
 DEPENDENCIES
   katello-candlepin (>= 13.0.0, < 13.1.0)
   katello-certs (>= 15.1.1, < 15.2.0)
@@ -119,6 +125,7 @@ DEPENDENCIES
   katello-katello (>= 22.0.0, < 22.1.0)
   katello-qpid (>= 9.1.0, < 9.2.0)
   puppet-mosquitto (>= 1.1.0)
+  puppetlabs-apache (>= 0)
   puppetlabs-postgresql (>= 7.0.0)
   puppetlabs-xinetd (>= 0)
   theforeman-dhcp (>= 8.2.0, < 8.3.0)


### PR DESCRIPTION
Without this Single Sign On using Keycloak doesn't work. The Apache module needs certain other modules enabled. On EL8 it also needs to enable a DNF module to install the package.

The fixes are upstream in 8.0.0 but various other modules don't allow that. Using a patched module is the smallest impact. Notably, only the pulpcore module needs allow 8.x. However, this is much harder for 3.3, which is also affected.