### PR TITLE
Do not use tilde specifier for PUPPET_VERSION read from environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rdoc', '< 6.4'
 
 gem 'kafo', '>= 7.3', '< 8'
 gem 'librarian-puppet', '>= 3.0'
-gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 7.0'
+gem 'puppet', ENV.key?('PUPPET_VERSION') ? "<= #{ENV['PUPPET_VERSION']}" : '~> 7.0'
 gem 'facter', '>= 3.0', '!= 4.0.52'
 
 gem 'puppet-strings'


### PR DESCRIPTION
when specifing a specific version this version should be used