### PR TITLE
Fixes #35564 - Use Redis 6 on EL8

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,6 +6,9 @@ mod 'puppetlabs/apache',             '>= 8.3.0'
 # Ensure Debian 11 support
 mod 'puppetlabs/postgresql',         '>= 7.4.0'
 
+# Dnfmodule support for Redis 6+ support
+mod 'puppet/redis',                  '>= 8.5.0'
+
 # Dependencies
 mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'

--- a/config/foreman.hiera/family/RedHat-8.yaml
+++ b/config/foreman.hiera/family/RedHat-8.yaml
@@ -1,3 +1,6 @@
 ---
 postgresql::globals::manage_dnf_module: true
 postgresql::globals::version: "12"
+
+redis::dnf_module_stream: "6"
+redis::package_ensure: ">=6.0"


### PR DESCRIPTION
Requires: https://github.com/voxpupuli/puppet-redis/pull/450