### PR TITLE
Allow puppetlabs/apache 12.x

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,8 +1,7 @@
 forge 'https://forgeapi.puppet.com/'
 
 # HTTP/2 and SSL support for settings in Hiera
-# Our modules aren't yet compatible with 12 and the builds fail
-mod 'puppetlabs/apache',               '>= 8.3', '< 12'
+mod 'puppetlabs/apache',               '>= 8.3'
 
 # Ensure Debian 11 support
 mod 'puppetlabs/postgresql',           '>= 7.4.0'


### PR DESCRIPTION
We need 12.0.3+ for Puppet 8 support due to https://github.com/puppetlabs/puppetlabs-apache/pull/2525

Draft as it needs:
- [x] https://github.com/theforeman/puppet-foreman/pull/1157
- [x] https://github.com/theforeman/puppet-pulpcore/pull/334
- [x] https://github.com/theforeman/puppet-katello/pull/492
- [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/478