### PR TITLE
Refs #37604 - Use the correct answer in DNS normalize migration

### DIFF
--- a/config/foreman-proxy-content.migrations/240715095211-normalize-dns-forwarders.rb
+++ b/config/foreman-proxy-content.migrations/240715095211-normalize-dns-forwarders.rb
@@ -1,8 +1,8 @@
 # forwarders was always an array, but previously it was documented as
 # --foreman-proxy-dns-forwarders "192.0.2.1; 192.0.2.2"
 fp_mod = answers['foreman_proxy']
-if fp_mod.is_a?(Hash) && fp_mod['forwarders']
-  fp_mod['forwarders'] = fp_mod['forwarders'].flat_map do |forwarder|
+if fp_mod.is_a?(Hash) && fp_mod['dns_forwarders']
+  fp_mod['dns_forwarders'] = fp_mod['dns_forwarders'].flat_map do |forwarder|
     forwarder.split(';').map(&:strip)
   end
 end

--- a/config/foreman.migrations/20240715095211_normalize_dns_forwarders.rb
+++ b/config/foreman.migrations/20240715095211_normalize_dns_forwarders.rb
@@ -1,8 +1,8 @@
 # forwarders was always an array, but previously it was documented as
 # --foreman-proxy-dns-forwarders "192.0.2.1; 192.0.2.2"
 fp_mod = answers['foreman_proxy']
-if fp_mod.is_a?(Hash) && fp_mod['forwarders']
-  fp_mod['forwarders'] = fp_mod['forwarders'].flat_map do |forwarder|
+if fp_mod.is_a?(Hash) && fp_mod['dns_forwarders']
+  fp_mod['dns_forwarders'] = fp_mod['dns_forwarders'].flat_map do |forwarder|
     forwarder.split(';').map(&:strip)
   end
 end

--- a/config/katello.migrations/240715095211-normalize-dns-forwarders.rb
+++ b/config/katello.migrations/240715095211-normalize-dns-forwarders.rb
@@ -1,8 +1,8 @@
 # forwarders was always an array, but previously it was documented as
 # --foreman-proxy-dns-forwarders "192.0.2.1; 192.0.2.2"
 fp_mod = answers['foreman_proxy']
-if fp_mod.is_a?(Hash) && fp_mod['forwarders']
-  fp_mod['forwarders'] = fp_mod['forwarders'].flat_map do |forwarder|
+if fp_mod.is_a?(Hash) && fp_mod['dns_forwarders']
+  fp_mod['dns_forwarders'] = fp_mod['dns_forwarders'].flat_map do |forwarder|
     forwarder.split(';').map(&:strip)
   end
 end

--- a/spec/migrations/20240715095211_normalize_dns_forwarders_spec.rb
+++ b/spec/migrations/20240715095211_normalize_dns_forwarders_spec.rb
@@ -6,13 +6,13 @@ migration '20240715095211_normalize_dns_forwarders' do
       let(:answers) do
         {
           'foreman_proxy' => {
-            'forwarders' => ['192.0.2.1', '192.0.2.2'],
+            'dns_forwarders' => ['192.0.2.1', '192.0.2.2'],
           },
         }
       end
 
       it 'leaves the answers untouched' do
-        expect(migrated_answers['foreman_proxy']['forwarders']).to eq(['192.0.2.1', '192.0.2.2'])
+        expect(migrated_answers['foreman_proxy']['dns_forwarders']).to eq(['192.0.2.1', '192.0.2.2'])
       end
     end
 
@@ -20,13 +20,13 @@ migration '20240715095211_normalize_dns_forwarders' do
       let(:answers) do
         {
           'foreman_proxy' => {
-            'forwarders' => ['192.0.2.1; 192.0.2.2'],
+            'dns_forwarders' => ['192.0.2.1; 192.0.2.2'],
           },
         }
       end
 
-      it 'leaves the answers untouched' do
-        expect(migrated_answers['foreman_proxy']['forwarders']).to eq(['192.0.2.1', '192.0.2.2'])
+      it 'normalizes the answer' do
+        expect(migrated_answers['foreman_proxy']['dns_forwarders']).to eq(['192.0.2.1', '192.0.2.2'])
       end
     end
   end


### PR DESCRIPTION
The previous patch used forwarders instead of dns_forwarders.

Fixes: e4fc6826b871 ("Refs #37604 - Normalize DNS forwarders to an array")