### PR TITLE
Fixes #37393 - Adapt rubocop command to work with rubocop version 0.80.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ lint:
   extends: .common
   stage: lint
   script:
-    - bundle exec rubocop --format junit --out rubocop.xml --display-only-failed
+    - bundle exec rubocop --format junit --out rubocop.xml --display-only-fail-level-offenses --fail-level=A
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
https://github.com/rubocop/rubocop/blob/v0.80.1/lib/rubocop/options.rb#L148