### PR TITLE
Fixes #36940 - Add necessary migration for host_config tftp directory

### DIFF
--- a/config/foreman-proxy-content.migrations/240531091300_foreman_proxy_tftp_host_config.rb
+++ b/config/foreman-proxy-content.migrations/240531091300_foreman_proxy_tftp_host_config.rb
@@ -1,0 +1,10 @@
+if answers['foreman_proxy'].is_a?(Hash)
+  root = answers['foreman_proxy']['tftp_root']
+  if root && answers['foreman_proxy']['tftp_dirs']
+    dirs = answers['foreman_proxy']['tftp_dirs']
+    dirs << "#{root}/bootloader-universe"
+    dirs << "#{root}/bootloader-universe/pxegrub2"
+    dirs << "#{root}/host-config"
+    dirs.uniq!
+  end
+end

--- a/config/foreman.migrations/20240531091300_foreman_proxy_tftp_host_config.rb
+++ b/config/foreman.migrations/20240531091300_foreman_proxy_tftp_host_config.rb
@@ -1,0 +1,10 @@
+if answers['foreman_proxy'].is_a?(Hash)
+  root = answers['foreman_proxy']['tftp_root']
+  if root && answers['foreman_proxy']['tftp_dirs']
+    dirs = answers['foreman_proxy']['tftp_dirs']
+    dirs << "#{root}/bootloader-universe"
+    dirs << "#{root}/bootloader-universe/pxegrub2"
+    dirs << "#{root}/host-config"
+    dirs.uniq!
+  end
+end

--- a/config/katello.migrations/240531091300_foreman_proxy_tftp_host_config.rb
+++ b/config/katello.migrations/240531091300_foreman_proxy_tftp_host_config.rb
@@ -1,0 +1,10 @@
+if answers['foreman_proxy'].is_a?(Hash)
+  root = answers['foreman_proxy']['tftp_root']
+  if root && answers['foreman_proxy']['tftp_dirs']
+    dirs = answers['foreman_proxy']['tftp_dirs']
+    dirs << "#{root}/bootloader-universe"
+    dirs << "#{root}/bootloader-universe/pxegrub2"
+    dirs << "#{root}/host-config"
+    dirs.uniq!
+  end
+end

--- a/spec/migrations/20240531091300_foreman_proxy_tftp_host_config_spec.rb
+++ b/spec/migrations/20240531091300_foreman_proxy_tftp_host_config_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+migration '20240531091300_foreman_proxy_tftp_host_config' do
+  scenarios %w[foreman katello foreman-proxy-content] do
+    context 'host-config in tftp_dirs missing' do
+      let(:answers) do
+        {
+          'foreman_proxy' => {
+            'tftp_root' => '/var/lib/tftpboot',
+            'tftp_dirs' => [
+              '/var/lib/tftpboot/pxelinux.cfg',
+              '/var/lib/tftpboot/grub',
+              '/var/lib/tftpboot/grub2',
+              '/var/lib/tftpboot/boot',
+              '/var/lib/tftpboot/ztp.cfg',
+              '/var/lib/tftpboot/poap.cfg',
+            ],
+          },
+        }
+      end
+
+      it 'adds bootloader-universe to tftp_dirs' do
+        expect(migrated_answers['foreman_proxy']['tftp_dirs']).to include '/var/lib/tftpboot/bootloader-universe'
+      end
+
+      it 'adds bootloader-universe/pxegrub2 to tftp_dirs' do
+        expect(migrated_answers['foreman_proxy']['tftp_dirs']).to include '/var/lib/tftpboot/bootloader-universe/pxegrub2'
+      end
+
+      it 'adds host-config to tftp_dirs' do
+        expect(migrated_answers['foreman_proxy']['tftp_dirs']).to include '/var/lib/tftpboot/host-config'
+      end
+    end
+
+    context 'tftp_dirs empty' do
+      let(:answers) do
+        {
+          'foreman_proxy' => {
+            'tftp_root' => '/var/lib/tftpboot',
+            'tftp_dirs' => nil,
+          },
+        }
+      end
+
+      it 'keeps tftp_dirs unchanged' do
+        expect(migrated_answers['foreman_proxy']['tftp_dirs']).to eq answers['foreman_proxy']['tftp_dirs']
+      end
+    end
+  end
+end


### PR DESCRIPTION
The migration is necessary as part of the puppet_foreman_proxy change in https://github.com/theforeman/puppet-foreman_proxy/pull/821

Belongs to the SecureBoot story: https://github.com/theforeman/foreman/pull/9864

