### PR TITLE
Add migration to set gunicorn control socket paths for pulpcore

### DIFF
--- a/config/foreman-proxy-content-answers.yaml
+++ b/config/foreman-proxy-content-answers.yaml
@@ -14,6 +14,8 @@ certs:
 foreman_proxy_content:
   pulpcore_mirror: true
   puppet: false
+  pulpcore_api_control_socket_path: /run/pulpcore-api/gunicorn.ctl
+  pulpcore_content_control_socket_path: /run/pulpcore-content/gunicorn.ctl
 foreman_proxy:
   foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
   foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem

--- a/config/foreman-proxy-content.migrations/20260430083000-set-gunicorn-control-socket.rb
+++ b/config/foreman-proxy-content.migrations/20260430083000-set-gunicorn-control-socket.rb
@@ -1,0 +1,4 @@
+if answers['foreman_proxy_content'].is_a?(Hash)
+  answers['foreman_proxy_content']['pulpcore_api_control_socket_path'] ||= '/run/pulpcore-api/gunicorn.ctl'
+  answers['foreman_proxy_content']['pulpcore_content_control_socket_path'] ||= '/run/pulpcore-content/gunicorn.ctl'
+end

--- a/config/katello.migrations/20260430083000-set-gunicorn-control-socket.rb
+++ b/config/katello.migrations/20260430083000-set-gunicorn-control-socket.rb
@@ -1,0 +1,4 @@
+if answers['foreman_proxy_content'].is_a?(Hash)
+  answers['foreman_proxy_content']['pulpcore_api_control_socket_path'] ||= '/run/pulpcore-api/gunicorn.ctl'
+  answers['foreman_proxy_content']['pulpcore_content_control_socket_path'] ||= '/run/pulpcore-content/gunicorn.ctl'
+end

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -62,6 +62,8 @@ foreman_proxy_content:
   proxy_pulp_isos_to_pulpcore: false
   proxy_pulp_yum_to_pulpcore: false
   puppet: false
+  pulpcore_api_control_socket_path: /run/pulpcore-api/gunicorn.ctl
+  pulpcore_content_control_socket_path: /run/pulpcore-content/gunicorn.ctl
 katello:
   enable_deb: true
   use_pulp_2_for_deb: true

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -62,6 +62,8 @@ foreman_proxy_content:
   proxy_pulp_yum_to_pulpcore: false
   proxy_pulp_deb_to_pulpcore: false
   puppet: false
+  pulpcore_api_control_socket_path: /run/pulpcore-api/gunicorn.ctl
+  pulpcore_content_control_socket_path: /run/pulpcore-content/gunicorn.ctl
 katello:
   use_pulp_2_for_deb: true
   use_pulp_2_for_docker: true

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -61,6 +61,8 @@ foreman_proxy_content:
   proxy_pulp_isos_to_pulpcore: false
   proxy_pulp_yum_to_pulpcore: false
   proxy_pulp_deb_to_pulpcore: false
+  pulpcore_api_control_socket_path: /run/pulpcore-api/gunicorn.ctl
+  pulpcore_content_control_socket_path: /run/pulpcore-content/gunicorn.ctl
 katello:
   use_pulp_2_for_docker: true
   use_pulp_2_for_file: true

--- a/spec/migrations/20260430083000-set-gunicorn-control-socket_spec.rb
+++ b/spec/migrations/20260430083000-set-gunicorn-control-socket_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+migration '20260430083000-set-gunicorn-control-socket' do
+  scenarios %w[katello foreman-proxy-content] do
+    context 'without existing socket path answers' do
+      let(:answers) { { 'foreman_proxy_content' => {} } }
+
+      it 'sets the api control socket path' do
+        expect(migrated_answers['foreman_proxy_content']['pulpcore_api_control_socket_path'])
+          .to eq('/run/pulpcore-api/gunicorn.ctl')
+      end
+
+      it 'sets the content control socket path' do
+        expect(migrated_answers['foreman_proxy_content']['pulpcore_content_control_socket_path'])
+          .to eq('/run/pulpcore-content/gunicorn.ctl')
+      end
+    end
+
+    context 'with existing custom socket paths' do
+      let(:answers) do
+        {
+          'foreman_proxy_content' => {
+            'pulpcore_api_control_socket_path' => '/custom/api.ctl',
+            'pulpcore_content_control_socket_path' => '/custom/content.ctl',
+          },
+        }
+      end
+
+      it 'preserves a custom api socket path' do
+        expect(migrated_answers['foreman_proxy_content']['pulpcore_api_control_socket_path'])
+          .to eq('/custom/api.ctl')
+      end
+
+      it 'preserves a custom content socket path' do
+        expect(migrated_answers['foreman_proxy_content']['pulpcore_content_control_socket_path'])
+          .to eq('/custom/content.ctl')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Gunicorn 25.1.0+ defaults to creating a control socket at \$HOME/gunicorn.ctl (/var/lib/pulp/gunicorn.ctl for the pulp user), causing SELinux AVC denials. https://github.com/theforeman/puppet-pulpcore/pull/403 adds api_control_socket_path and content_control_socket_path parameters; this migration sets them to /run/pulpcore-{api,content}/gunicorn.ctl for existing installations, where systemd already creates those directories with the correct pulpcore_server_var_run_t SELinux label.