### PR TITLE
Drop register-in-foreman option from install message output

### DIFF
--- a/KATELLO.md
+++ b/KATELLO.md
@@ -46,7 +46,6 @@ foreman-proxy-certs-generate --foreman-proxy-fqdn "myforeman-proxy-content.examp
 # Copy the ~/myforeman-proxy.example.com-certs.tar to the foreman-proxy system
 # register the system to Katello and run:
 foreman-installer --scenario                                "foreman-proxy-content"\
-                  --foreman-proxy-register-in-foreman       "true"\
                   --foreman-proxy-foreman-base-url          "https://master.example.com"\
                   --foreman-proxy-trusted-hosts             "master.example.com"\
                   --foreman-proxy-trusted-hosts             "myforeman-proxy.example.com"\

--- a/katello_certs/hooks/boot/02-message-helpers.rb
+++ b/katello_certs/hooks/boot/02-message-helpers.rb
@@ -50,7 +50,6 @@ module KatelloCertsMessageHookContextExtension
   #{installer_command}\\
                     --scenario #{scenario_name}\\
                     --certs-tar-file                              "<%= color("#{certs_tar_file}", :info) %>"\\
-                    --foreman-proxy-register-in-foreman           "true"\\
                     --foreman-proxy-foreman-base-url              "#{foreman_url}"\\
                     --foreman-proxy-trusted-hosts                 "#{fqdn}"\\
                     --foreman-proxy-trusted-hosts                 "#{foreman_proxy_fqdn}"\\


### PR DESCRIPTION
The default value for `--foreman-proxy-register-in-foreman` is true in the puppet module, so this option is not needed in the output. 