### PR TITLE
Ensure Ansible callback from the Ansible collection is used

### DIFF
--- a/config/foreman.migrations/20230321134738_ansible_callback_from_module.rb
+++ b/config/foreman.migrations/20230321134738_ansible_callback_from_module.rb
@@ -1,0 +1,4 @@
+# https://github.com/theforeman/puppet-foreman_proxy/commit/946a422baf57726d5f189a6eecad6f3a30cbd84c
+if answers['foreman_proxy::plugin::ansible'].is_a?(Hash) && answers['foreman_proxy::plugin::ansible']['callback'] == 'foreman'
+  answers['foreman_proxy::plugin::ansible']['callback'] = 'theforeman.foreman.foreman'
+end


### PR DESCRIPTION
This is only applied to the Foreman scenario because the parameter always Red Hat always defaulted to the collection parameter since it was introduced. It's mostly for Debian, but should be safe for RH too so no facts are inspected.