### PR TITLE
Fixes #36170 - drop memcache plugin support

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -44,7 +44,6 @@ foreman::plugin::hooks: false
 foreman::plugin::host_extra_validator: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
-foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
 foreman::plugin::omaha: false

--- a/config/foreman.migrations/20230301112305_drop_memcache_plugin.rb
+++ b/config/foreman.migrations/20230301112305_drop_memcache_plugin.rb
@@ -1,0 +1,1 @@
+answers.delete('foreman::plugin::memcache')

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -58,7 +58,6 @@ foreman::plugin::hooks: false
 foreman::plugin::kernel_care: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
-foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
 foreman::plugin::openscap: false

--- a/config/katello.migrations/230301112308-drop-memcache-plugin.rb
+++ b/config/katello.migrations/230301112308-drop-memcache-plugin.rb
@@ -1,0 +1,1 @@
+answers.delete('foreman::plugin::memcache')

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -25,7 +25,6 @@ foreman::plugin::google: false
 foreman::plugin::kernel_care: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
-foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
 foreman::plugin::puppet: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -25,7 +25,6 @@ foreman::plugin::google: false
 foreman::plugin::kernel_care: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
-foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
 foreman::plugin::puppet: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -25,7 +25,6 @@ foreman::plugin::google: false
 foreman::plugin::kernel_care: false
 foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
-foreman::plugin::memcache: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
 foreman::plugin::puppet: false


### PR DESCRIPTION
it's broken since Foreman 3.4 and nobody is fixing it

(cherry picked from commit bb767c98d979017bdbc5536638c85e25abafe0ad)