### PR TITLE
Fixes #38533 - Drop evr extension first when resetting data

### DIFF
--- a/hooks/pre/10-reset_data.rb
+++ b/hooks/pre/10-reset_data.rb
@@ -28,7 +28,9 @@ end
 
 # WARNING: deletes all the data owned by the user. No warnings. No confirmations.
 def empty_database!(config)
+  drop_evr_statement = 'DROP EXTENSION IF EXISTS evr CASCADE;'
   delete_statement = 'DROP OWNED BY CURRENT_USER CASCADE;'
+  execute!(pg_sql_statement(drop_evr_statement), false, true, pg_env(config))
   execute!(pg_sql_statement(delete_statement), false, true, pg_env(config))
 end
 


### PR DESCRIPTION
Under certain circumstances (12-to-13 upgraded remote DB),
`DROP OWNED BY CURRENT_USER CASCADE;` fails with "cannot drop type evr_t
because extension evr requires it" because it tries to drop the type
before the extension. However, dropping the extension using
`DROP EXTENSION IF EXISTS evr CASCADE;` works just fine and then the
"DROP OWNED" works too.
