### PR TITLE
Correctly evaluate the Puppetfile in pin_modules

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -323,7 +323,7 @@ else
     filename = 'Puppetfile'
 
     fake = FakePuppetfile.new
-    fake.instance_eval { eval(File.read(filename), filename, 1) }
+    fake.instance_eval { instance_eval(File.read(filename), filename, 1) }
 
     File.open(filename, 'w') do |file|
       fake.content do |line|


### PR DESCRIPTION
For some reason I changed it to eval instead of instance_eval and this broke.

Fixes: 24a81c701f37 ("Factor out FakePuppetfile so it can be tested in rspec")