### PR TITLE
Require base64 for Ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,11 @@ gem 'facter', '>= 3.0', '!= 4.0.52'
 gem 'puppet-strings'
 gem 'rake'
 
+if RUBY_VERSION >= '3.4'
+  gem 'base64'
+  gem 'getoptlong'
+  gem 'syslog'
+end
 gem 'racc' if RUBY_VERSION >= '3.3'
 
 gem 'semverse', groups: [:development, :test]

--- a/Puppetfile
+++ b/Puppetfile
@@ -13,6 +13,9 @@ mod 'puppet/redis',                    '>= 8.5.0'
 # https://github.com/theforeman/puppet-puppet/#git-repo-support
 mod 'puppetlabs/vcsrepo',              '>= 5.2.0'
 
+# https://github.com/southalc/podman/pull/100
+mod 'puppet/systemd', '< 8'
+
 # Soft dependency of theforeman/foreman
 mod 'theforeman/iop_advisor_engine',   :git => 'https://github.com/theforeman/puppet-iop_advisor_engine'
 


### PR DESCRIPTION
I am testing if these fix things or not. I noticed Packit switched to Fedora 42 w/ Ruby 3.4 which is where the base64 requirement came from in the Gemfile.