### PR TITLE
Fixes #38516 - Reset Apache & Foreman Proxy on certs-reset

### DIFF
--- a/hooks/pre/20-certs_update.rb
+++ b/hooks/pre/20-certs_update.rb
@@ -22,7 +22,7 @@ if module_enabled?('certs')
     hostname = param('certs', 'node_fqdn').value
   end
 
-  if app_value(:certs_update_server)
+  if app_value(:certs_update_server) || app_value(:certs_reset)
     mark_for_update("#{hostname}-apache", hostname)
     mark_for_update("#{hostname}-foreman-proxy", hostname)
   end


### PR DESCRIPTION
When the user passes `--certs-reset` the intention is clearly that all certificates must be updated. It was reported that adding `--certs-update-server` does work. This makes sure the [documented procedure](https://docs.theforeman.org/nightly/Installing_Server/index-katello.html#resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-foreman_foreman) matches that reality.