### PR TITLE
Add a rake modules task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -81,6 +81,9 @@ DATAROOTDIR = DATADIR = ENV['DATAROOTDIR'] || "#{PREFIX}/share"
 MANDIR = ENV['MANDIR'] || "#{DATAROOTDIR}/man"
 PKGDIR = ENV['PKGDIR'] || File.expand_path('pkg')
 
+desc 'Install the Puppet modules'
+task :modules => "#{BUILDDIR}/modules"
+
 if BUILD_KATELLO
   SCENARIOS = ['foreman', 'foreman-proxy-content', 'katello'].freeze
   CERTS_SCENARIOS = ['foreman-proxy-certs'].freeze


### PR DESCRIPTION
This is a small wrapper around librarian-puppet so you don't have to do the complete build. If you don't need the parser cache, this is a lot faster.