### PR TITLE
Fixes #37297 - Use SCRAM passwd encryption with PostgreSQL

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,8 +3,8 @@ forge 'https://forgeapi.puppet.com/'
 # HTTP/2 and SSL support for settings in Hiera
 mod 'puppetlabs/apache',               '>= 8.3'
 
-# Ensure Debian 11 support
-mod 'puppetlabs/postgresql',           '>= 7.4.0'
+# SCRAM password support
+mod 'puppetlabs/postgresql',           '>= 10.1'
 
 # Dnfmodule support for Redis 6+ support
 mod 'puppet/redis',                    '>= 8.5.0'

--- a/config/foreman.hiera/common.yaml
+++ b/config/foreman.hiera/common.yaml
@@ -18,3 +18,6 @@ dhcp::config_comment: |
 foreman::config::apache::proxy_params:
   retry: '0'
   timeout: '900'
+
+# Match default in PostgreSQL 14+ sooner to phase out MD5
+postgresql::globals::password_encryption: 'scram-sha-256'


### PR DESCRIPTION
PostgreSQL supports SCRAM encryption and PostgreSQL 14 will also default to this. Moving to it sooner helps removing md5 from the system.