### PR TITLE
Pin puppetlabs/apache to ~> 8.3

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,7 @@
 forge 'https://forgeapi.puppet.com/'
 
 # HTTP/2 and SSL support for settings in Hiera
-mod 'puppetlabs/apache',             '>= 8.3.0'
+mod 'puppetlabs/apache',             '~> 8.3'
 
 # Ensure Debian 11 support
 mod 'puppetlabs/postgresql',         '>= 7.4.0'


### PR DESCRIPTION
This should prevent attempting to pull in version 9.x. There are several breaking changes, but they largely don't affect us. Once all modules are updated, this pin can be relaxed again.