### PR TITLE
Fixes #37306 - Reset Puppetserver ciphers if needed

### DIFF
--- a/config/foreman-proxy-content.migrations/240328125552-reset-puppetserver-ciphers.rb
+++ b/config/foreman-proxy-content.migrations/240328125552-reset-puppetserver-ciphers.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-puppet/commit/8cc4e3094d5bbd6d05d794e087816934e1697a87
+old_ciphers = ['TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA', 'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA']
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_cipher_suites'] == old_ciphers
+  answers['puppet'].delete('server_cipher_suites')
+end

--- a/config/foreman.migrations/20240328125552_reset_puppetserver_ciphers.rb
+++ b/config/foreman.migrations/20240328125552_reset_puppetserver_ciphers.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-puppet/commit/8cc4e3094d5bbd6d05d794e087816934e1697a87
+old_ciphers = ['TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA', 'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA']
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_cipher_suites'] == old_ciphers
+  answers['puppet'].delete('server_cipher_suites')
+end

--- a/config/katello.migrations/240328125552-reset-puppetserver-ciphers.rb
+++ b/config/katello.migrations/240328125552-reset-puppetserver-ciphers.rb
@@ -1,0 +1,5 @@
+# https://github.com/theforeman/puppet-puppet/commit/8cc4e3094d5bbd6d05d794e087816934e1697a87
+old_ciphers = ['TLS_RSA_WITH_AES_256_CBC_SHA256', 'TLS_RSA_WITH_AES_256_CBC_SHA', 'TLS_RSA_WITH_AES_128_CBC_SHA256', 'TLS_RSA_WITH_AES_128_CBC_SHA']
+if answers['puppet'].is_a?(Hash) && answers['puppet']['server_cipher_suites'] == old_ciphers
+  answers['puppet'].delete('server_cipher_suites')
+end

--- a/spec/migrations/20240328125552_reset_puppetserver_ciphers_spec.rb
+++ b/spec/migrations/20240328125552_reset_puppetserver_ciphers_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+migration '20231005004305_redis_default_cache' do
+  scenarios %w[foreman katello foreman-proxy-content] do
+    context 'current ciphers' do
+      let(:answers) do
+        {
+          'puppet' => {
+            'server_cipher_suites' => [
+              'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
+              'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+              'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',
+              'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
+              'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',
+              'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
+            ],
+          },
+        }
+      end
+
+      it 'leaves ciphers untouched' do
+        expect(migrated_answers['puppet']['server_cipher_suites']).not_to be_nil
+      end
+    end
+
+    context 'outdated ciphers' do
+      let(:answers) do
+        {
+          'puppet' => {
+            'server_cipher_suites' => [
+              'TLS_RSA_WITH_AES_256_CBC_SHA256',
+              'TLS_RSA_WITH_AES_256_CBC_SHA',
+              'TLS_RSA_WITH_AES_128_CBC_SHA256',
+              'TLS_RSA_WITH_AES_128_CBC_SHA',
+            ],
+          },
+        }
+      end
+
+      it 'resets the answer' do
+        expect(migrated_answers['puppet']['server_cipher_suites']).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
In foreman-installer 2.0 we [updated] the ciphers for puppetserver, but didn't introduce a migration to update existing installations. Users from very old installs will still use the insecure ciphers. This breaks on FIPS and leaves other users more vulnerable than they need to be.

[updated]: https://github.com/theforeman/puppet-puppet/commit/8cc4e3094d5bbd6d05d794e087816934e1697a87