### PR TITLE
Raise minimum Puppet version to 7.9.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,7 @@ mod 'puppetlabs/apt',                  '< 9.1.0'
 mod 'puppetlabs/apache',               '>= 8.3'
 
 # Ensure Debian 11 support
-mod 'puppetlabs/postgresql',           '>= 7.4.0'
+mod 'puppetlabs/postgresql',           '>= 7.4.0', '< 10'
 
 # Dnfmodule support for Redis 6+ support
 mod 'puppet/redis',                    '>= 8.5.0'

--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'semantic_puppet'
 
-SUPPORTED_PUPPET_VERSIONS = ['7.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
+SUPPORTED_PUPPET_VERSIONS = ['7.9.0'].map { |v| SemanticPuppet::Version.parse(v) }
 
 describe 'Puppet module' do
   Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|


### PR DESCRIPTION
puppetlabs/apache requires at least 7.9.0, not 7.0.0.

Also includes a pin to puppetlabs/postgresql due to the puppetlabs/stdlib 9.x
requirement.