### PR TITLE
Add script to analyze installer log for action run times

### DIFF
--- a/bin/installer-profile
+++ b/bin/installer-profile
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+log = File.read(ARGV[0])
+
+tasks = log.split("\n").select do |line|
+  line.include?('Evaluated in')
+end
+
+profile = []
+
+#2021-04-27 01:13:35 [DEBUG ] [configure] /Stage[main]/Foreman/Foreman::Rake[apipie:cache:index]/Exec[foreman-rake-apipie:cache:index]: Evaluated in 86.60 seconds
+tasks.each do |task|
+  EVALTRACE = %r{.+/(?<resource>.+\]): Evaluated in (?<time>\d+\.\d+) seconds}
+
+  evaltrace = EVALTRACE.match(task)
+  next if evaltrace.nil?
+  profile << {:task => evaltrace[:resource], :time => evaltrace[:time].to_f}
+end
+
+profile.sort! { |a,b| b[:time] <=> a[:time] }
+
+profile[0...15].each do |task|
+  puts "#{task[:time]}:  #{task[:task]}"
+end

--- a/bin/installer-profile
+++ b/bin/installer-profile
@@ -9,9 +9,9 @@ end
 profile = []
 
 #2021-04-27 01:13:35 [DEBUG ] [configure] /Stage[main]/Foreman/Foreman::Rake[apipie:cache:index]/Exec[foreman-rake-apipie:cache:index]: Evaluated in 86.60 seconds
-tasks.each do |task|
-  EVALTRACE = %r{.+/(?<resource>.+\]): Evaluated in (?<time>\d+\.\d+) seconds}
+EVALTRACE = %r{.+/(?<resource>.+\]): Evaluated in (?<time>\d+\.\d+) seconds}
 
+tasks.each do |task|
   evaltrace = EVALTRACE.match(task)
   next if evaltrace.nil?
   profile << {:task => evaltrace[:resource], :time => evaltrace[:time].to_f}

--- a/bin/installer-profile
+++ b/bin/installer-profile
@@ -9,7 +9,7 @@ end
 profile = []
 
 #2021-04-27 01:13:35 [DEBUG ] [configure] /Stage[main]/Foreman/Foreman::Rake[apipie:cache:index]/Exec[foreman-rake-apipie:cache:index]: Evaluated in 86.60 seconds
-EVALTRACE = %r{.+/(?<resource>.+\]): Evaluated in (?<time>\d+\.\d+) seconds}
+EVALTRACE = %r{.+/(?<resource>.+\[.+\]): Evaluated in (?<time>\d+\.\d+) seconds}
 
 tasks.each do |task|
   evaltrace = EVALTRACE.match(task)


### PR DESCRIPTION
I've had this little script for a while, and wanted to stop losing track of where it is. The idea is it analyzes an installer run log file and identifies the actions that took the longest. For example, a recent analysis:

```
61.42:  Exec[foreman-rake-db:migrate]
39.89:  Exec[pulpcore-manager migrate --noinput]
38.11:  Service[foreman]
26.33:  Service[dynflow-sidekiq@worker-hosts-queue-1]
26.27:  Service[dynflow-sidekiq@worker-1]
25.94:  Exec[foreman-rake-db:seed]
25.57:  Service[dynflow-sidekiq@orchestrator]
7.99:  Exec[pulpcore-manager reset-admin-password --random]
7.36:  Foreman_host[foreman-ip-10-0-168-157.rhos-01.prod.psi.rdu2.redhat.com]
4.13:  Foreman_smartproxy[ip-10-0-168-157.rhos-01.prod.psi.rdu2.redhat.com]
3.27:  Package[mod_ssl]
2.9:  Service[pulpcore-content.service]
2.82:  Service[pulpcore-api.service]
2.27:  Cert[ip-10-0-168-157.rhos-01.prod.psi.rdu2.redhat.com-apache]
2.25:  Exec[pulpcore-manager collectstatic --noinput]
```