### PR TITLE
Require kafo >= 7.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 # We don't want to list psych since that updates the bundled version
 gem 'rdoc', '< 6.4'
 
-gem 'kafo', '>= 7.6', '< 8'
+gem 'kafo', '>= 7.7', '< 8'
 gem 'librarian-puppet', '>= 3.0'
 
 gem 'openvox', "~> #{ENV.fetch('PUPPET_VERSION', '8.0')}"


### PR DESCRIPTION
theforeman/puppet since [1] uses syntax that can only be parsed by kafo 7.7+ [2]

[1] https://github.com/theforeman/puppet-puppet/pull/978
[2] https://github.com/theforeman/kafo/pull/391