### PR TITLE
Fixes #37883 - halt if remote DB does not own EVR

### DIFF
--- a/hooks/pre/10-reset_data.rb
+++ b/hooks/pre/10-reset_data.rb
@@ -10,36 +10,6 @@ def reset
   reset_pulpcore if pulpcore_enabled?
 end
 
-def load_db_config(db)
-  case db
-  when 'foreman'
-    module_name = 'foreman'
-    user_param = 'username'
-    db_param = 'database'
-    param_prefix = 'db_'
-  when 'candlepin'
-    module_name = 'katello'
-    user_param = 'user'
-    db_param = 'name'
-    param_prefix = 'candlepin_db_'
-  when 'pulpcore'
-    module_name = 'foreman_proxy_content'
-    user_param = 'user'
-    db_param = 'db_name'
-    param_prefix = 'pulpcore_postgresql_'
-  else
-    raise "installer module unknown for db: #{db}"
-  end
-
-  {
-    host: param_value(module_name, "#{param_prefix}host") || 'localhost',
-    port: param_value(module_name, "#{param_prefix}port") || 5432,
-    database: param_value(module_name, "#{param_prefix}#{db_param}") || db,
-    username: param_value(module_name, "#{param_prefix}#{user_param}"),
-    password: param_value(module_name, "#{param_prefix}password"),
-  }
-end
-
 def empty_db_in_postgresql(db)
   logger.notice "Dropping #{db} database!"
 
@@ -54,20 +24,6 @@ end
 def reset_candlepin
   execute!('rm -f /var/lib/candlepin/.puppet-candlepin-*', false, true)
   empty_db_in_postgresql('candlepin')
-end
-
-def pg_env(config)
-  {
-    'PGHOST' => config.fetch(:host, 'localhost'),
-    'PGPORT' => config.fetch(:port, '5432').to_s,
-    'PGUSER' => config[:username],
-    'PGPASSWORD' => config[:password],
-    'PGDATABASE' => config[:database],
-  }
-end
-
-def pg_sql_statement(statement)
-  "psql -t -c \"#{statement}\""
 end
 
 # WARNING: deletes all the data owned by the user. No warnings. No confirmations.

--- a/hooks/pre_commit/42-evr_extension_permissions.rb
+++ b/hooks/pre_commit/42-evr_extension_permissions.rb
@@ -2,29 +2,30 @@
 return if local_postgresql?
 
 database = param_value('foreman', 'db_database') || 'foreman'
-username = param_value('foreman', 'db_username') || 'foreman'
-password = param_value('foreman', 'db_password')
-host = param_value('foreman', 'db_host')
-port = param_value('foreman', 'db_port') || 5432
+config = load_db_config(database)
 
 # If postgres is the owner of the DB, then the permissions will not matter.
-return if username == 'postgres'
+return if config[:username] == 'postgres'
 
 check_evr_owner_sql = "SELECT CASE" \
-                      " WHEN r.rolname = 'postgres' THEN 1" \
-                      " ELSE 0" \
+                      " WHEN r.rolname = '#{config[:username]}' THEN 0" \
+                      " ELSE 1" \
                       " END AS evr_owned_by_postgres" \
                       " FROM pg_extension e" \
                       " JOIN pg_roles r ON e.extowner = r.oid" \
                       " WHERE e.extname = 'evr';"
 
-command = "PGPASSWORD='#{password}' psql -U #{username} -h #{host} -p #{port} -d #{database} -t -c \"#{check_evr_owner_sql}\""
+command = pg_sql_statement(check_evr_owner_sql)
 logger.debug "Checking if the evr extension is owned by the postgres user via #{command}"
-output, = execute_command(command, false, true)
-unless output.nil?
-  if output.strip == '1'
-    fail_and_exit("The evr extension is owned by postgres and not the foreman DB owner. Please run the following command to fix it: " \
-                  "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_authid WHERE rolname='#{username}');")
-  end
-end
+output, = execute_command(command, false, true, pg_env(config))
 
+case output&.strip
+when '0'
+  # The evr extension is owned by the foreman DB owner, so we can skip this check.
+  return
+when '1'
+  fail_and_exit("The evr extension is not owned by the #{database} DB owner. Please run the following command to fix it: " \
+                "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_authid WHERE rolname='#{config[:username]}') WHERE extname='evr';")
+else
+  fail_and_exit("Failed to check the ownership of the evr extension.")
+end

--- a/hooks/pre_commit/42-evr_extension_permissions.rb
+++ b/hooks/pre_commit/42-evr_extension_permissions.rb
@@ -1,0 +1,30 @@
+# Managed databases will be handled automatically.
+return if local_postgresql?
+
+database = param_value('foreman', 'db_database') || 'foreman'
+username = param_value('foreman', 'db_username') || 'foreman'
+password = param_value('foreman', 'db_password')
+host = param_value('foreman', 'db_host')
+port = param_value('foreman', 'db_port') || 5432
+
+# If postgres is the owner of the DB, then the permissions will not matter.
+return if username == 'postgres'
+
+check_evr_owner_sql = "SELECT CASE" \
+                      " WHEN r.rolname = 'postgres' THEN 1" \
+                      " ELSE 0" \
+                      " END AS evr_owned_by_postgres" \
+                      " FROM pg_extension e" \
+                      " JOIN pg_roles r ON e.extowner = r.oid" \
+                      " WHERE e.extname = 'evr';"
+
+command = "PGPASSWORD='#{password}' psql -U #{username} -h #{host} -p #{port} -d #{database} -t -c \"#{check_evr_owner_sql}\""
+logger.debug "Checking if the evr extension is owned by the postgres user via #{command}"
+output, = execute_command(command, false, true)
+unless output.nil?
+  if output.strip == '1'
+    fail_and_exit("The evr extension is owned by postgres and not the foreman DB owner. Please run the following command to fix it: " \
+                  "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_authid WHERE rolname='#{username}');")
+  end
+end
+

--- a/hooks/pre_commit/42-evr_extension_permissions.rb
+++ b/hooks/pre_commit/42-evr_extension_permissions.rb
@@ -7,6 +7,13 @@ config = load_db_config('foreman')
 # If postgres is the owner of the DB, then the permissions will not matter.
 return if config[:username] == 'postgres'
 
+evr_existence_command = pg_sql_statement("SELECT 1 FROM pg_extension WHERE extname = 'evr';")
+logger.debug "Checking if the evr extension exists via #{evr_existence_command}"
+evr_existence_output, = execute_command(evr_existence_command, false, true, pg_env(config))
+
+# If the evr extension does not exist, then we can skip this check.
+return if evr_existence_output&.strip != '1'
+
 check_evr_owner_sql = "SELECT CASE" \
                       " WHEN r.rolname = '#{config[:username]}' THEN 0" \
                       " ELSE 1" \

--- a/hooks/pre_commit/42-evr_extension_permissions.rb
+++ b/hooks/pre_commit/42-evr_extension_permissions.rb
@@ -1,8 +1,8 @@
 # Managed databases will be handled automatically.
 return if local_postgresql?
+return unless katello_enabled?
 
-database = param_value('foreman', 'db_database') || 'foreman'
-config = load_db_config(database)
+config = load_db_config('foreman')
 
 # If postgres is the owner of the DB, then the permissions will not matter.
 return if config[:username] == 'postgres'
@@ -24,7 +24,7 @@ when '0'
   # The evr extension is owned by the foreman DB owner, so we can skip this check.
   return
 when '1'
-  fail_and_exit("The evr extension is not owned by the #{database} DB owner. Please run the following command to fix it: " \
+  fail_and_exit("The evr extension is not owned by the foreman DB owner. Please run the following command to fix it: " \
                 "UPDATE pg_extension SET extowner = (SELECT oid FROM pg_authid WHERE rolname='#{config[:username]}') WHERE extname='evr';")
 else
   fail_and_exit("Failed to check the ownership of the evr extension.")


### PR DESCRIPTION
Checks if the `postgres` user owns the `evr` extension. If it does, halt the foreman-installer and report an error with the command to run to fix the permissions.

Also check if `postgres` is the foreman DB owner. In that case, don't do anything because the migration will succeed.

There's no provision if the admin user is called something other than postgres. Should there be?