### PR TITLE
Pin Puppet module versions to ~> x.y.z

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,32 +1,32 @@
 forge 'https://forgeapi.puppet.com/'
 
 # HTTP/2 and SSL support for settings in Hiera
-mod 'puppetlabs/apache',             '~> 8.3'
+mod 'puppetlabs/apache',               '~> 8.3'
 
 # Ensure Debian 11 support
-mod 'puppetlabs/postgresql',         '>= 7.4.0'
+mod 'puppetlabs/postgresql',           '>= 7.4.0'
 
 # Dnfmodule support for Redis 6+ support
-mod 'puppet/redis',                  '>= 8.5.0'
+mod 'puppet/redis',                    '>= 8.5.0'
 
 # Dependencies
-mod 'theforeman/dhcp',               :git => 'https://github.com/theforeman/puppet-dhcp'
-mod 'theforeman/dns',                :git => 'https://github.com/theforeman/puppet-dns'
-mod 'theforeman/git',                :git => 'https://github.com/theforeman/puppet-git'
+mod 'theforeman/dhcp',                 :git => 'https://github.com/theforeman/puppet-dhcp'
+mod 'theforeman/dns',                  :git => 'https://github.com/theforeman/puppet-dns'
+mod 'theforeman/git',                  :git => 'https://github.com/theforeman/puppet-git'
 mod 'theforeman/puppetserver_foreman', :git => 'https://github.com/theforeman/puppet-puppetserver_foreman'
-mod 'theforeman/tftp',               :git => 'https://github.com/theforeman/puppet-tftp'
+mod 'theforeman/tftp',                 :git => 'https://github.com/theforeman/puppet-tftp'
 
 # Katello dependencies
-mod 'katello/candlepin',             :git => 'https://github.com/theforeman/puppet-candlepin'
-mod 'theforeman/pulpcore',           :git => 'https://github.com/theforeman/puppet-pulpcore'
-mod 'katello/qpid',                  :git => 'https://github.com/theforeman/puppet-qpid'
+mod 'katello/candlepin',               :git => 'https://github.com/theforeman/puppet-candlepin'
+mod 'theforeman/pulpcore',             :git => 'https://github.com/theforeman/puppet-pulpcore'
+mod 'katello/qpid',                    :git => 'https://github.com/theforeman/puppet-qpid'
 
 # Top-level modules
-mod 'theforeman/foreman',            :git => 'https://github.com/theforeman/puppet-foreman'
-mod 'theforeman/foreman_proxy',      :git => 'https://github.com/theforeman/puppet-foreman_proxy'
-mod 'theforeman/puppet',             :git => 'https://github.com/theforeman/puppet-puppet'
+mod 'theforeman/foreman',              :git => 'https://github.com/theforeman/puppet-foreman'
+mod 'theforeman/foreman_proxy',        :git => 'https://github.com/theforeman/puppet-foreman_proxy'
+mod 'theforeman/puppet',               :git => 'https://github.com/theforeman/puppet-puppet'
 
 # Top-level katello modules
-mod 'katello/foreman_proxy_content', :git => 'https://github.com/theforeman/puppet-foreman_proxy_content'
-mod 'katello/certs',                 :git => 'https://github.com/theforeman/puppet-certs'
-mod 'katello/katello',               :git => 'https://github.com/theforeman/puppet-katello'
+mod 'katello/foreman_proxy_content',   :git => 'https://github.com/theforeman/puppet-foreman_proxy_content'
+mod 'katello/certs',                   :git => 'https://github.com/theforeman/puppet-certs'
+mod 'katello/katello',                 :git => 'https://github.com/theforeman/puppet-katello'

--- a/Rakefile
+++ b/Rakefile
@@ -32,9 +32,7 @@ begin
     def mod(name, options = nil)
       if options.is_a?(Hash) && !options.include?(:ref)
         release = PuppetForge::Module.find(name.tr('/', '-')).current_release
-        version = Semverse::Version.new(release.version)
-        max = "#{version.major}.#{version.minor + 1}.0"
-        @new_content << ['mod', name, ">= #{version} < #{max}"]
+        @new_content << ['mod', name, "~> #{release.version}"]
       else
         @new_content << ['mod', name, options]
       end


### PR DESCRIPTION
This is essentially the same as wel already did, but it's much easier to change if you need to bump a .y version. Instead of two places, it's now just two. It also simplifies the code to do the pinning.

Also visually aligns the module versions to make the diff when pinning smaller.