### PR TITLE
 Refs #37803 - Remove ProxyCommand option from Ansible options

### DIFF
--- a/config/foreman.migrations/20241106161211_remove_proxycommand.rb
+++ b/config/foreman.migrations/20241106161211_remove_proxycommand.rb
@@ -1,0 +1,3 @@
+if answers['foreman_proxy::plugin::ansible'].is_a?(Hash) && answers['foreman_proxy::plugin::ansible']['ssh_args'] == '-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s'
+  answers['foreman_proxy::plugin::ansible']['ssh_args'] = '-C -o ControlMaster=auto -o ControlPersist=60s'
+end


### PR DESCRIPTION
Relates to https://github.com/theforeman/puppet-foreman_proxy/pull/845