### PR TITLE
Fixes #35553 - Disable ansible-runner repo on upgrade

### DIFF
--- a/config/foreman.migrations/20220926102315_set_ansible_runner_repo_false_on_debian.rb
+++ b/config/foreman.migrations/20220926102315_set_ansible_runner_repo_false_on_debian.rb
@@ -1,0 +1,5 @@
+# 18ac4a1b2e667ad24a7db418c27af8e48f559905
+# The Ansible repo is no longer a thing for Debian
+if answers['foreman_proxy::plugin::ansible'].is_a?(Hash) && facts[:os][:family] == 'Debian'
+  answers['foreman_proxy::plugin::ansible'].delete('manage_runner_repo')
+end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -151,4 +151,25 @@ describe 'with all migrations' do
       end
     end
   end
+
+  context 'the migration 20220926102315_set_ansible_runner_repo_false_on_debian on foreman' do
+    let(:scenario_name) { 'foreman' }
+    let(:answers) do
+      {
+        'foreman_proxy::plugin::ansible' => {
+          'manage_runner_repo' => true,
+        },
+      }
+    end
+
+    specify 'on Debian' do
+      expect_any_instance_of(Kafo::MigrationContext).to receive(:facts).and_return({ os: { family: 'Debian' } })
+      expect(migrated_answers['foreman_proxy::plugin::ansible']).not_to include('manage_runner_repo')
+    end
+
+    specify 'on RedHat' do
+      expect_any_instance_of(Kafo::MigrationContext).to receive(:facts).and_return({ os: { family: 'RedHat' } })
+      expect(migrated_answers['foreman_proxy::plugin::ansible']).to include('manage_runner_repo')
+    end
+  end
 end


### PR DESCRIPTION
ansible-runner is now included in the Foreman repositories, so the repository should no longer be managed.