### PR TITLE
Refs #37797 - ensure we can start PostgreSQL by forcing the old version

### DIFF
--- a/spec/postgresql_upgrade_hook_context_extension_spec.rb
+++ b/spec/postgresql_upgrade_hook_context_extension_spec.rb
@@ -31,6 +31,7 @@ describe PostgresqlUpgradeHookContextExtension do
     subject { context.postgresql_upgrade(13) }
 
     before do
+      allow(File).to receive(:read).with('/var/lib/pgsql/data/PG_VERSION').and_return('12')
       allow(context).to receive(:logger).and_return(logger)
       allow(context).to receive(:'execute!')
       allow(context).to receive(:ensure_packages)


### PR DESCRIPTION
Something (f-m) might have already called switch-to postgresql:13, which
- upgraded packages
- tried to restart services

The later obviously fails as the on-disk data is in the wrong format.
