### PR TITLE
Use a shared context to do migration testing

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,28 @@ def load_fixture_yaml(directory, filename)
   YAML.load_file(fixture_path(directory, filename))
 end
 
+RSpec.shared_context 'with migrations', type: :migrations do
+  subject(:migrator) { Kafo::Migrations.new(migrations).run(config, answers) }
+
+  let(:config) { load_config_yaml("#{scenario_name}.yaml") }
+  let(:answers) { load_config_yaml("#{scenario_name}-answers.yaml") }
+  let(:migrations) { config_path("#{scenario_name}.migrations") }
+
+  let(:migrated_config) { migrator[0] }
+  let(:migrated_answers) { migrator[1] }
+
+  def self.scenarios(scenarios, &block)
+    scenarios.each do |scenario_name|
+      context "with scenario #{scenario_name}" do
+        let(:scenario_name) { scenario_name }
+
+        class_exec(&block)
+      end
+    end
+  end
+end
+
 RSpec.configure do |c|
   c.before(:suite) { Kafo::KafoConfigure.logger = Logger.new('test.log') }
+  c.alias_example_group_to :migration, type: :migrations
 end


### PR DESCRIPTION
By using a shared context we can easily write more migration test without repeating the same context over and over again.

I've also thought about splitting up the file and make it one file per migration. For now I decided against this since you can still reasonably see a diff now when you ignore whitespace.