### PR TITLE
Fixes #38841 - Remove ACD plugin

### DIFF
--- a/config/foreman-answers.yaml
+++ b/config/foreman-answers.yaml
@@ -30,7 +30,6 @@ foreman::compute::ec2: false
 foreman::compute::libvirt: false
 foreman::compute::openstack: false
 foreman::compute::vmware: false
-foreman::plugin::acd: false
 foreman::plugin::ansible: false
 foreman::plugin::azure: false
 foreman::plugin::bootdisk: false
@@ -65,7 +64,6 @@ foreman::plugin::vault: false
 foreman::plugin::webhooks: false
 foreman::plugin::wreckingball: false
 foreman_proxy: {}
-foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false

--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -28,7 +28,6 @@ foreman_proxy:
   templates: true
   puppet: false
   puppetca: false
-foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false

--- a/config/foreman-proxy-content.migrations/20251015000000_remove_acd.rb
+++ b/config/foreman-proxy-content.migrations/20251015000000_remove_acd.rb
@@ -1,0 +1,3 @@
+if answers.key?('foreman_proxy::plugin::acd')
+  answers.delete('foreman_proxy::plugin::acd')
+end

--- a/config/foreman.migrations/20251015000000_remove_acd.rb
+++ b/config/foreman.migrations/20251015000000_remove_acd.rb
@@ -1,0 +1,6 @@
+if answers.key?('foreman::plugin::acd')
+  answers.delete('foreman::plugin::acd')
+end
+if answers.key?('foreman_proxy::plugin::acd')
+  answers.delete('foreman_proxy::plugin::acd')
+end

--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -46,7 +46,6 @@ foreman::compute::ec2: false
 foreman::compute::libvirt: false
 foreman::compute::openstack: false
 foreman::compute::vmware: false
-foreman::plugin::acd: false
 foreman::plugin::ansible: false
 foreman::plugin::azure: false
 foreman::plugin::bootdisk: false
@@ -93,7 +92,6 @@ foreman_proxy:
   ssl_port: '9090'
   puppet: false
   puppetca: false
-foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::ansible: false
 foreman_proxy::plugin::dhcp::infoblox: false
 foreman_proxy::plugin::dhcp::remote_isc: false

--- a/config/katello.migrations/20251015000000_remove_acd.rb
+++ b/config/katello.migrations/20251015000000_remove_acd.rb
@@ -1,0 +1,6 @@
+if answers.key?('foreman::plugin::acd')
+  answers.delete('foreman::plugin::acd')
+end
+if answers.key?('foreman_proxy::plugin::acd')
+  answers.delete('foreman_proxy::plugin::acd')
+end

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -18,7 +18,6 @@ foreman::compute::ec2: false
 foreman::compute::libvirt: false
 foreman::compute::openstack: false
 foreman::compute::vmware: false
-foreman::plugin::acd: false
 foreman::plugin::azure: false
 foreman::plugin::dlm: false
 foreman::plugin::dhcp_browser: false
@@ -46,7 +45,6 @@ foreman::plugin::vault: false
 foreman::plugin::virt_who_configure: false
 foreman::plugin::webhooks: false
 foreman::plugin::wreckingball: false
-foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::powerdns: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -18,7 +18,6 @@ foreman::compute::ec2: false
 foreman::compute::libvirt: false
 foreman::compute::openstack: false
 foreman::compute::vmware: false
-foreman::plugin::acd: false
 foreman::plugin::azure: false
 foreman::plugin::dlm: false
 foreman::plugin::dhcp_browser: false
@@ -46,7 +45,6 @@ foreman::plugin::vault: false
 foreman::plugin::virt_who_configure: false
 foreman::plugin::webhooks: false
 foreman::plugin::wreckingball: false
-foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::powerdns: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -18,7 +18,6 @@ foreman::compute::ec2: false
 foreman::compute::libvirt: false
 foreman::compute::openstack: false
 foreman::compute::vmware: false
-foreman::plugin::acd: false
 foreman::plugin::azure: false
 foreman::plugin::dlm: false
 foreman::plugin::dhcp_browser: false
@@ -46,7 +45,6 @@ foreman::plugin::vault: false
 foreman::plugin::virt_who_configure: false
 foreman::plugin::webhooks: false
 foreman::plugin::wreckingball: false
-foreman_proxy::plugin::acd: false
 foreman_proxy::plugin::dhcp::remote_isc: false
 foreman_proxy::plugin::discovery: false
 foreman_proxy::plugin::dns::powerdns: false


### PR DESCRIPTION
Foreman and Foreman+Katello nightly do not support foreman_acd and smart_proxy_acd anymore.

Applying this migration should revert
adde36b1ab402a536aa6a01b9c1d52f1634c75b7 on Foreman Server & Smart Proxy Servers.

Refs PR 4359 in foreman-documentation