### PR TITLE
Refs #36760 - Reset candlepin key- and truststore

### DIFF
--- a/config/katello.migrations/231003142402-reset-store-credentials.rb
+++ b/config/katello.migrations/231003142402-reset-store-credentials.rb
@@ -1,0 +1,4 @@
+# The server.xml file contained the passwords world readable
+# Purging them will regenerate them
+FileUtils.rm_f('/opt/puppetlabs/puppet/cache/foreman_cache_data/keystore_password-file')
+FileUtils.rm_f('/opt/puppetlabs/puppet/cache/foreman_cache_data/truststore_password-file')

--- a/hooks/pre/40-katello_reset_candlepin_stores.rb
+++ b/hooks/pre/40-katello_reset_candlepin_stores.rb
@@ -1,0 +1,12 @@
+# theforeman/certs can't deal with password changes
+# This partially works around it by introducing a worflow where the cache file
+# is removed, but the store exists it removes the store
+if !app_value(:noop) && module_enabled?('katello')
+  cache_dir = '/opt/puppetlabs/puppet/cache/foreman_cache_data'
+  certs_dir = '/etc/candlepin/certs'
+  ['keystore', 'truststore'].each do |store|
+    unless File.exist?(File.join(cache_dir, "#{store}_password-file"))
+      FileUtils.rm_f(File.join(certs_dir, store))
+    end
+  end
+end


### PR DESCRIPTION
This takes a 2 step approach where the cached password is removed during migration (which ends up running during the RPM installation). Since we don't want to break the system, the actual stores are only removed when the installer runs. This will recreate them and update the matching password files. Allowing a reset, even if theforeman/certs can't deal with it.

This is one option that doesn't rely on https://github.com/theforeman/puppet-certs/commit/6fea0bbb4143ca439cff01bf9f0e54cf88140d10, but instead implements a hook.