### PR TITLE
drop explicit dependency on mosquitto

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -27,6 +27,3 @@ mod 'theforeman/puppet',             :git => 'https://github.com/theforeman/pupp
 mod 'katello/foreman_proxy_content', :git => 'https://github.com/theforeman/puppet-foreman_proxy_content'
 mod 'katello/certs',                 :git => 'https://github.com/theforeman/puppet-certs'
 mod 'katello/katello',               :git => 'https://github.com/theforeman/puppet-katello'
-
-# REX dependencies
-mod 'puppet/mosquitto',              '>= 1.1.0'


### PR DESCRIPTION
since https://github.com/theforeman/puppet-foreman_proxy/commit/58fa4c7742e719218971a9cb42aa84787f02e59f it's an explicit dependency of theforeman/foreman_proxy, so we don't need to call it out here anymore