### PR TITLE
Fixes #35631 - Enable HTTP/2 by default

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,9 @@
 forge 'https://forgeapi.puppet.com/'
 
+# Ensure Debian 11 support
+mod 'puppetlabs/postgresql',         '>= 7.4.0'
+
 # Dependencies
-mod 'puppetlabs/postgresql',         '>= 7.0.0'
 mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'
 mod 'theforeman/git',                :git => 'https://github.com/theforeman/puppet-git'

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,5 +1,9 @@
 forge 'https://forgeapi.puppet.com/'
 
+# Unreleased module for:
+# ssl support: b3b9a82f50442c9d197ee8c30cb3df286d7eb099 & 4bd6143eba4bf58eabdcd0044bc0e3eadb1400b9
+mod 'puppetlabs/apache',             :git => 'https://github.com/puppetlabs/puppetlabs-apache', :ref => '47f0d7259cb7a368a685068a45d8422cc15b456b'
+
 # Ensure Debian 11 support
 mod 'puppetlabs/postgresql',         '>= 7.4.0'
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,6 +1,7 @@
 forge 'https://forgeapi.puppet.com/'
 
 # Unreleased module for:
+# http2 loading: 6fa784a66061551e844203f17ad9367f7ad41d4b
 # ssl support: b3b9a82f50442c9d197ee8c30cb3df286d7eb099 & 4bd6143eba4bf58eabdcd0044bc0e3eadb1400b9
 mod 'puppetlabs/apache',             :git => 'https://github.com/puppetlabs/puppetlabs-apache', :ref => '47f0d7259cb7a368a685068a45d8422cc15b456b'
 

--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -2,6 +2,10 @@
 apache::default_vhost: false
 apache::default_mods: false
 apache::mpm_module: 'event'
+apache::protocols:
+  - 'h2'
+  - 'h2c'
+  - 'http/1.1'
 
 dhcp::config_comment: |
   READ: This file was written the foreman-installer and not by the Foreman

--- a/config/foreman.hiera/family/Debian.yaml
+++ b/config/foreman.hiera/family/Debian.yaml
@@ -1,0 +1,7 @@
+# Taken from https://ssl-config.mozilla.org/#server=apache&version=2.4.6&config=intermediate&openssl=1.0.2&guideline=5.6
+apache::mod::ssl::ssl_cipher: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384'
+apache::mod::ssl::ssl_protocol:
+  - 'ALL'
+  - '-SSLv3'
+  - '-TLSv1'
+  - '-TLSv1.1'

--- a/config/foreman.hiera/family/RedHat-8.yaml
+++ b/config/foreman.hiera/family/RedHat-8.yaml
@@ -1,13 +1,3 @@
 ---
-apache::mod::ssl::ssl_ciper: 'PROFILE=SYSTEM'
-# TODO: depends on https://github.com/puppetlabs/puppetlabs-apache/pull/2335
-apache::mod::ssl::ssl_proxy_ciper_suite: 'PROFILE=SYSTEM'
-# EL8 doesn't have support for SSLv3 anymore and errors out on it. This
-# overrides security.yaml
-apache::mod::ssl::ssl_protocol:
-  - 'ALL'
-  - '-TLSv1'
-  - '-TLSv1.1'
-
 postgresql::globals::manage_dnf_module: true
 postgresql::globals::version: "12"

--- a/config/foreman.hiera/security.yaml
+++ b/config/foreman.hiera/security.yaml
@@ -1,9 +1,2 @@
 ---
-# Taken from https://ssl-config.mozilla.org/#server=apache&version=2.4.6&config=intermediate&openssl=1.0.2&guideline=5.6
-apache::mod::ssl::ssl_cipher: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384'
-apache::mod::ssl::ssl_protocol:
-  - 'ALL'
-  - '-SSLv3'
-  - '-TLSv1'
-  - '-TLSv1.1'
 apache::trace_enable: 'Off'


### PR DESCRIPTION
Apache doesn't load HTTP/2 by default since it's incompatible with the prefork MPM. We use the event MPM where it should work. Enabling HTTP/2 allows clients to retrieve resources in parallel which means pages load faster.

Currently this is blocked on loading mod_http2, which will be done automatically once https://github.com/puppetlabs/puppetlabs-apache/pull/2337 is released. Apache ignores unknown protocols, so it can probably be merged, but then we don't get the benefit. I'd prefer to ensure we have a sufficiently recents puppetlabs/apache module.