### PR TITLE
Override broken apache::mod::event::maxclients default

### DIFF
--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -6,6 +6,10 @@ apache::protocols:
   - 'h2'
   - 'h2c'
   - 'http/1.1'
+# Value 150 is below the httpd default and showing warnings
+# https://httpd.apache.org/docs/current/mod/mpm_common.html#maxrequestworkers
+# https://bugzilla.redhat.com/show_bug.cgi?id=2244370
+apache::mod::event::maxclients: false
 
 dhcp::config_comment: |
   READ: This file was written the foreman-installer and not by the Foreman


### PR DESCRIPTION
Quoting the [manual](https://httpd.apache.org/docs/current/mod/mpm_common.html#maxrequestworkers):

> For threaded and hybrid servers (e.g. event or worker),
> MaxRequestWorkers restricts the total number of threads that will be
> available to serve clients. For hybrid MPMs, the default value is 16
> (ServerLimit) multiplied by the value of 25 (ThreadsPerChild).
> Therefore, to increase MaxRequestWorkers to a value that requires more
> than 16 processes, you must also raise ServerLimit.

The value of 150 actually results in a lower value:

    AH00513: WARNING: MaxRequestWorkers of 150 is not an integer multiple of ThreadsPerChild of 16, decreasing to nearest multiple 144, for a maximum of 9 servers.

This is submitted as a PR against 3.7-stable because 3.8 and newer use puppetlabs-apache 9.x which has dropped maxclients and no longer sets a default, relying on httpd to do the right thing.