### PR TITLE
Fixes #36567 - Make katello-certs-check failures fatal

### DIFF
--- a/hooks/pre_commit/20-certs_update.rb
+++ b/hooks/pre_commit/20-certs_update.rb
@@ -17,7 +17,7 @@ if module_enabled?('certs')
     stdout_stderr, success = execute_command(%(katello-certs-check -c "#{cert_file}" -k "#{key_file}" -b "#{ca_file}"), false, true)
 
     unless success
-      log_and_say(:error, stdout_stderr, true, false)
+      fail_and_exit(stdout_stderr)
     end
   end
 end


### PR DESCRIPTION
Prior to 688d0a7dc08fc78407ed84466f3b0861c3cbfc2f the execute! method was used, which caused the installer to exit if katello-certs-check failed. That commit changed it to only output the error on failure, but it no longer stopped the installer.

Fixes: 688d0a7dc08f ("Fixes #34888: Display katello-certs-check output only if error")