### PR TITLE
Restructure installation and add a pulp scenario

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ MANDIR = ENV['MANDIR'] || "#{DATAROOTDIR}/man"
 PKGDIR = ENV['PKGDIR'] || File.expand_path('pkg')
 
 if BUILD_KATELLO
-  SCENARIOS = ['foreman', 'foreman-proxy-content', 'katello'].freeze
+  SCENARIOS = ['foreman', 'foreman-proxy-content', 'katello', 'pulp'].freeze
   CERTS_SCENARIOS = ['foreman-proxy-certs'].freeze
 else
   SCENARIOS = ['foreman'].freeze

--- a/Rakefile
+++ b/Rakefile
@@ -99,10 +99,11 @@ directory BUILDDIR
 directory PKGDIR
 directory "#{BUILDDIR}/parser_cache"
 file "#{BUILDDIR}/parser_cache" => BUILDDIR
+directory "#{BUILDDIR}/scenarios.d" => BUILDDIR
 
 SCENARIOS.each do |scenario|
   config = "config/#{scenario}.yaml"
-  file "#{BUILDDIR}/#{scenario}.yaml" => [config, BUILDDIR] do |t|
+  file "#{BUILDDIR}/scenarios.d/#{scenario}.yaml" => [config, "#{BUILDDIR}/scenarios.d"] do |t|
     cp t.prerequisites.first, t.name
 
     scenario_config_replacements = {
@@ -123,37 +124,34 @@ SCENARIOS.each do |scenario|
     end
   end
 
+  file "#{BUILDDIR}/scenarios.d/#{scenario}-answers.yaml" => ["config/#{scenario}-answers.yaml", "#{BUILDDIR}/scenarios.d"] do |t|
+    cp t.prerequisites.first, t.name
+  end
+
+  # Store migration scripts under DATADIR, symlinked back into SYSCONFDIR and keep .applied file in SYSCONFDIR
+  file "#{BUILDDIR}/config/#{scenario}.migrations" => ["config/#{scenario}.migrations", "#{BUILDDIR}/config"] do |t|
+    cp_r t.prerequisites.first, t.name
+  end
+
+  file "#{BUILDDIR}/config/#{scenario}.migrations/.applied" => "#{BUILDDIR}/config/#{scenario}.migrations" do |t|
+    ln_s "#{SYSCONFDIR}/foreman-installer/scenarios.d/#{scenario}-migrations-applied", t.name
+  end
+
+  file "#{BUILDDIR}/scenarios.d/#{scenario}.migrations" => "#{BUILDDIR}/scenarios.d" do |t|
+    ln_s "#{DATADIR}/foreman-installer/config/#{scenario}.migrations", t.name
+  end
+
+  # Generate an empty applied migrations file to ensure the symlink is preserved
+  file "#{BUILDDIR}/scenarios.d/#{scenario}-migrations-applied" => "#{BUILDDIR}/scenarios.d" do |t|
+    File.write(t.name, [].to_yaml)
+  end
+
   file "#{BUILDDIR}/parser_cache/#{scenario}.yaml" => [config, "#{BUILDDIR}/modules", "#{BUILDDIR}/parser_cache"] do |t|
     sh "#{exporter}/kafo-export-params -c #{t.prerequisites.first} -f parsercache --no-parser-cache -o #{t.name}"
   end
 
   file "#{BUILDDIR}/#{scenario}-options.asciidoc" => [config, "#{BUILDDIR}/parser_cache/#{scenario}.yaml"] do |t|
     sh "#{exporter}/kafo-export-params -c #{t.prerequisites.first} -f asciidoc -o #{t.name}"
-  end
-
-  # Store migration scripts under DATADIR, symlinked back into SYSCONFDIR and keep .applied file in SYSCONFDIR
-  directory "#{BUILDDIR}/#{scenario}.migrations"
-  file "#{BUILDDIR}/#{scenario}.migrations" => BUILDDIR do |t|
-    # These symlinks are broken until installation, so don't reference them in rake file tasks
-    ln_s "#{DATADIR}/foreman-installer/config/#{scenario}.migrations", "#{t.name}/#{scenario}.migrations"
-    ln_s "#{SYSCONFDIR}/foreman-installer/scenarios.d/#{scenario}-migrations-applied", "#{t.name}/.applied"
-  end
-
-  file "#{BUILDDIR}/config/#{scenario}.migrations" => ["config/#{scenario}.migrations", "#{BUILDDIR}/config"] do |t|
-    cp_r t.prerequisites.first, t.name
-  end
-
-  file "#{BUILDDIR}/config/#{scenario}.yaml" => ["config/#{scenario}.yaml", "#{BUILDDIR}/config"] do |t|
-    cp t.prerequisites.first, t.name
-  end
-
-  file "#{BUILDDIR}/config/#{scenario}-answers.yaml" => ["config/#{scenario}-answers.yaml", "#{BUILDDIR}/config"] do |t|
-    cp t.prerequisites.first, t.name
-  end
-
-  # Generate an empty applied migrations file to ensure the symlink is preserved
-  file "#{BUILDDIR}/#{scenario}-migrations-applied" => BUILDDIR do |t|
-    File.open(t.name, 'w') { |f| f.write([].to_yaml) }
   end
 end
 
@@ -268,11 +266,9 @@ namespace :build do
 
   task :scenarios => [SCENARIOS.map do |scenario|
     [
-      "#{BUILDDIR}/#{scenario}.yaml",
-      "#{BUILDDIR}/#{scenario}.migrations",
-      "#{BUILDDIR}/#{scenario}-migrations-applied",
-      "#{BUILDDIR}/config/#{scenario}.yaml",
-      "#{BUILDDIR}/config/#{scenario}-answers.yaml",
+      "#{BUILDDIR}/scenarios.d/#{scenario}.yaml",
+      "#{BUILDDIR}/scenarios.d/#{scenario}-answers.yaml",
+      "#{BUILDDIR}/scenarios.d/#{scenario}-migrations-applied",
       "#{BUILDDIR}/config/#{scenario}.migrations",
       "#{BUILDDIR}/parser_cache/#{scenario}.yaml",
     ]
@@ -290,17 +286,10 @@ task :build => ['build:base', 'build:scenarios', 'build:certs_scenarios']
 
 task :install => :build do
   mkdir_p "#{DATADIR}/foreman-installer"
-  cp_r Dir.glob('{checks,hooks,VERSION,README.md,LICENSE}'), "#{DATADIR}/foreman-installer"
+  cp_r Dir.glob('{checks,hooks,VERSION}'), "#{DATADIR}/foreman-installer"
   cp_r "#{BUILDDIR}/config", "#{DATADIR}/foreman-installer"
-
-  mkdir_p "#{SYSCONFDIR}/foreman-installer/scenarios.d"
-  SCENARIOS.each do |scenario|
-    cp "#{BUILDDIR}/#{scenario}.yaml", "#{SYSCONFDIR}/foreman-installer/scenarios.d/"
-    cp "config/#{scenario}-answers.yaml", "#{SYSCONFDIR}/foreman-installer/scenarios.d/#{scenario}-answers.yaml"
-    cp "#{BUILDDIR}/#{scenario}-migrations-applied", "#{SYSCONFDIR}/foreman-installer/scenarios.d/#{scenario}-migrations-applied"
-    copy_entry "#{BUILDDIR}/#{scenario}.migrations/#{scenario}.migrations", "#{SYSCONFDIR}/foreman-installer/scenarios.d/#{scenario}.migrations"
-    copy_entry "#{BUILDDIR}/#{scenario}.migrations/.applied", "#{DATADIR}/foreman-installer/config/#{scenario}.migrations/.applied"
-  end
+  cp_r "#{BUILDDIR}/modules", "#{DATADIR}/foreman-installer", :preserve => true
+  cp_r "#{BUILDDIR}/parser_cache", "#{DATADIR}/foreman-installer"
 
   if CERTS_SCENARIOS.any?
     mkdir_p "#{DATADIR}/foreman-installer/katello-certs/scenarios.d"
@@ -311,11 +300,9 @@ task :install => :build do
     cp "katello_certs/config/#{scenario}-answers.yaml", "#{DATADIR}/foreman-installer/katello-certs/scenarios.d/#{scenario}-answers.yaml"
   end
 
-  cp_r "#{BUILDDIR}/modules", "#{DATADIR}/foreman-installer", :preserve => true
-  cp_r "#{BUILDDIR}/parser_cache", "#{DATADIR}/foreman-installer"
-
   mkdir_p "#{SYSCONFDIR}/foreman-installer"
   cp "config/custom-hiera.yaml", "#{SYSCONFDIR}/foreman-installer"
+  cp_r "#{BUILDDIR}/scenarios.d", "#{SYSCONFDIR}/foreman-installer"
 
   mkdir_p SBINDIR
   install "#{BUILDDIR}/foreman-installer", "#{SBINDIR}/foreman-installer", :mode => 0o755, :verbose => true

--- a/config/pulp-answers.yaml
+++ b/config/pulp-answers.yaml
@@ -1,0 +1,12 @@
+---
+pulpcore: true
+pulpcore::cli: true
+pulpcore::repo: true
+pulpcore::plugin::ansible: false
+pulpcore::plugin::certguard: false
+pulpcore::plugin::container: false
+pulpcore::plugin::deb: false
+pulpcore::plugin::file: true
+pulpcore::plugin::ostree: false
+pulpcore::plugin::python: false
+pulpcore::plugin::rpm: true

--- a/config/pulp.yaml
+++ b/config/pulp.yaml
@@ -1,0 +1,20 @@
+## Installer configuration
+# Path to answer file
+:answer_file: ./config/pulp-answers.yaml
+:installer_dir: .
+# Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default
+:module_dirs: ./_build/modules
+:hiera_config: ./config/foreman-hiera.yaml
+# Location of an optional cache of parsed module data, generate with kafo-export-params -f parsercache
+:parser_cache_path: ./_build/parser_cache/pulp.yaml
+
+## Useful for development, e.g. when you want to move log files to local directory
+:log_dir: './_build/'
+:log_name: 'pulp.log'
+:log_level: :debug
+:verbose: true
+:verbose_log_level: notice
+
+## Kafo tuning, customization of core functionality
+:name: Pulp
+:description: Standalone installation of Pulp


### PR DESCRIPTION
Heavy draft, but at a basic level it works. What doesn't:

* Kafo can't parse pulpcore's types/logger.pp (https://projects.theforeman.org/issues/21398) - workaround is to join it all on one line
* Kafo interprets functions literally: `extlib::cache_data()` and worker count calculation is put as the answer - workaround is pass it as installer parameters
* There is no certificate setup: it assumes `/etc/pki/tls/certs/localhost.crt` and `/etc/pki/tls/private/localhost.key` exist - workaround is to run `openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/pki/tls/private/localhost.key -out /etc/pki/tls/certs/localhost.crt` prior
* Requires a packaging change

Additionally: various parameters should be marked as advanced but currently aren't. This makes --help less useful.