### PR TITLE
Remove foreman::cli::virt_who_configure

### DIFF
--- a/config/katello-answers.yaml
+++ b/config/katello-answers.yaml
@@ -40,7 +40,6 @@ foreman::cli::scc_manager: false
 foreman::cli::ssh: false
 foreman::cli::tasks: false
 foreman::cli::templates: false
-foreman::cli::virt_who_configure: false
 foreman::cli::webhooks: false
 foreman::compute::ec2: false
 foreman::compute::libvirt: false

--- a/config/katello.migrations/260616084754-remove-virt-who-configure-cli.rb
+++ b/config/katello.migrations/260616084754-remove-virt-who-configure-cli.rb
@@ -1,0 +1,1 @@
+answers.delete('foreman::cli::virt_who_configure')

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-after.yaml
@@ -12,7 +12,6 @@ foreman::cli::rh_cloud: false
 foreman::cli::salt: false
 foreman::cli::scc_manager: false
 foreman::cli::ssh: false
-foreman::cli::virt_who_configure: false
 foreman::cli::webhooks: false
 foreman::compute::ec2: false
 foreman::compute::libvirt: false

--- a/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-before.yaml
+++ b/spec/fixtures/pulpcore-migration-dont-use-content-plugins-on-upgrades/katello-answers-before.yaml
@@ -2,7 +2,6 @@ foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
 foreman::cli::kubevirt: false
-foreman::cli::virt_who_configure: false
 foreman::compute::ec2: false
 foreman::compute::gce: false
 foreman::compute::libvirt: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-after.yaml
@@ -12,7 +12,6 @@ foreman::cli::rh_cloud: false
 foreman::cli::salt: false
 foreman::cli::scc_manager: false
 foreman::cli::ssh: false
-foreman::cli::virt_who_configure: false
 foreman::cli::webhooks: false
 foreman::compute::ec2: false
 foreman::compute::libvirt: false

--- a/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-before.yaml
+++ b/spec/fixtures/pulpcore-migration-rpm-only/katello-answers-before.yaml
@@ -2,7 +2,6 @@ foreman::cli: true
 foreman::cli::ansible: false
 foreman::cli::azure: false
 foreman::cli::kubevirt: false
-foreman::cli::virt_who_configure: false
 foreman::compute::ec2: false
 foreman::compute::gce: false
 foreman::compute::libvirt: false

--- a/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
+++ b/spec/fixtures/pulpcore-migration/katello-answers-after.yaml
@@ -12,7 +12,6 @@ foreman::cli::rh_cloud: false
 foreman::cli::salt: false
 foreman::cli::scc_manager: false
 foreman::cli::ssh: false
-foreman::cli::virt_who_configure: false
 foreman::cli::webhooks: false
 foreman::compute::ec2: false
 foreman::compute::libvirt: false


### PR DESCRIPTION
The `foreman::cli::virt_who_configure` class was removed from puppet-foreman
in theforeman/puppet-foreman@f345cfa, breaking nightly builds:

```
File not found .../foreman/manifests/cli/virt_who_configure.pp, check your answer file (KafoParsers::ModuleName)
```

This PR:
- Removes the class from `katello-answers.yaml`
- Adds a migration to clean up existing answer files
- Removes the stale line from the `190710133444-add-virt-who` migration
- Updates spec fixtures