### PR TITLE
Fixes #36211 - Add PowerDNS and Route53 plugins to scenarios

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -71,6 +71,7 @@ foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
 foreman_proxy::plugin::dns::powerdns: false
+foreman_proxy::plugin::dns::route53: false
 foreman_proxy::plugin::dynflow: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::omaha: false

--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -34,6 +34,8 @@ foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
+foreman_proxy::plugin::dns::powerdns: false
+foreman_proxy::plugin::dns::route53: false
 foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::script: false
 foreman_proxy::plugin::salt: false

--- a/config/foreman-proxy-content.migrations/230321094659-add-dns-plugins.rb
+++ b/config/foreman-proxy-content.migrations/230321094659-add-dns-plugins.rb
@@ -1,0 +1,2 @@
+answers['foreman_proxy::plugin::dns::powerdns'] ||= false
+answers['foreman_proxy::plugin::dns::route53'] ||= false

--- a/config/foreman.migrations/20230321094659_add_dns_plugins.rb
+++ b/config/foreman.migrations/20230321094659_add_dns_plugins.rb
@@ -1,0 +1,1 @@
+answers['foreman_proxy::plugin::dns::route53'] ||= false

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -95,6 +95,8 @@ foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::infoblox: false
+foreman_proxy::plugin::dns::powerdns: false
+foreman_proxy::plugin::dns::route53: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::openscap: false
 foreman_proxy::plugin::remote_execution::script: false

--- a/config/katello.migrations/230321094659-add-dns-plugins.rb
+++ b/config/katello.migrations/230321094659-add-dns-plugins.rb
@@ -1,0 +1,2 @@
+answers['foreman_proxy::plugin::dns::powerdns'] ||= false
+answers['foreman_proxy::plugin::dns::route53'] ||= false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -43,6 +43,8 @@ foreman::plugin::wreckingball: false
 foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
+foreman_proxy::plugin::dns::powerdns: false
+foreman_proxy::plugin::dns::route53: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -43,6 +43,8 @@ foreman::plugin::wreckingball: false
 foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
+foreman_proxy::plugin::dns::powerdns: false
+foreman_proxy::plugin::dns::route53: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -43,6 +43,8 @@ foreman::plugin::wreckingball: false
 foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
+foreman_proxy::plugin::dns::powerdns: false
+foreman_proxy::plugin::dns::route53: false
 foreman_proxy::plugin::monitoring: false
 foreman_proxy::plugin::salt: false
 foreman_proxy::plugin::shellhooks: false

--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'semantic_puppet'
 
 describe 'Puppet module' do
-  VERSIONS = ['6.23.0', '7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
+  VERSIONS = ['6.24.0', '7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
 
   Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|
     context File.basename(File.dirname(filename)) do


### PR DESCRIPTION
These plugins have long been packaged, but the Foreman Proxy module has started to include the correct provided if needed. This means users now need to be able to configure the parameters, where they could previously manually manage it.

[1]: https://github.com/theforeman/puppet-foreman_proxy/commit/463c87638c83387ce2cb748dbe9433f9a027241c