### PR TITLE
Fixes #35800 - Add foreman_kernel_care plugin support

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -55,6 +55,7 @@ foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::google: false
 foreman::plugin::hooks: false
+foreman::plugin::kernel_care: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false

--- a/config/katello.migrations/221212190700-add-foreman-kernel-care.rb
+++ b/config/katello.migrations/221212190700-add-foreman-kernel-care.rb
@@ -1,0 +1,1 @@
+answers['foreman::plugin::kernel_care'] ||= false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -22,6 +22,7 @@ foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::google: false
+foreman::plugin::kernel_care: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -22,6 +22,7 @@ foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::google: false
+foreman::plugin::kernel_care: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -22,6 +22,7 @@ foreman::plugin::dhcp_browser: false
 foreman::plugin::expire_hosts: false
 foreman::plugin::git_templates: false
 foreman::plugin::google: false
+foreman::plugin::kernel_care: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::memcache: false


### PR DESCRIPTION
This is a Foreman plugin that depends on Katello, which is why it's only added to the katello scenario.

(cherry picked from commit b4a9773d5b7fcbcebbd0efa35d507ecde3390441)