### PR TITLE
Fixes #36809 - Do not clobber answers provided on the command line wi…

### DIFF
--- a/hooks/pre_exit/20-certs_regenerate.rb
+++ b/hooks/pre_exit/20-certs_regenerate.rb
@@ -1,4 +1,4 @@
-if module_enabled?('certs') && param('certs', 'regenerate').value == true
+if !app_value(:noop) && !app_value(:dont_save_answers) && module_enabled?('certs') && param('certs', 'regenerate').value == true
   kafo.config.modules.each do |mod|
     if mod.identifier == 'certs'
       mod.params_hash['regenerate'] = false

--- a/hooks/pre_exit/20-certs_regenerate.rb
+++ b/hooks/pre_exit/20-certs_regenerate.rb
@@ -1,6 +1,9 @@
 if module_enabled?('certs') && param('certs', 'regenerate').value == true
-  answers = kafo.config.answers
-  answers['certs']['regenerate'] = false
+  kafo.config.modules.each do |mod|
+    if mod.identifier == 'certs'
+      mod.params_hash['regenerate'] = false
+    end
+  end
 
-  kafo.config.store(answers)
+  kafo.send(:store_params)
 end


### PR DESCRIPTION
…th --certs-regenerate

Problem:

```
foreman-installer --certs-state Texas --certs-regenerate True
```

The installer will see and run as if the `state` value was changed to Texas, regenerating certificates. However, because `kafo.config.app.answers` returns the *answers file* and not the compiled params, what gets written back to the answers file is the original answers at runtime. Thus the answers file now have the previous value (e.g. North Carolina) and the next installer run will trigger a certificate update under the hood.