### PR TITLE
Refs #35629 - Switch back to puppetlabs/apache releases

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,9 +1,7 @@
 forge 'https://forgeapi.puppet.com/'
 
-# Unreleased module for:
-# http2 loading: 6fa784a66061551e844203f17ad9367f7ad41d4b
-# ssl support: b3b9a82f50442c9d197ee8c30cb3df286d7eb099 & 4bd6143eba4bf58eabdcd0044bc0e3eadb1400b9
-mod 'puppetlabs/apache',             :git => 'https://github.com/puppetlabs/puppetlabs-apache', :ref => '47f0d7259cb7a368a685068a45d8422cc15b456b'
+# HTTP/2 and SSL support for settings in Hiera
+mod 'puppetlabs/apache',             '>= 8.3.0'
 
 # Ensure Debian 11 support
 mod 'puppetlabs/postgresql',         '>= 7.4.0'


### PR DESCRIPTION
8.3.0 was released with the features we need.