### PR TITLE
Make katello-certs-check openssl 1.1 (EL8) compatible again

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -157,7 +157,7 @@ function check-priv-key () {
 function check-ca-bundle () {
     printf "Checking CA bundle against the certificate file: "
     ERROR_PATTERN="error [0-9]+ at"
-    CHECK=$(openssl verify -no-CApath -no-CAstore -CAfile $CA_BUNDLE_FILE -purpose sslserver -verbose $CERT_FILE 2>&1)
+    CHECK=$(openssl verify -no-CApath -CAfile $CA_BUNDLE_FILE -purpose sslserver -verbose $CERT_FILE 2>&1)
     CHECK_STATUS=$?
 
     if [[ $CHECK_STATUS != "0" || $CHECK =~ $ERROR_PATTERN ]]; then


### PR DESCRIPTION
Removed openssl command option that isn't supported by openssl 1.1.1

The `-no-CAstore` option is not supported in EL8 and will cause foreman-installer to fail on EL8 servers.