### PR TITLE
Refs #36760 - Reset candlepin key- and truststore

### DIFF
--- a/config/katello.migrations/231003142402-reset-store-credentials.rb
+++ b/config/katello.migrations/231003142402-reset-store-credentials.rb
@@ -1,0 +1,4 @@
+# The server.xml file contained the passwords world readable
+# Purging them will regenerate them
+FileUtils.rm_f('/opt/puppetlabs/puppet/cache/foreman_cache_data/keystore_password-file')
+FileUtils.rm_f('/opt/puppetlabs/puppet/cache/foreman_cache_data/truststore_password-file')


### PR DESCRIPTION
This takes a 2 step approach where the cached password is removed during migration (which ends up running during the RPM installation). The installer then handles replacing the stores when it really runs.

This version is an alternative to https://github.com/theforeman/foreman-installer/pull/886, but relies on https://github.com/theforeman/puppet-certs/commit/6fea0bbb4143ca439cff01bf9f0e54cf88140d10 to do the heavy lifting. When cherry picking, it must include a Puppetfile update that includes this support.