### PR TITLE
Check if /opt/puppetlabs is mounted noexec

### DIFF
--- a/checks/noexec
+++ b/checks/noexec
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+TARGET="/opt/puppetlabs"
+
+if findmnt --target "$TARGET" --noheadings --output options | grep -q noexec ; then
+  echo "$TARGET is on mount with the noexec option." >&2
+  echo "Installation requires access to binaries which are stored under $TARGET and must therefore be mounted with exec." >&2
+  exit 2
+fi


### PR DESCRIPTION
It was [reported](https://community.theforeman.org/t/problem-foreman-installer-ruby-spawn-errno-enoent/34332/5) that facter can't be found if puppet is installed on a filesystem that's mounted noexec.