### PR TITLE
Fixes #39546 - Fix glob expansion crash in katello-certs-check loops

### DIFF
--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -201,15 +201,18 @@ function check-cert-san () {
         success
         printf "Checking if any Subject Alt Name on certificate matches the Subject CN"
         SUBJECT_CN=$(openssl x509 -in $CERT_FILE -noout -subject -nameopt multiline|grep commonName|cut -d '=' -f 2|tr -d ' ')
+        set -o noglob
         for DNS in ${DNS_LIST}
           do
           DNS_VALUE="$( echo ${DNS//DNS:/} | tr -d ',')"
           if [ $SUBJECT_CN == $DNS_VALUE ]
           then
+            set +o noglob
             success
             return
           fi
         done
+        set +o noglob
         error 11 "The $CERT_FILE does not have a Subject Alt Name matching the Subject CN"
     else
         error 11 "The $CERT_FILE does not contain a Subject Alt Name. Common Name is deprecated, use Subject Alt Name instead. See: https://tools.ietf.org/html/rfc2818#section-3.1"
@@ -236,15 +239,18 @@ function check-shortname () {
 
     DNS_LIST=$(openssl x509 -noout -text -in $CERT_FILE | grep DNS:)
     if [[ $? == "0" ]]; then
+        set -o noglob
         for DNS in ${DNS_LIST}
           do
           DNS_VALUE="$( echo ${DNS//DNS:/} | tr -d ',')"
 
           if [[ $DNS_VALUE == *"."* ]]; then
+            set +o noglob
             success
             return
           fi
         done
+        set +o noglob
         error 1 "The $(basename $CERT_FILE) is using only shortnames for Subject Alt Name and cannot be used with $PROJECT.\n"
     fi
 }

--- a/bin/katello-certs-check
+++ b/bin/katello-certs-check
@@ -12,6 +12,7 @@ BRANDING_FILE=/usr/share/foreman-installer/katello-certs-check-branding
 if [[ -f "${BRANDING_FILE}" ]]; then
   source "${BRANDING_FILE}"
 fi
+set -o noglob
 PROJECT=${PROJECT:-Katello}
 SERVER_SCENARIO=${SERVER_SCENARIO:-katello}
 INSTALLER=${INSTALLER:-foreman-installer}
@@ -201,18 +202,15 @@ function check-cert-san () {
         success
         printf "Checking if any Subject Alt Name on certificate matches the Subject CN"
         SUBJECT_CN=$(openssl x509 -in $CERT_FILE -noout -subject -nameopt multiline|grep commonName|cut -d '=' -f 2|tr -d ' ')
-        set -o noglob
         for DNS in ${DNS_LIST}
           do
           DNS_VALUE="$( echo ${DNS//DNS:/} | tr -d ',')"
           if [ $SUBJECT_CN == $DNS_VALUE ]
           then
-            set +o noglob
             success
             return
           fi
         done
-        set +o noglob
         error 11 "The $CERT_FILE does not have a Subject Alt Name matching the Subject CN"
     else
         error 11 "The $CERT_FILE does not contain a Subject Alt Name. Common Name is deprecated, use Subject Alt Name instead. See: https://tools.ietf.org/html/rfc2818#section-3.1"
@@ -239,18 +237,15 @@ function check-shortname () {
 
     DNS_LIST=$(openssl x509 -noout -text -in $CERT_FILE | grep DNS:)
     if [[ $? == "0" ]]; then
-        set -o noglob
         for DNS in ${DNS_LIST}
           do
           DNS_VALUE="$( echo ${DNS//DNS:/} | tr -d ',')"
 
           if [[ $DNS_VALUE == *"."* ]]; then
-            set +o noglob
             success
             return
           fi
         done
-        set +o noglob
         error 1 "The $(basename $CERT_FILE) is using only shortnames for Subject Alt Name and cannot be used with $PROJECT.\n"
     fi
 }

--- a/spec/katello_certs_check_spec.rb
+++ b/spec/katello_certs_check_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'open3'
+require 'tmpdir'
 
 # certs/ca were generated with https://github.com/iNecas/ownca
 # badkey passphrase is 'foreman'
@@ -95,6 +96,22 @@ describe 'katello-certs-check' do
       expect(stderr).to eq ''
       expect(stdout).to include 'Checking CA bundle size: 2'
       expect(status.exitstatus).to eq 0
+    end
+
+    it 'does not expand wildcard SANs as filesystem globs' do
+      command_with_certs = "#{command} -b #{ca} -k #{key} -c #{cert}"
+      cert_details = `openssl x509 -noout -text -in #{cert}`
+
+      Dir.mktmpdir do |tmpdir|
+        File.write(File.join(tmpdir, 'one.example.com'), '')
+        File.write(File.join(tmpdir, 'two.example.com'), '')
+
+        _stdout, stderr, status = Open3.capture3(command_with_certs, chdir: tmpdir)
+
+        expect(cert_details).to include 'DNS:*.example.com'
+        expect(stderr).to eq ''
+        expect(status.exitstatus).to eq 0
+      end
     end
   end
 


### PR DESCRIPTION
Wrap both DNS_LIST for-loops with set -o noglob / set +o noglob to prevent wildcard SANs (e.g. *.example.com) from being expanded as filesystem globs, causing a "too many arguments" error in the [ ] test.