### PR TITLE
Add certs command

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,7 @@ upstream_tag_template: "{version}"
 
 actions:
   post-upstream-clone:
-    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/foreman/foreman-installer/foreman-installer.spec -O foreman-installer.spec"
+    - "wget https://raw.githubusercontent.com/evgeni/foreman-packaging/ansible-installer/packages/foreman/foreman-installer/foreman-installer.spec -O foreman-installer.spec"
   get-current-version:
     - "sed 's/-develop//' VERSION"
   create-archive:

--- a/Rakefile
+++ b/Rakefile
@@ -37,9 +37,11 @@ task :modules => "#{BUILDDIR}/modules"
 if BUILD_KATELLO
   SCENARIOS = ['foreman', 'foreman-proxy-content', 'katello'].freeze
   CERTS_SCENARIOS = ['foreman-proxy-certs'].freeze
+  NEW_CERTS_SCENARIOS = ['foreman-certs'].freeze
 else
   SCENARIOS = ['foreman'].freeze
   CERTS_SCENARIOS = [].freeze
+  NEW_CERTS_SCENARIOS = [].freeze
 end
 
 exporter_dirs = ENV['PATH'].split(':').push('/usr/bin', ENV['KAFO_EXPORTER'])
@@ -136,6 +138,33 @@ CERTS_SCENARIOS.each do |scenario|
   end
 end
 
+NEW_CERTS_SCENARIOS.each do |scenario|
+  config = "foreman_certs/config/#{scenario}.yaml"
+  file "#{BUILDDIR}/#{scenario}.yaml" => [config, BUILDDIR] do |t|
+    cp t.prerequisites.first, t.name
+
+    scenario_config_replacements = {
+      'answer_file' => "#{DATADIR}/foreman-installer/foreman-certs/scenarios.d/#{scenario}-answers.yaml",
+      'installer_dir' => "#{DATADIR}/foreman-installer/foreman-certs",
+      'log_dir' => "#{LOGDIR}/foreman-installer",
+      'module_dirs' => "#{DATADIR}/foreman-installer/modules",
+      'parser_cache_path' => "#{DATADIR}/foreman-installer/parser_cache/#{scenario}.yaml",
+    }
+
+    scenario_config_replacements.each do |setting, value|
+      sh format('sed -i "s#\(.*%s:\).*#\1 %s#" %s', setting, value, t.name)
+    end
+  end
+
+  file "#{BUILDDIR}/parser_cache/#{scenario}.yaml" => [config, "#{BUILDDIR}/modules", "#{BUILDDIR}/parser_cache"] do |t|
+    sh "#{exporter}/kafo-export-params -c #{t.prerequisites.first} -f parsercache --no-parser-cache -o #{t.name}"
+  end
+
+  file "#{BUILDDIR}/#{scenario}-options.asciidoc" => [config, "#{BUILDDIR}/parser_cache/#{scenario}.yaml"] do |t|
+    sh "#{exporter}/kafo-export-params -c #{t.prerequisites.first} -f asciidoc -o #{t.name}"
+  end
+end
+
 file "#{BUILDDIR}/foreman-installer" => 'bin/foreman-installer' do |t|
   cp t.prerequisites[0], t.name
   sh format('sed -i "s#\(^.*CONFIG_DIR = \).*#CONFIG_DIR = %s#" %s', "'#{SYSCONFDIR}/foreman-installer/scenarios.d/'", t.name)
@@ -144,6 +173,11 @@ end
 file "#{BUILDDIR}/foreman-proxy-certs-generate" => 'bin/foreman-proxy-certs-generate' do |t|
   cp t.prerequisites[0], t.name
   sh format('sed -i "s#^.*\(CONFIG_DIR = \).*#\1%s#" %s', "'#{DATADIR}/foreman-installer/katello-certs/scenarios.d/'", t.name)
+end
+
+file "#{BUILDDIR}/foreman-certs" => 'bin/foreman-certs' do |t|
+  cp t.prerequisites[0], t.name
+  sh format('sed -i "s#^.*\(CONFIG_DIR = \).*#\1%s#" %s', "'#{DATADIR}/foreman-installer/foreman-certs/scenarios.d/'", t.name)
 end
 
 file "#{BUILDDIR}/katello-certs-check" => 'bin/katello-certs-check' do |t|
@@ -211,6 +245,7 @@ namespace :build do
 
   if BUILD_KATELLO
     task :base => [
+      "#{BUILDDIR}/foreman-certs",
       "#{BUILDDIR}/foreman-proxy-certs-generate",
       "#{BUILDDIR}/katello-certs-check",
     ]
@@ -234,9 +269,16 @@ namespace :build do
       "#{BUILDDIR}/parser_cache/#{scenario}.yaml",
     ]
   end].flatten
+
+  task :new_certs_scenarios => [NEW_CERTS_SCENARIOS.map do |scenario|
+    [
+      "#{BUILDDIR}/#{scenario}.yaml",
+      "#{BUILDDIR}/parser_cache/#{scenario}.yaml",
+    ]
+  end].flatten
 end
 
-task :build => ['build:base', 'build:scenarios', 'build:certs_scenarios']
+task :build => ['build:base', 'build:scenarios', 'build:certs_scenarios', 'build:new_certs_scenarios']
 
 task :install => :build do
   mkdir_p "#{DATADIR}/foreman-installer"
@@ -261,6 +303,14 @@ task :install => :build do
     cp "katello_certs/config/#{scenario}-answers.yaml", "#{DATADIR}/foreman-installer/katello-certs/scenarios.d/#{scenario}-answers.yaml"
   end
 
+  if NEW_CERTS_SCENARIOS.any?
+    mkdir_p "#{DATADIR}/foreman-installer/foreman-certs/scenarios.d"
+  end
+  NEW_CERTS_SCENARIOS.each do |scenario|
+    cp "#{BUILDDIR}/#{scenario}.yaml", "#{DATADIR}/foreman-installer/foreman-certs/scenarios.d/#{scenario}.yaml"
+    cp "foreman_certs/config/#{scenario}-answers.yaml", "#{DATADIR}/foreman-installer/foreman-certs/scenarios.d/#{scenario}-answers.yaml"
+  end
+
   cp_r "#{BUILDDIR}/modules", "#{DATADIR}/foreman-installer", :preserve => true
   cp_r "#{BUILDDIR}/parser_cache", "#{DATADIR}/foreman-installer"
 
@@ -271,6 +321,7 @@ task :install => :build do
   install "#{BUILDDIR}/foreman-installer", "#{SBINDIR}/foreman-installer", :mode => 0o755, :verbose => true
 
   if BUILD_KATELLO
+    install "#{BUILDDIR}/foreman-certs", "#{SBINDIR}/foreman-certs", :mode => 0o755, :verbose => true
     install "#{BUILDDIR}/foreman-proxy-certs-generate", "#{SBINDIR}/foreman-proxy-certs-generate", :mode => 0o755, :verbose => true
     install "#{BUILDDIR}/katello-certs-check", "#{SBINDIR}/katello-certs-check", :mode => 0o755, :verbose => true
   end

--- a/bin/foreman-certs
+++ b/bin/foreman-certs
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'kafo'
+
+CONFIG_DIR = './foreman_certs/config/'.freeze
+
+@result = Kafo::KafoConfigure.run
+exit((@result.nil? || @result.exit_code == 2) ? 0 : @result.exit_code)

--- a/foreman_certs/config/foreman-certs-answers.yaml
+++ b/foreman_certs/config/foreman-certs-answers.yaml
@@ -1,0 +1,6 @@
+certs:
+  generate: true
+  regenerate: true
+  deploy: false
+  group: root
+certs::generate: true

--- a/foreman_certs/config/foreman-certs.yaml
+++ b/foreman_certs/config/foreman-certs.yaml
@@ -1,0 +1,27 @@
+---
+:answer_file: "./foreman_certs/config/foreman-certs-answers.yaml"
+:color_of_background: :dark
+:colors: true
+:custom: {}
+:description: Generate Foreman certificates
+:dont_save_answers: true
+:enabled: true
+:facts: {}
+:hook_dirs: []
+:installer_dir: "./foreman_certs"
+:log_dir: "./_build/"
+:log_level: :debug
+:log_name: foreman-certs.log
+:low_priority_modules: []
+:mapping: {}
+:module_dirs: "./_build/modules"
+:name: foreman-certs
+:no_prefix: true
+:order:
+- certs
+- certs:generate
+:parser_cache_path: "./_build/parser_cache/foreman-certs.yaml"
+:skip_puppet_version_check: false
+:store_dir: ''
+:verbose: false
+:verbose_log_level: debug


### PR DESCRIPTION
The idea here is to introduce a command that can stand-alone generate certificates as is done within the installer using the same logic of puppet-certs module. This intentionally does not cover deployment, it simply allows generation of the certificates. This relies upon https://github.com/theforeman/puppet-certs/pull/449 as it introduces a class that makes this process works and avoids the complication that the individual certificate classes create via their params.

The full design idea is to split generation from deployment and allow generation to happen prior to full `puppet apply` within the installer and allow the installer part to only handle deployment. This will put us a step closer to allowing users to provider their own certificates by standardizing on the set of certificates as inputs where those inputs can come directly from the user or from the self-generated set.