### PR TITLE
Revert "Pin puppet-systemd to version 7 or less"

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,9 +13,6 @@ mod 'puppet/redis',                    '>= 8.5.0'
 # https://github.com/theforeman/puppet-puppet/#git-repo-support
 mod 'puppetlabs/vcsrepo',              '>= 5.2.0'
 
-# https://github.com/southalc/podman/pull/100
-mod 'puppet/systemd', '< 8'
-
 # Dependencies
 mod 'theforeman/dhcp',                 :git => 'https://github.com/theforeman/puppet-dhcp'
 mod 'theforeman/dns',                  :git => 'https://github.com/theforeman/puppet-dns'


### PR DESCRIPTION
This reverts commit 2109b6b1b78f53e7dc6b0d44976498441434d83c.

systemd was pinned because the podman module didn't support it. This was changed in the most recent release. https://forge.puppet.com/modules/southalc/podman/readme 0.7.13 supports latest puppet/systemd (9.1.0).