### PR TITLE
[3.11] Revert "Fixes #37828: Ignore system CA trust when verifying certificates"

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -157,7 +157,7 @@ function check-priv-key () {
 function check-ca-bundle () {
     printf "Checking CA bundle against the certificate file: "
     ERROR_PATTERN="error [0-9]+ at"
-    CHECK=$(openssl verify -no-CApath -no-CAstore -CAfile $CA_BUNDLE_FILE -purpose sslserver -verbose $CERT_FILE 2>&1)
+    CHECK=$(openssl verify -CAfile $CA_BUNDLE_FILE -purpose sslserver -verbose $CERT_FILE 2>&1)
     CHECK_STATUS=$?
 
     if [[ $CHECK_STATUS != "0" || $CHECK =~ $ERROR_PATTERN ]]; then


### PR DESCRIPTION
This reverts commit a25324c1948ddc4766b1724a18bc4dd47b267c46 because OpenSSL on EL8 doesn't support the `-no-CApath` option.