### PR TITLE
Refs #37298 - Add migrations to drop setup plugin

### DIFF
--- a/config/foreman.migrations/20240326121346_drop_setup_plugin.rb
+++ b/config/foreman.migrations/20240326121346_drop_setup_plugin.rb
@@ -1,0 +1,1 @@
+answers.delete('foreman::plugin::setup')

--- a/config/katello.migrations/240326121346-drop-setup-plugin.rb
+++ b/config/katello.migrations/240326121346-drop-setup-plugin.rb
@@ -1,0 +1,1 @@
+answers.delete('foreman::plugin::setup')


### PR DESCRIPTION
Fixes: e4338f1d7ea9 ("Fixes #37298 - Drop foreman_setup plugin")

A classic case of a forgotten `git add` because I did writ them.