### PR TITLE
Fixes #37693 - Add check for ipv6.disable=1 in /proc/cmdline

### DIFF
--- a/checks/ipv6
+++ b/checks/ipv6
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if grep -q "ipv6.disable=1" /proc/cmdline ; then
+	echo "The kernel contains ipv6.disable=1 which is known to break installation and upgrade." >&2
+        echo "Remove and reboot before continuining." >&2
+	exit 2
+fi


### PR DESCRIPTION
When a system has ipv6.disable=1 in /proc/cmdline then it doesn't have ::1 but some of our services (most notably, Redis) listen on it and cause problems. Adding a check prevents users from installing in the first place.

This check is based on definitions/checks/check_ipv6_disable.rb in foreman_maintain. Biggest reason to add it here is to also guard it on fresh installations.