### PR TITLE
Drop webpack_dev_server related message

### DIFF
--- a/hooks/boot/02-message-helpers.rb
+++ b/hooks/boot/02-message-helpers.rb
@@ -7,13 +7,10 @@ module MessageHookContextExtension
     say "  * <%= color('Foreman', :info) %> is running at <%= color('#{kafo.param('foreman', 'foreman_url').value}', :info) %>"
   end
 
-  def dev_server_success_message(kafo)
+  def dev_server_success_message
     say "  * To run the <%= color('Katello', :info) %> dev server log in using SSH"
     say "  * Run `cd foreman && bundle exec foreman start`"
     say "  * The server is running at <%= color('https://#{`hostname -f`}', :info) %>"
-    if kafo.param('katello_devel', 'webpack_dev_server').value
-      say "  * On Firefox you need to accept the certificate at <%= color('https://#{`hostname -f`}:3808', :info) %>"
-    end
   end
 
   def certs_generate_command_message

--- a/hooks/post/99-post_install_message.rb
+++ b/hooks/post/99-post_install_message.rb
@@ -12,7 +12,7 @@ if [0, 2].include? @kafo.exit_code
   end
 
   if devel_scenario?
-    dev_server_success_message(@kafo)
+    dev_server_success_message
     dev_new_install_message(@kafo) if new_install?
   end
 


### PR DESCRIPTION
The use of webpack_dev_server was dropped in theforeman/foreman#9834 and theforeman/puppet-katello_devel#310

Currently katello-devel scenario fails with
```
  stderr: |-
    /usr/share/foreman-installer/hooks/boot/02-message-helpers.rb:14:in `dev_server_success_message': undefined method `value' for nil:NilClass (NoMethodError)
            from /usr/share/foreman-installer/hooks/post/99-post_install_message.rb:15:in `block (4 levels) in load'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/hooking.rb:36:in `instance_eval'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/hooking.rb:36:in `block (4 levels) in load'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/hook_context.rb:19:in `instance_eval'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/hook_context.rb:19:in `execute'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/hooking.rb:67:in `block in execute'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/hooking.rb:65:in `each'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/hooking.rb:65:in `execute'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/kafo_configure.rb:560:in `run_installation'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/kafo_configure.rb:225:in `execute'
            from /usr/share/gems/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/kafo_configure.rb:184:in `run'
            from /usr/share/gems/gems/clamp-1.3.2/lib/clamp/command.rb:140:in `run'
            from /usr/share/gems/gems/kafo-7.6.0/lib/kafo/kafo_configure.rb:54:in `run'
            from /sbin/foreman-installer:8:in `<main>'
```