### PR TITLE
Fixes #37828: Ignore system CA trust when verifying certificates

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -157,7 +157,7 @@ function check-priv-key () {
 function check-ca-bundle () {
     printf "Checking CA bundle against the certificate file: "
     ERROR_PATTERN="error [0-9]+ at"
-    CHECK=$(openssl verify -CAfile $CA_BUNDLE_FILE -purpose sslserver -verbose $CERT_FILE 2>&1)
+    CHECK=$(openssl verify -no-CApath -no-CAstore -CAfile $CA_BUNDLE_FILE -purpose sslserver -verbose $CERT_FILE 2>&1)
     CHECK_STATUS=$?
 
     if [[ $CHECK_STATUS != "0" || $CHECK =~ $ERROR_PATTERN ]]; then


### PR DESCRIPTION
While [picking this to 3.11](https://github.com/theforeman/foreman-installer/pull/985) I thought I was picking https://projects.theforeman.org/issues/37817 (too many certificate issues) and then when the bot didn't set the Fixed in Releases as I expected, I got suspicous. This pick makes sure it's in 3.11, 3.12 and 3.13.

(cherry picked from commit d54d28ad6e329a47267595564b514d94cf17bbc5)