### PR TITLE
Refs #37291 - Reset Puppet's java_bin

### DIFF
--- a/config/foreman-proxy-content.migrations/240322170637-reset-puppet-server-java-bin.rb
+++ b/config/foreman-proxy-content.migrations/240322170637-reset-puppet-server-java-bin.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin']
+  answers['puppet'].delete('server_jvm_java_bin')
+end

--- a/config/foreman.migrations/20240322170637_reset_puppet_server_java_bin.rb
+++ b/config/foreman.migrations/20240322170637_reset_puppet_server_java_bin.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin']
+  answers['puppet'].delete('server_jvm_java_bin')
+end

--- a/config/katello.migrations/240322170637-reset-puppet-server-java-bin.rb
+++ b/config/katello.migrations/240322170637-reset-puppet-server-java-bin.rb
@@ -1,0 +1,3 @@
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin']
+  answers['puppet'].delete('server_jvm_java_bin')
+end


### PR DESCRIPTION
In theforeman/puppet 19.2.0 the puppet::server_jvm_java_bin parameter was changed to undef and determined at runtime. This helps with Puppet 8 upgrades.