### PR TITLE
Fixes #36319 - Add Promxox support

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -48,6 +48,7 @@ foreman::plugin::netbox: false
 foreman::plugin::omaha: false
 foreman::plugin::openscap: false
 foreman::plugin::ovirt_provision: false
+foreman::plugin::proxmox: false
 foreman::plugin::puppet: true
 foreman::plugin::puppetdb: false
 foreman::plugin::remote_execution: false

--- a/config/foreman.migrations/20230425145037_add_fog_proxmox.rb
+++ b/config/foreman.migrations/20230425145037_add_fog_proxmox.rb
@@ -1,0 +1,1 @@
+answers['foreman::plugin::proxmox'] ||= false

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -60,6 +60,7 @@ foreman::plugin::leapp: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
 foreman::plugin::openscap: false
+foreman::plugin::proxmox: false
 foreman::plugin::puppet: false
 foreman::plugin::puppetdb: false
 foreman::plugin::remote_execution: true

--- a/config/katello.migrations/230425145037-add-fog-proxmox.rb
+++ b/config/katello.migrations/230425145037-add-fog-proxmox.rb
@@ -1,0 +1,1 @@
+answers['foreman::plugin::proxmox'] ||= false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -26,6 +26,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
+foreman::plugin::proxmox: false
 foreman::plugin::puppet: false
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -26,6 +26,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
+foreman::plugin::proxmox: false
 foreman::plugin::puppet: false
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -26,6 +26,7 @@ foreman::plugin::kubevirt: false
 foreman::plugin::leapp: false
 foreman::plugin::monitoring: false
 foreman::plugin::netbox: false
+foreman::plugin::proxmox: false
 foreman::plugin::puppet: false
 foreman::plugin::remote_execution: true
 foreman::plugin::remote_execution::cockpit: false


### PR DESCRIPTION
I would like to add Proxmox to foreman-installer to simplify the installation process for users.

* PR in foreman-documentation: https://github.com/theforeman/foreman-documentation/pull/2142
* PR in puppet-foreman: https://github.com/theforeman/puppet-foreman/pull/1115