### PR TITLE
Fixes #36345 - Drop Puppet 6 support

### DIFF
--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'semantic_puppet'
 
 describe 'Puppet module' do
-  VERSIONS = ['6.24.0', '7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
+  VERSIONS = ['7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
 
   Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|
     context File.basename(File.dirname(filename)) do


### PR DESCRIPTION
Puppet 6 is end of life and more and more modules are dropping support. Rather than pinning modules this takes the approach of dropping Puppet 6.

Still a draft because I'd like to fix CI as well.