### PR TITLE
Fix packit configuration for 3.9 building

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,7 @@ upstream_tag_template: "{version}"
 
 actions:
   post-upstream-clone:
-    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/foreman/foreman-installer/foreman-installer.spec -O foreman-installer.spec"
+    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/3.9/packages/foreman/foreman-installer/foreman-installer.spec -O foreman-installer.spec"
   get-current-version:
     - "sed 's/-develop//' VERSION"
   create-archive:
@@ -31,11 +31,11 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      centos-stream-8:
+      rhel-8:
         additional_modules: "foreman:el8"
         additional_repos:
-          - http://koji.katello.org/releases/yum/foreman-nightly/el8/x86_64/
-          - http://yum.puppet.com/puppet7/el/8/x86_64/
+          - https://yum.theforeman.org/releases/3.9/el8/x86_64/
+          - https://yum.puppet.com/puppet7/el/8/x86_64/
     module_hotfixes: true
 
 srpm_build_deps:


### PR DESCRIPTION
This uses the correct spec file and staging repo. Also builds with rhel-8 instead of centos-stream-8 since that's what we end up doing when we really build.