### PR TITLE
Fixes #38389 - Ignore missing db on --reset-data

### DIFF
--- a/hooks/pre/10-reset_data.rb
+++ b/hooks/pre/10-reset_data.rb
@@ -17,7 +17,7 @@ def empty_db_in_postgresql(db)
   if remote_host?(config[:host])
     empty_database!(config)
   else
-    execute!("runuser -l postgres -c 'dropdb #{config[:database]}'", false, true)
+    execute!("runuser -l postgres -c 'dropdb --if-exists #{config[:database]}'", false, true)
   end
 end
 


### PR DESCRIPTION
The dropdb command will error out when the database doesn't exist but in our case that's fine. We just want to ensure it's done. Passing `--if-exists` changes the error into a notice.