### PR TITLE
Refs #36843: Pass array to capture2e as arguments

### DIFF
--- a/bin/foreman-proxy-certs-generate
+++ b/bin/foreman-proxy-certs-generate
@@ -42,7 +42,7 @@ Kafo::KafoConfigure.hooking.register_pre_commit(:certs_check) do
     end
 
     begin
-      stdout_stderr, status = Open3.capture2e(command)
+      stdout_stderr, status = Open3.capture2e(*command)
     rescue Errno::ENOENT
       say :error, 'katello-certs-check not found'
       exit 1


### PR DESCRIPTION
The error seen:

```
capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
                                   --certs-tar  "~/$CAPSULE-certs.tar" \
                                   --server-cert "/root/ssl/cap/capsule.pem" \
                                   --server-key "/root/ssl/cap/capsule.key" \
                                   --server-ca-cert "/root/ssl/cap/CA.pem"

Traceback (most recent call last):
	15: from /usr/sbin/capsule-certs-generate:58:in `<main>'
	14: from /usr/share/gems/gems/kafo-7.3.0/lib/kafo/kafo_configure.rb:54:in `run'
	13: from /usr/share/gems/gems/clamp-1.3.2/lib/clamp/command.rb:140:in `run'
	12: from /usr/share/gems/gems/kafo-7.3.0/lib/kafo/kafo_configure.rb:184:in `run'
	11: from /usr/share/gems/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
	10: from /usr/share/gems/gems/kafo-7.3.0/lib/kafo/kafo_configure.rb:214:in `execute'
	 9: from /usr/share/gems/gems/kafo-7.3.0/lib/kafo/hooking.rb:65:in `execute'
	 8: from /usr/share/gems/gems/kafo-7.3.0/lib/kafo/hooking.rb:65:in `each'
	 7: from /usr/share/gems/gems/kafo-7.3.0/lib/kafo/hooking.rb:67:in `block in execute'
	 6: from /usr/share/gems/gems/kafo-7.3.0/lib/kafo/hook_context.rb:19:in `execute'
	 5: from /usr/share/gems/gems/kafo-7.3.0/lib/kafo/hook_context.rb:19:in `instance_eval'
	 4: from /usr/sbin/capsule-certs-generate:45:in `block in <main>'
	 3: from /usr/share/ruby/open3.rb:390:in `capture2e'
	 2: from /usr/share/ruby/open3.rb:208:in `popen2e'
	 1: from /usr/share/ruby/open3.rb:213:in `popen_run'
/usr/share/ruby/open3.rb:213:in `spawn': wrong first argument (ArgumentError)
```