### PR TITLE
Build packit on rhel-8

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -31,11 +31,11 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      centos-stream-8:
+      rhel-8:
         additional_modules: "foreman:el8"
         additional_repos:
           - https://yum.theforeman.org/releases/nightly/el8/x86_64/
-          - http://yum.puppet.com/puppet7/el/8/x86_64/
+          - https://yum.puppet.com/puppet7/el/8/x86_64/
     module_hotfixes: true
 
 srpm_build_deps:


### PR DESCRIPTION
This is consistent with how we eventually build it. It also switches yum over to use HTTPS.