### PR TITLE
Clean up unused keys related to katello-agent

### DIFF
--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -18,5 +18,3 @@ dhcp::config_comment: |
 foreman::config::apache::proxy_params:
   retry: '0'
   timeout: '900'
-
-katello::globals::enable_katello_agent: "%{alias('foreman_proxy_content::enable_katello_agent')}"

--- a/config/foreman.hiera/tuning/common.yaml
+++ b/config/foreman.hiera/tuning/common.yaml
@@ -8,9 +8,6 @@ lookup_options:
   postgresql::server::config_entries:
     merge: hash
 
-qpid::open_file_limit: 65536
-qpid::router::open_file_limit: 150100
-
 postgresql::server::config_entries:
   checkpoint_completion_target: 0.9
   max_connections: 500


### PR DESCRIPTION
This will be accompanied by a check in foreman-maintain that halts the upgrade if katello-agent is enabled and warns the user to have an alternative deployed before upgrading.

It will be followed by complete removal of katello-agent and qpid code from the installer modules, after a release to ensure that upgrading users have everything cleaned up.