### PR TITLE
Fixes #36784 - Drop MaxRequestsPerChild tuning

### DIFF
--- a/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-extra-large.yaml
@@ -1,7 +1,6 @@
 ---
 apache::mod::event::serverlimit: 64
 apache::mod::event::maxrequestworkers: 1024
-apache::mod::event::maxrequestsperchild: 4000
 
 candlepin::java_opts: "-Xms1024m -Xmx8192m"
 

--- a/config/foreman.hiera/tuning/sizes/extra-large.yaml
+++ b/config/foreman.hiera/tuning/sizes/extra-large.yaml
@@ -1,7 +1,6 @@
 ---
 apache::mod::event::serverlimit: 64
 apache::mod::event::maxrequestworkers: 1024
-apache::mod::event::maxrequestsperchild: 4000
 
 candlepin::java_opts: "-Xms1024m -Xmx8192m"
 

--- a/config/foreman.hiera/tuning/sizes/large.yaml
+++ b/config/foreman.hiera/tuning/sizes/large.yaml
@@ -1,7 +1,6 @@
 ---
 apache::mod::event::serverlimit: 64
 apache::mod::event::maxrequestworkers: 1024
-apache::mod::event::maxrequestsperchild: 4000
 
 postgresql::server::config_entries:
   max_connections: 1000

--- a/config/foreman.hiera/tuning/sizes/medium.yaml
+++ b/config/foreman.hiera/tuning/sizes/medium.yaml
@@ -1,7 +1,6 @@
 ---
 apache::mod::event::serverlimit: 64
 apache::mod::event::maxrequestworkers: 1024
-apache::mod::event::maxrequestsperchild: 4000
 
 postgresql::server::config_entries:
   max_connections: 1000


### PR DESCRIPTION
Since puppetlabs-apache 9.0.0 this tuning does nothing, since the parameter was dropped. For older versions it may also trigger https://bugzilla.redhat.com/show_bug.cgi?id=2238325 and the default tuning doesn't set it, so is likely unaffected.