### PR TITLE
Fixes #38313 - make case insensitive for SAN entries and  Subject CN on certificate

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -196,14 +196,14 @@ function check-ca-bundle-trust-rules () {
 
 function check-cert-san () {
     printf "Checking Subject Alt Name on certificate "
-    DNS_LIST=$(openssl x509 -noout -text -in $CERT_FILE | grep DNS:)
+    DNS_LIST=$(openssl x509 -noout -text -in $CERT_FILE | grep DNS: | tr '[:upper:]' '[:lower:]')
     if [[ $? == "0" ]]; then
         success
         printf "Checking if any Subject Alt Name on certificate matches the Subject CN"
-        SUBJECT_CN=$(openssl x509 -in $CERT_FILE -noout -subject -nameopt multiline|grep commonName|cut -d '=' -f 2|tr -d ' ')
+        SUBJECT_CN=$(openssl x509 -in $CERT_FILE -noout -subject -nameopt multiline|grep commonName|cut -d '=' -f 2|tr -d ' ' | tr '[:upper:]' '[:lower:]')
         for DNS in ${DNS_LIST}
           do
-          DNS_VALUE="$( echo ${DNS//DNS:/} | tr -d ',')"
+          DNS_VALUE="$( echo ${DNS//dns:/} | tr -d ',')"
           if [ $SUBJECT_CN == $DNS_VALUE ]
           then
             success


### PR DESCRIPTION
katello-certs-check will error when the certificate has the same FQDN in CN and SAN, but one is uppercase and another is in lowercase.

With this change, both FQDN will lowercase and check will not fail