### PR TITLE
Fixes #36217 - Include Puppet certificate change

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -27,6 +27,6 @@ mod 'theforeman/foreman_proxy',        '>= 24.2.0 < 24.3.0'
 mod 'theforeman/puppet',               '>= 16.5.0 < 16.6.0'
 
 # Top-level katello modules
-mod 'katello/foreman_proxy_content',   '>= 22.2.0 < 22.3.0'
+mod 'katello/foreman_proxy_content',   '>= 23.0.0 < 23.1.0'
 mod 'katello/certs',                   '>= 16.0.0 < 16.1.0'
 mod 'katello/katello',                 '>= 22.1.1 < 22.2.0'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -10,7 +10,7 @@ FORGE
       puppet-extlib (>= 3.0.0, < 7.0.0)
       puppetlabs-concat (>= 1.0.0, < 8.0.0)
       puppetlabs-stdlib (>= 4.25.0, < 9.0.0)
-    katello-foreman_proxy_content (22.2.0)
+    katello-foreman_proxy_content (23.0.0)
       katello-certs (>= 15.0.0, < 17.0.0)
       katello-qpid (>= 8.0.0, < 10.0.0)
       puppet-extlib (>= 3.0.0, < 7.0.0)
@@ -107,7 +107,7 @@ FORGE
 DEPENDENCIES
   katello-candlepin (>= 13.2.0, < 13.3.0)
   katello-certs (>= 16.0.0, < 16.1.0)
-  katello-foreman_proxy_content (>= 22.2.0, < 22.3.0)
+  katello-foreman_proxy_content (>= 23.0.0, < 23.1.0)
   katello-katello (>= 22.1.1, < 22.2.0)
   katello-qpid (>= 9.1.0, < 9.2.0)
   puppet-redis (>= 8.5.0)


### PR DESCRIPTION
This change was missed and causes a duplicate definition of the certs::puppet class.

Depends on https://github.com/theforeman/puppet-foreman_proxy_content/pull/441