### PR TITLE
Refs #35943 - Switch to puppetlabs/vcsrepo

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,10 +13,13 @@ mod 'puppetlabs/postgresql',           '>= 7.4.0'
 # Dnfmodule support for Redis 6+ support
 mod 'puppet/redis',                    '>= 8.5.0'
 
+# Soft dependency of theforeman/puppet
+# https://github.com/theforeman/puppet-puppet/#git-repo-support
+mod 'puppetlabs/vcsrepo',              '>= 5.2.0'
+
 # Dependencies
 mod 'theforeman/dhcp',                 :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                  :git => 'https://github.com/theforeman/puppet-dns'
-mod 'theforeman/git',                  :git => 'https://github.com/theforeman/puppet-git'
 mod 'theforeman/puppetserver_foreman', :git => 'https://github.com/theforeman/puppet-puppetserver_foreman'
 mod 'theforeman/tftp',                 :git => 'https://github.com/theforeman/puppet-tftp'
 


### PR DESCRIPTION
Our theforeman/puppet module has switch from our own custom module to the generic puppetlabs/vcsrepo. This saves maintenance on our side and for users it provides more functionality. In large environments it's already common and allows reuse.