### PR TITLE
Only mark certs for update if the directory exists

### DIFF
--- a/hooks/pre/20-certs_update.rb
+++ b/hooks/pre/20-certs_update.rb
@@ -6,6 +6,8 @@ if module_enabled?('certs')
 
   def mark_for_update(cert_name, hostname = nil)
     path = File.join(*[SSL_BUILD_DIR, hostname, cert_name].compact)
+    return unless File.exist?(File.dirname(path))
+
     if app_value(:noop)
       puts "Marking certificate #{path} for update (noop)"
     else


### PR DESCRIPTION
Marking for update only makes sense if the directory exists. Otherwise it'll simply be generated. This avoids a bug where file creation fails.