### PR TITLE
Fixes #38228 - Add Hammer CLI for foreman_bootdisk

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -13,6 +13,7 @@ foreman: {}
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
+foreman::cli::bootdisk: false
 foreman::cli::discovery: false
 foreman::cli::google: false
 foreman::cli::kubevirt: false

--- a/config/foreman.migrations/250218123832_add_hammer_cli_bootdisk.rb
+++ b/config/foreman.migrations/250218123832_add_hammer_cli_bootdisk.rb
@@ -1,0 +1,1 @@
+answers['foreman::cli::bootdisk'] ||= false

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -25,6 +25,7 @@ foreman:
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
+foreman::cli::bootdisk: false
 foreman::cli::discovery: false
 foreman::cli::google: false
 foreman::cli::katello: true

--- a/config/katello.migrations/250218123832-add-hammer-cli-bootdisk.rb
+++ b/config/katello.migrations/250218123832-add-hammer-cli-bootdisk.rb
@@ -1,0 +1,1 @@
+answers['foreman::cli::bootdisk'] ||= false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -1,6 +1,7 @@
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
+foreman::cli::bootdisk: false
 foreman::cli::google: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -1,6 +1,7 @@
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
+foreman::cli::bootdisk: false
 foreman::cli::google: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -1,6 +1,7 @@
 foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
+foreman::cli::bootdisk: false
 foreman::cli::google: false
 foreman::cli::katello: true
 foreman::cli::kubevirt: false


### PR DESCRIPTION
Based on 73df3c20d55ac38f8287f5efbf181259432ea383

https://projects.theforeman.org/issues/38228

Tested locally by cherry-picking on Foreman 3.11; compared the stdout of foreman-installer, dnf, and hammer which all looked sane to me.

Refs https://github.com/theforeman/puppet-foreman/pull/1213

Tests require a change in Puppetfile to reference the proper branch for puppet-foreman