### PR TITLE
Fixes #38012 - Handle Java versions newer than 8

### DIFF
--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -157,6 +157,14 @@ module HookContextExtension
     end
     mountpoint[:available_bytes]
   end
+
+  def parse_java_version(output)
+    output&.match(/version "\d+\.(?<version>\d+)\.\d+/) do |java_match|
+      return unless (version = java_match[:version])
+
+      yield version.to_i
+    end
+  end
 end
 
 Kafo::HookContext.send(:include, HookContextExtension)

--- a/hooks/boot/01-kafo-hook-extensions.rb
+++ b/hooks/boot/01-kafo-hook-extensions.rb
@@ -159,8 +159,10 @@ module HookContextExtension
   end
 
   def parse_java_version(output)
-    output&.match(/version "\d+\.(?<version>\d+)\.\d+/) do |java_match|
+    output&.match(/version "(?<version>\d+\.\d+)\.\d+/) do |java_match|
       return unless (version = java_match[:version])
+
+      version = version.delete_prefix('1.') if version.start_with?('1.')
 
       yield version.to_i
     end

--- a/hooks/pre/31-puppet_puppet_server_invalid_java.rb
+++ b/hooks/pre/31-puppet_puppet_server_invalid_java.rb
@@ -16,9 +16,9 @@ if File.exist?(sysconfig_file)
     logger.debug("Found Puppetserver #{puppetserver_match[:version]}")
     if puppetserver_match[:version] == '8'
       java_stdout_stderr, _status = execute_command("source #{sysconfig_file} ; $JAVA_BIN -version", false, true)
-      java_stdout_stderr&.match(/version "\d+\.(?<version>\d+)\.\d+/) do |java_match|
-        if java_match[:version] && java_match[:version].to_i < 11
-          logger.info "Detected Java #{java_match[:version]} which is too old for Puppetserver #{puppetserver_match[:version]}"
+      parse_java_version(java_stdout_stderr) do |java_version|
+        if java_version < 11
+          logger.info "Detected Java #{java_version} which is too old for Puppetserver #{puppetserver_match[:version]}"
           if app_value(:noop)
             logger.debug 'Would stop puppetserver.service'
           else

--- a/spec/hook_context_extension_spec.rb
+++ b/spec/hook_context_extension_spec.rb
@@ -11,6 +11,22 @@ describe HookContextExtension do
     allow(context).to receive(:logger).and_return(logger)
   end
 
+  describe '.parse_java_version' do
+    context 'java-1.8.0-openjdk-headless' do
+      let(:output) do
+        <<~OUTPUT
+          openjdk version "1.8.0_362"
+          OpenJDK Runtime Environment (build 1.8.0_362-b08)
+          OpenJDK 64-Bit Server VM (build 25.362-b08, mixed mode)
+        OUTPUT
+      end
+
+      it do
+        expect { |block| context.parse_java_version(output, &block) }.to yield_with_args(8)
+      end
+    end
+  end
+
   describe '.ensure_packages' do
     subject { context.ensure_packages(packages, state) }
 

--- a/spec/hook_context_extension_spec.rb
+++ b/spec/hook_context_extension_spec.rb
@@ -25,6 +25,48 @@ describe HookContextExtension do
         expect { |block| context.parse_java_version(output, &block) }.to yield_with_args(8)
       end
     end
+
+    context 'java-11-openjdk-headless' do
+      let(:output) do
+        <<~OUTPUT
+          openjdk version "11.0.20.1" 2023-08-24 LTS
+          OpenJDK Runtime Environment (Red_Hat-11.0.20.1.1-2) (build 11.0.20.1+1-LTS)
+          OpenJDK 64-Bit Server VM (Red_Hat-11.0.20.1.1-2) (build 11.0.20.1+1-LTS, mixed mode, sharing)
+        OUTPUT
+      end
+
+      it do
+        expect { |block| context.parse_java_version(output, &block) }.to yield_with_args(11)
+      end
+    end
+
+    context 'java-17-openjdk-headless' do
+      let(:output) do
+        <<~OUTPUT
+          openjdk version "17.0.11" 2024-04-16 LTS
+          OpenJDK Runtime Environment (Red_Hat-17.0.11.0.9-5) (build 17.0.11+9-LTS)
+          OpenJDK 64-Bit Server VM (Red_Hat-17.0.11.0.9-5) (build 17.0.11+9-LTS, mixed mode, sharing)
+        OUTPUT
+      end
+
+      it do
+        expect { |block| context.parse_java_version(output, &block) }.to yield_with_args(17)
+      end
+    end
+
+    context 'java-21-openjdk-headless' do
+      let(:output) do
+        <<~OUTPUT
+          openjdk version "21.0.4" 2024-07-16 LTS
+          OpenJDK Runtime Environment (Red_Hat-21.0.4.0.7-1) (build 21.0.4+7-LTS)
+          OpenJDK 64-Bit Server VM (Red_Hat-21.0.4.0.7-1) (build 21.0.4+7-LTS, mixed mode, sharing)
+        OUTPUT
+      end
+
+      it do
+        expect { |block| context.parse_java_version(output, &block) }.to yield_with_args(21)
+      end
+    end
   end
 
   describe '.ensure_packages' do


### PR DESCRIPTION
Java < 11 uses version 1.X where X is the major while Java 11 drops the old 1. prefix.

It also refactors the code so it can be tested. I've only tested this using unit tests, but the `java -version` output was retrieved from a real CentOS Stream 9 system.