### PR TITLE
Fixes #36561 - Run katello-certs-check on proxy cert generation

### DIFF
--- a/bin/foreman-proxy-certs-generate
+++ b/bin/foreman-proxy-certs-generate
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 require 'rubygems'
+require 'shellwords'
+require 'open3'
 require 'kafo'
 
 CONFIG_DIR = './katello_certs/config/'.freeze
@@ -26,6 +28,32 @@ Kafo::KafoConfigure.hooking.register_pre(:init) do
   organization ||= "Default Organization"
 
   org_param.value = organization
+end
+
+Kafo::KafoConfigure.hooking.register_pre(:boot) do
+  app_option(
+    '--certs-skip-check',
+    :flag,
+    "This option will cause skipping the certificates sanity check. Use with caution",
+    :default => false
+  )
+end
+
+Kafo::KafoConfigure.hooking.register_pre(:pre_commit) do
+  ca_file   = param('certs', 'server_ca_cert').value
+  cert_file = param('certs', 'server_cert').value
+  key_file  = param('certs', 'server_key').value
+
+  unless app_value(:certs_skip_check) || [cert_file, ca_file, key_file].all? { |v| v.to_s.empty? }
+    command = ['katello-certs-check', '-c', cert_file, '-k', key_file, '-b', ca_file]
+    logger.debug("Executing #{Shellwords.join(command)}")
+    stdout_stderr, success = Open3.capture2e(command)
+
+    unless success
+      say color(stdout_stderr, :bad)
+      exit(1)
+    end
+  end
 end
 
 @result = Kafo::KafoConfigure.run

--- a/spec/foreman_proxy_certs_generate_spec.rb
+++ b/spec/foreman_proxy_certs_generate_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+require 'open3'
+require 'tempfile'
+
+Output = Struct.new(:stdout, :stderr, :status) do
+  def exitstatus
+    status.exitstatus
+  end
+end
+
+describe 'foreman-proxy-certs-generate' do
+  subject { Output.new(*Open3.capture3(*command)) }
+
+  let(:command) { ['bin/foreman-proxy-certs-generate'] + arguments }
+  let(:hostname) { 'proxy.example.com' }
+  let(:arguments) { ['--no-colors', '--noop', '--foreman-proxy-fqdn', hostname] }
+
+  describe 'without arguments' do
+    it do
+      is_expected.to have_attributes(
+        stdout: "Error during configuration, exiting\n",
+        stderr: /Parameter certs-tar invalid:/,
+        exitstatus: 21,
+      )
+    end
+  end
+
+  describe 'with valid certs-tar' do
+    let(:arguments) { super() + ['--certs-tar', tar_file.path] }
+    let(:tar_file) { Tempfile.new }
+
+    after { tar_file.unlink }
+
+    it do
+      is_expected.to have_attributes(
+        stdout: '',
+        stderr: '',
+        exitstatus: 0,
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is similar to how it runs on the regular installer. The advantage of running this in foreman-proxy-certs-generate is that the user gets the feedback earlier. So rather than running:

* foreman-proxy-certs-generate
* copy tar file to proxy
* run installer

And then finding out there was something wrong, the user gets the feedback at the first step.

There could be a minor mismatch in version for n-1 version support, but it's safe to assume the server will only be stricter but still compatible. The check can be skipped if needed.