### PR TITLE
Fixes #35943 - Switch to puppetlabs vcsrepo for gitrepo tracking

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,13 +6,15 @@ mod 'puppetlabs/apache',             '~> 8.3'
 # Ensure Debian 11 support
 mod 'puppetlabs/postgresql',         '>= 7.4.0'
 
+# Ensure `umask` parameter exists
+mod 'puppetlabs/vcsrepo',            '>= 5.2.0'
+
 # Dnfmodule support for Redis 6+ support
 mod 'puppet/redis',                  '>= 8.5.0'
 
 # Dependencies
 mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'
-mod 'theforeman/git',                :git => 'https://github.com/theforeman/puppet-git'
 mod 'theforeman/puppetserver_foreman', :git => 'https://github.com/theforeman/puppet-puppetserver_foreman'
 mod 'theforeman/tftp',               :git => 'https://github.com/theforeman/puppet-tftp'
 


### PR DESCRIPTION
This is related to https://github.com/theforeman/puppet-puppet/pull/860

I'm unclear if foreman/git is used by any other modules within the project so I've left that in place.  If it is safe to remove, I'd be happy to do so.