### PR TITLE
Refs #35833 - Revert "Drop Applied catalog lines" patch

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,7 @@ mod 'puppet/redis',                    '>= 8.5.0'
 mod 'theforeman/dhcp',                 '>= 8.2.0 < 8.3.0'
 mod 'theforeman/dns',                  '>= 9.5.1 < 9.6.0'
 mod 'theforeman/git',                  '>= 7.2.0 < 7.3.0'
-mod 'theforeman/puppetserver_foreman', '>= 2.2.0 < 2.3.0'
+mod 'theforeman/puppetserver_foreman', '>= 2.3.0 < 2.4.0'
 mod 'theforeman/tftp',                 '>= 8.0.0 < 8.1.0'
 
 # Katello dependencies

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -99,7 +99,7 @@ FORGE
       puppet-systemd (>= 2.9.0, < 5.0.0)
       puppetlabs-concat (>= 4.1.0, < 8.0.0)
       puppetlabs-stdlib (>= 4.18.0, < 9.0.0)
-    theforeman-puppetserver_foreman (2.2.0)
+    theforeman-puppetserver_foreman (2.3.0)
       puppetlabs-stdlib (>= 4.18.0, < 9.0.0)
     theforeman-tftp (8.0.0)
       puppetlabs-stdlib (>= 4.13.1, < 9.0.0)
@@ -120,6 +120,6 @@ DEPENDENCIES
   theforeman-git (>= 7.2.0, < 7.3.0)
   theforeman-pulpcore (>= 7.2.0, < 7.3.0)
   theforeman-puppet (>= 16.5.0, < 16.6.0)
-  theforeman-puppetserver_foreman (>= 2.2.0, < 2.3.0)
+  theforeman-puppetserver_foreman (>= 2.3.0, < 2.4.0)
   theforeman-tftp (>= 8.0.0, < 8.1.0)
 


### PR DESCRIPTION
This caused a regression where eventless Puppet reports were not recognized as Puppet reports.