### PR TITLE
Refs #37291 - Only reset puppetserver's JVM if it's /usr/bin/java

### DIFF
--- a/config/foreman-proxy-content.migrations/240322170637-reset-puppet-server-java-bin.rb
+++ b/config/foreman-proxy-content.migrations/240322170637-reset-puppet-server-java-bin.rb
@@ -1,3 +1,3 @@
-if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin']
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin'] == '/usr/bin/java'
   answers['puppet'].delete('server_jvm_java_bin')
 end

--- a/config/foreman.migrations/20240322170637_reset_puppet_server_java_bin.rb
+++ b/config/foreman.migrations/20240322170637_reset_puppet_server_java_bin.rb
@@ -1,3 +1,3 @@
-if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin']
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin'] == '/usr/bin/java'
   answers['puppet'].delete('server_jvm_java_bin')
 end

--- a/config/katello.migrations/240322170637-reset-puppet-server-java-bin.rb
+++ b/config/katello.migrations/240322170637-reset-puppet-server-java-bin.rb
@@ -1,3 +1,3 @@
-if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin']
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_jvm_java_bin'] == '/usr/bin/java'
   answers['puppet'].delete('server_jvm_java_bin')
 end


### PR DESCRIPTION
The intent was to only reset it if it was the default value, not just any value.

Fixes: 19310592c8d7f16b2c59f0995463e7ae913e01ef ("Refs #37291 - Reset Puppet's java_bin")