### PR TITLE
pkg:generate_source already prints the path to the tarball

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,7 +25,6 @@ actions:
     - bundle config set --local without development:test
     - bundle install
     - bundle exec rake pkg:generate_source
-    - bash -c "ls -1t pkg/*.tar.bz2 | head -n 1"
 
 jobs:
   - job: copr_build


### PR DESCRIPTION
create-archive needs to "return" (print) the path, but there is no need to do it twice