### PR TITLE
Fix apache::trace_enable example

### DIFF
--- a/config/custom-hiera.yaml
+++ b/config/custom-hiera.yaml
@@ -6,7 +6,7 @@
 # For example, to set 'TraceEnable Off' in Apache, a common requirement for
 # security auditors, add this to this file:
 #
-#   apache::trace_enable: Off
+#   apache::trace_enable: 'Off'
 #
 # Consult the full module documentation on http://forge.puppetlabs.com,
 # or the actual puppet classes themselves, to discover options to configure.


### PR DESCRIPTION
In puppetlabs-apache 10.0 the trace_enable became stricter and only accepts certain strings. YAML converts Off to a boolean, which breaks.  By quoting it we still have a valid example.