### PR TITLE
Reset puppet package parameters if nil or empty

### DIFF
--- a/config/foreman-proxy-content.migrations/251105202301-reset-puppet-package-params.rb
+++ b/config/foreman-proxy-content.migrations/251105202301-reset-puppet-package-params.rb
@@ -1,0 +1,13 @@
+if answers["puppet"].is_a?(Hash)
+  puppet = answers["puppet"]
+
+  if puppet.has_key?("server_package") &&
+     (puppet["server_package"].nil? || puppet["server_package"].empty?)
+    puppet.delete('server_package')
+  end
+
+  if puppet.has_key?("package") &&
+     (puppet["package"].nil? || puppet["package"].empty?)
+    puppet.delete('package')
+  end
+end

--- a/config/foreman.migrations/20251105194319_reset_puppet_package_params.rb
+++ b/config/foreman.migrations/20251105194319_reset_puppet_package_params.rb
@@ -1,0 +1,13 @@
+if answers["puppet"].is_a?(Hash)
+  puppet = answers["puppet"]
+
+  if puppet.has_key?("server_package") &&
+     (puppet["server_package"].nil? || puppet["server_package"].empty?)
+    puppet.delete('server_package')
+  end
+
+  if puppet.has_key?("package") &&
+     (puppet["package"].nil? || puppet["package"].empty?)
+    puppet.delete('package')
+  end
+end

--- a/config/katello.migrations/251105195459-reset-puppet-package-params.rb
+++ b/config/katello.migrations/251105195459-reset-puppet-package-params.rb
@@ -1,0 +1,13 @@
+if answers["puppet"].is_a?(Hash)
+  puppet = answers["puppet"]
+
+  if puppet.has_key?("server_package") &&
+     (puppet["server_package"].nil? || puppet["server_package"].empty?)
+    puppet.delete('server_package')
+  end
+
+  if puppet.has_key?("package") &&
+     (puppet["package"].nil? || puppet["package"].empty?)
+    puppet.delete('package')
+  end
+end


### PR DESCRIPTION
This results from changes in https://github.com/theforeman/puppet-puppet/pull/935

@evgeni I believe this should address the Debian upgrade issue since those two parameters are no longer optional.