### PR TITLE
Fixes #35629 - Default Apache to PROFILE=system ciphers

### DIFF
--- a/config/foreman.hiera/family/RedHat-8.yaml
+++ b/config/foreman.hiera/family/RedHat-8.yaml
@@ -1,4 +1,7 @@
 ---
+apache::mod::ssl::ssl_ciper: 'PROFILE=system'
+# TODO: depends on https://github.com/puppetlabs/puppetlabs-apache/pull/2335
+apache::mod::ssl::ssl_proxy_ciper_suite: 'PROFILE=system'
 # EL8 doesn't have support for SSLv3 anymore and errors out on it. This
 # overrides security.yaml
 apache::mod::ssl::ssl_protocol:


### PR DESCRIPTION
At least on EL8 it's possible to use PROFILE=system for SSLCipherSuite and SSLProxyCipherSuite. This allows admins to configure the cipher suite on a system level and it also means we don't have to keep our cipher suite up to date.

Today SSLProxyCipherSuite is not yet an option (https://github.com/puppetlabs/puppetlabs-apache/pull/2335 should add it), but Hiera will ignore unknown keys. When the option becomes available, it will be set.

I don't know if Debian/Ubuntu can do the same so for now I've set it only for RH-8.