### PR TITLE
Refs #36573 - Drop puppet::server_foreman_url value if redundant

### DIFF
--- a/config/foreman-proxy-content.migrations/230707122737-drop_puppet_server_foreman_url.rb
+++ b/config/foreman-proxy-content.migrations/230707122737-drop_puppet_server_foreman_url.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash) && answers['foreman_proxy'].is_a?(Hash) && answers['puppet']['server_foreman_url'] == answers['foreman_proxy']['foreman_base_url']
+  answers['puppet'].delete('server_foreman_url')
+end

--- a/config/foreman.migrations/20230707122737_drop_puppet_server_foreman_url.rb
+++ b/config/foreman.migrations/20230707122737_drop_puppet_server_foreman_url.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash) && answers['foreman_proxy'].is_a?(Hash) && answers['puppet']['server_foreman_url'] == answers['foreman_proxy']['foreman_base_url']
+  answers['puppet'].delete('server_foreman_url')
+end

--- a/config/katello.migrations/230707122737-drop_puppet_server_foreman_url.rb
+++ b/config/katello.migrations/230707122737-drop_puppet_server_foreman_url.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash) && answers['foreman_proxy'].is_a?(Hash) && answers['puppet']['server_foreman_url'] == answers['foreman_proxy']['foreman_base_url']
+  answers['puppet'].delete('server_foreman_url')
+end


### PR DESCRIPTION
theforeman/puppetserver_foreman has started to default to copying the value from foreman_proxy::foreman_base_url when unspecified.  theforeman/puppet has removed its default. This completes it by removing the value if both answers are the same.

The biggest benefit is that the user only needs to care about a single answer and no longer keep them in sync. This means we can stop thinking about whether Puppet is enabled or not in all our user instructions.

Depends on both https://github.com/theforeman/puppet-puppet/pull/880 and https://github.com/theforeman/puppet-puppetserver_foreman/pull/31 being merged.