### PR TITLE
Ensure Puppet 8 support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,7 +4,7 @@ forge 'https://forgeapi.puppet.com/'
 mod 'puppetlabs/apache',               '>= 8.3'
 
 # Ensure Debian 11 support
-mod 'puppetlabs/postgresql',           '>= 7.4.0', '< 10'
+mod 'puppetlabs/postgresql',           '>= 7.4.0'
 
 # Dnfmodule support for Redis 6+ support
 mod 'puppet/redis',                    '>= 8.5.0'

--- a/spec/puppet_version_spec.rb
+++ b/spec/puppet_version_spec.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'semantic_puppet'
 
-SUPPORTED_PUPPET_VERSIONS = ['7.9.0'].map { |v| SemanticPuppet::Version.parse(v) }
+SUPPORTED_PUPPET_VERSIONS = ['7.9.0', '8.0.0'].map { |v| SemanticPuppet::Version.parse(v) }
 
 describe 'Puppet module' do
   Dir.glob(File.join(__dir__, '../_build/modules/*/metadata.json')).each do |filename|


### PR DESCRIPTION
To be done:
* Update puppetlabs-postgresql to >= 10 allow puppet-systemd >= 6 (https://github.com/puppetlabs/puppetlabs-postgresql/commit/09d38490f29e3c06e42d29d8abf72ba6aa0eda5a)
  * https://github.com/theforeman/puppet-candlepin/pull/248
  * https://github.com/theforeman/puppet-foreman/pull/1143
  * https://github.com/theforeman/puppet-pulpcore/pull/316
* https://github.com/voxpupuli/puppet-redis/pull/484
* https://github.com/theforeman/puppet-katello/pull/484