### PR TITLE
Drop inclusion of Qpid module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -23,7 +23,6 @@ mod 'theforeman/tftp',                 :git => 'https://github.com/theforeman/pu
 # Katello dependencies
 mod 'katello/candlepin',               :git => 'https://github.com/theforeman/puppet-candlepin'
 mod 'theforeman/pulpcore',             :git => 'https://github.com/theforeman/puppet-pulpcore'
-mod 'katello/qpid',                    :git => 'https://github.com/theforeman/puppet-qpid'
 
 # Top-level modules
 mod 'theforeman/foreman',              :git => 'https://github.com/theforeman/puppet-foreman'

--- a/hooks/boot/04-services.rb
+++ b/hooks/boot/04-services.rb
@@ -9,8 +9,6 @@ module ServicesHookContextExtension
     'httpd.service', # Apache on Red Hat
     'postgresql*', # Used by Foreman/Dynflow and Pulpcore
     'pulpcore*',
-    'qdrouterd.service', # Used by Katello for katello-agent
-    'qpidd.service', # Used by Katello for katello-agent
     'smart_proxy_dynflow_core.service', # Used by Foreman Proxy
     'tomcat.service', # Candlepin
   ].freeze

--- a/hooks/boot/04-services.rb
+++ b/hooks/boot/04-services.rb
@@ -9,7 +9,6 @@ module ServicesHookContextExtension
     'httpd.service', # Apache on Red Hat
     'postgresql*', # Used by Foreman/Dynflow and Pulpcore
     'pulpcore*',
-    'smart_proxy_dynflow_core.service', # Used by Foreman Proxy
     'tomcat.service', # Candlepin
   ].freeze
 


### PR DESCRIPTION
Related PRs:

- https://github.com/theforeman/puppet-katello/pull/491
- https://github.com/theforeman/puppet-foreman_proxy_content/pull/476
- https://github.com/theforeman/puppet-certs/pull/414

Qpid has been dropped for 3 versions of Katello now, so we can safely cleanup all the code paths.