### PR TITLE
    Bump TargetRubyVersion to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
     - '_build/**/*'
     - 'pkg/**/*'


### PR DESCRIPTION
Raise RuboCop Ruby level from 2.5 to 2.7 in .rubocop.yml.