### PR TITLE
Add hammer-cli-foreman-scc-manager package

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -36,6 +36,7 @@ foreman::cli::remote_execution: true
 foreman::cli::resource_quota: false
 foreman::cli::rh_cloud: false
 foreman::cli::salt: false
+foreman::cli::scc_manager: false
 foreman::cli::ssh: false
 foreman::cli::tasks: false
 foreman::cli::templates: false

--- a/config/katello.migrations/250221150932-add-hammer-cli-scc-manager.rb
+++ b/config/katello.migrations/250221150932-add-hammer-cli-scc-manager.rb
@@ -1,0 +1,1 @@
+answers['foreman::cli::scc_manager'] ||= false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -10,6 +10,7 @@ foreman::cli::remote_execution: true
 foreman::cli::resource_quota: false
 foreman::cli::rh_cloud: false
 foreman::cli::salt: false
+foreman::cli::scc_manager: false
 foreman::cli::ssh: false
 foreman::cli::virt_who_configure: false
 foreman::cli::webhooks: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -10,6 +10,7 @@ foreman::cli::remote_execution: true
 foreman::cli::resource_quota: false
 foreman::cli::rh_cloud: false
 foreman::cli::salt: false
+foreman::cli::scc_manager: false
 foreman::cli::ssh: false
 foreman::cli::virt_who_configure: false
 foreman::cli::webhooks: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -10,6 +10,7 @@ foreman::cli::remote_execution: true
 foreman::cli::resource_quota: false
 foreman::cli::rh_cloud: false
 foreman::cli::salt: false
+foreman::cli::scc_manager: false
 foreman::cli::ssh: false
 foreman::cli::virt_who_configure: false
 foreman::cli::webhooks: false


### PR DESCRIPTION
Adds Hammer CLI for foreman_scc_manager: https://github.com/ATIX-AG/hammer-cli-foreman-scc-manager

Refs: https://github.com/theforeman/puppet-foreman/pull/1215